### PR TITLE
fix: don't add min_p and top_p samplers to stack if falsy

### DIFF
--- a/exllamav3/generator/sampler/presets.py
+++ b/exllamav3/generator/sampler/presets.py
@@ -109,11 +109,12 @@ class ComboSampler(CustomSampler):
         else:
             stack += [
                 SS_Temperature(temperature if not temp_last else 1.0),
-                SS_MinP(min_p),
+                SS_MinP(min_p) if min_p else None,
                 SS_TopK(top_k),
-                SS_TopP(top_p),
+                SS_TopP(top_p) if top_p else None,
                 SS_Temperature(temperature if temp_last else 1.0),
                 SS_Sample()
             ]
+            stack = [s for s in stack if s is not None]
 
         super().__init__(stack)


### PR DESCRIPTION
Got AssertionError because the samplers (min_p, top_p) were not allowed to be 0.0.
I don't know if I should set them to 1.0 instead to turn them off.
Because of these unclear (to me; severe memory issues) values for "off" I did not set this for the other samplers (they did not have the asserts).