### PR TITLE
Fix a tokenizer issue while converting models without a bos_token_id defined

### DIFF
--- a/exllamav3/tokenizer/tokenizer.py
+++ b/exllamav3/tokenizer/tokenizer.py
@@ -118,8 +118,8 @@ class Tokenizer:
 
         # Get control token strings
         self.unk_token = self.tokenizer.model.unk_token
-        self.bos_token = self.extended_id_to_piece.get(self.bos_token_id) or self.tokenizer.id_to_token(self.bos_token_id)
-        self.eos_token = self.extended_id_to_piece.get(self.eos_token_id) or self.tokenizer.id_to_token(self.eos_token_id)
+        self.bos_token = None if self.bos_token_id is None else (self.extended_id_to_piece.get(self.bos_token_id) or self.tokenizer.id_to_token(self.bos_token_id))
+        self.eos_token = None if self.eos_token_id is None else (self.extended_id_to_piece.get(self.eos_token_id) or self.tokenizer.id_to_token(self.eos_token_id))
 
         # Use "<pad>" or BOS token as fallback for padding token
         if self.pad_token_id is None:


### PR DESCRIPTION
I had to make this change to be able to convert `arcee-ai/Virtuoso-Small`, which is of architecture `Qwen2ForCausalLM` and has this in its `tokenizer_config.json`:

```
  "bos_token": null,
```

Without it, I get the following error:

```
  File "/home/me/text-generation-webui/repositories/exllamav3/exllamav3/conversion/convert_model.py", line 215, in main    
    config, model, tokenizer = get_base_model(args)
                               ^^^^^^^^^^^^^^^^^^^^
  File "/home/me/text-generation-webui/repositories/exllamav3/exllamav3/conversion/convert_model.py", line 170, in get_base_model    
    tokenizer = Tokenizer.from_config(config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/text-generation-webui/repositories/exllamav3/exllamav3/tokenizer/tokenizer.py", line 595, in from_config    
    return Tokenizer(config)
           ^^^^^^^^^^^^^^^^^
  File "/home/me/text-generation-webui/repositories/exllamav3/exllamav3/tokenizer/tokenizer.py", line 121, in __init__    
    self.bos_token = self.extended_id_to_piece.get(self.bos_token_id) or self.tokenizer.id_to_token(self.bos_token_id)
                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 'id': 'NoneType' object cannot be interpreted as an integer
```