### PR TITLE
Reka Flash 3 vs padding

### DIFF
--- a/eval/humaneval.py
+++ b/eval/humaneval.py
@@ -49,6 +49,13 @@ prompt_formats = {
         "<start_of_turn>model\n"
         "```python\n{{problem}}",
         "    "
+    ),
+    "reka": (
+        "human: Complete the following Python function."
+        " Provide your reasoning in comments, but be concise and don't second-guess."
+        "\n\n{{problem}}"
+        " <sep> assistant: ```python\n{{problem}}",
+        "    "
     )
 }
 


### PR DESCRIPTION
I'm not sure how this might interact with other models, but it fixes [Reka Flash 3](https://huggingface.co/RekaAI/reka-flash-3) quantization. Otherwise, there are attempts to add and multiply matrices of incompatible sizes, because the model has both output and input sizes that are not divisible by 128, but only the output is padded.

![reka](https://github.com/user-attachments/assets/86dff661-4120-436c-8262-19e042ba31ba)

Here is HumanEval for [[1]](https://huggingface.co/lucyknada/RekaAI_reka-flash-3-exl2) and [[2]](https://huggingface.co/isogen/reka-flash-3-exl3-3bpw) (eager with no reasoning block, sampling with reasoning and full precision is supposed to be 96.3).

| quant     | KV   | GB   | prompt | pass@1 (1K, 2K) |
| --------- | ---- | ---- | ------ | --------------- |
| exl2 3bpw | Q4   | 10.7 | raw    | 67.1, 71.3      |
| exl2 3bpw | Q8   | 11.8 | raw    | 72.0, 72.6      |
| exl2 3bpw | FP16 | 12.9 | raw    | 70.1, 69.5      |
| exl2 3bpw | Q4   | 10.7 | reka   | 77.4, 77.4      |
| exl2 3bpw | Q8   | 11.8 | reka   | 75.6, 78.7      |
| exl2 3bpw | FP16 | 12.9 | reka   | 77.4, 73.2      |
| exl2 4bpw | Q4   | 12.2 | raw    | 86.0, 84.8      |
| exl2 4bpw | Q8   | 13.2 | raw    | 85.4, 88.4      |
| exl2 4bpw | FP16 | 15.4 | raw    | 87.2, 87.2      |
| exl2 4bpw | Q4   | 12.2 | reka   | 84.8, 86.0      |
| exl2 4bpw | Q8   | 13.2 | reka   | 86.0, 89.6      |
| exl2 4bpw | FP16 | 15.4 | reka   | 86.0, 85.4      |
| exl3 3bpw | Q4   | 8.8  | raw    | 84.8, 86.0      |
| exl3 3bpw | Q8   | 9.0  | raw    | 87.8, 89.0      |
| exl3 3bpw | FP16 | 9.6  | raw    | 88.4, 89.0      |
| exl3 3bpw | Q4   | 8.8  | reka   | 87.2, 87.8      |
| exl3 3bpw | Q8   | 9.0  | reka   | 88.4, 90.2      |
| exl3 3bpw | FP16 | 9.6  | reka   | 90.2, **90.9**  |
| exl3 4bpw | Q4   | 11.3 | raw    | 89.0, 88.4      |
| exl3 4bpw | Q8   | 11.5 | raw    | 87.2, 88.4      |
| exl3 4bpw | FP16 | 12.3 | raw    | 87.2, 87.2      |
| exl3 4bpw | Q4   | 11.3 | reka   | 86.6, 85.4      |
| exl3 4bpw | Q8   | 11.5 | reka   | 84.1, 86.6      |
| exl3 4bpw | FP16 | 12.3 | reka   | 86.0, 86.6      |