### PR TITLE
Short-circuit unload_tp if not loaded with tp

### DIFF
--- a/exllamav3/models/model_tp.py
+++ b/exllamav3/models/model_tp.py
@@ -300,6 +300,8 @@ class Model_TPMixin:
 
 
     def unload_tp(self):
+        if self.tp_output_device is None:
+            return
         self.destroy_tp_context()
         self.loaded_tp = False
         self.tp_output_device = None


### PR DESCRIPTION
Encountered the following issue trying to unload/switch models from a front-end when the model **was not** loaded with tensor-parallelism enabled:

```
Traceback (most recent call last):
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/gradio/queueing.py", line 541, in process_events
    response = await route_utils.call_process_api(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/gradio/route_utils.py", line 276, in call_process_api
    output = await app.get_blocks().process_api(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/gradio/blocks.py", line 1928, in process_api
    result = await self.call_function(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/gradio/blocks.py", line 1514, in call_function
    prediction = await anyio.to_thread.run_sync(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2470, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 967, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/gradio/utils.py", line 833, in wrapper
    response = f(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/text-generation-webui/modules/ui_model_menu.py", line 411, in handle_unload_model_click
    unload_model()
  File "/home/[redacted]/text-generation-webui/modules/models.py", line 122, in unload_model
    shared.model.unload()
  File "/home/[redacted]/text-generation-webui/modules/exllamav3_hf.py", line 252, in unload
    self.ex_model.unload()
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/exllamav3/models/model.py", line 105, in unload
    self.unload_tp()
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/exllamav3/models/model_tp.py", line 303, in unload_tp
    self.destroy_tp_context()
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/exllamav3/models/model_tp.py", line 105, in destroy_tp_context
    self.mp_parent_conn[self.tp_output_device].quit()
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
TypeError: list indices must be integers or slices, not NoneType
```

`self.tp_output_device` is set to something non-`None` early on into `_load_tp`, so I think it's safe to bail out of `unload_tp` if this is None. Open to alternative suggestions.