### PR TITLE
Account for renamed/added submodules in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,11 +70,12 @@ setup(
     version=version,
     packages=[
         "exllamav3",
+        "exllamav3.architecture",
         "exllamav3.generator",
         "exllamav3.generator.sampler",
         "exllamav3.generator.filter",
         "exllamav3.conversion",
-        "exllamav3.models",
+        "exllamav3.model",
         "exllamav3.modules",
         "exllamav3.modules.quant",
         "exllamav3.modules.quant.exl3_lib",


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "/home/[redacted]/exllamav3/examples/chat.py", line 5, in <module>
    from exllamav3 import Generator, Job, model_init
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/exllamav3/__init__.py", line 1, in <module>
    from .model.config import Config
ModuleNotFoundError: No module named 'exllamav3.model'
```

and/or

```
Traceback (most recent call last):
  File "/home/[redacted]/exllamav3/examples/chat.py", line 289, in <module>
    main(_args)
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/examples/chat.py", line 40, in main
    model, config, cache, tokenizer = model_init.init(args)
                                      ^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/exllamav3/model_init.py", line 80, in init
    config = Config.from_directory(args.model_dir)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[redacted]/exllamav3/exl3venv/lib/python3.12/site-packages/exllamav3/model/config.py", line 125, in from_directory
    from exllamav3.architecture.architectures import get_architectures
ModuleNotFoundError: No module named 'exllamav3.architecture'
```