### PR TITLE
Add support for Seed-OSS

### DIFF
--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -19,6 +19,7 @@ from .phi3 import Phi3Model
 from .qwen2 import Qwen2Model
 from .qwen3 import Qwen3Model
 from .qwen3_moe import Qwen3MoeModel
+from .seedoss import SeedOssModel
 from .smollm3 import SmolLM3Model
 
 ARCHITECTURES = {
@@ -49,6 +50,7 @@ ARCHITECTURES = {
         Qwen2Model,
         Qwen3Model,
         Qwen3MoeModel,
+        SeedOssModel,
         SmolLM3Model,
     ]
 }

--- a/exllamav3/architecture/seedoss.py
+++ b/exllamav3/architecture/seedoss.py
@@ -1,0 +1,42 @@
+from typing_extensions import override
+from .llama import LlamaConfig, LlamaModel
+
+# Qwen2 is identical to Llama except for bias on Q, K and V projections, but Linear module automatically
+# detects *.bias tensor
+
+class SeedOssConfig(LlamaConfig):
+    arch_string = "SeedOssForCausalLM"
+
+    def __init__(
+        self,
+        directory: str,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            derived_model = {"text": SeedOssModel},
+            **kwargs
+        )
+
+
+class SeedOssModel(LlamaModel):
+    config_class = SeedOssConfig
+
+    def __init__(
+        self,
+        config: SeedOssConfig,
+        **kwargs
+    ):
+        super().__init__(config, **kwargs)
+
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        p = ""
+        if system_prompt:
+            p += f"<seed:bos>system\n"
+            p += f"{system_prompt}<seed:eos>\n"
+        p += f"<seed:bos>user\n"
+        p += f"{prompt}<seed:eos>\n"
+        p += f"<seed:bos>assistant\n"
+        return p

--- a/exllamav3/util/rope.py
+++ b/exllamav3/util/rope.py
@@ -87,6 +87,8 @@ class RoPE:
             t = rs.rope_scaling.get("rope_type", rs.rope_scaling.get("type"))
         match t:
             case None:
+                self.inv_freq, self.attn_factor = self._rope_params_default
+            case "default":
                 self.inv_freq, self.attn_factor = self._rope_params_default()
             case "llama3":
                 self.inv_freq, self.attn_factor = self._rope_params_llama3()

--- a/exllamav3/util/rope.py
+++ b/exllamav3/util/rope.py
@@ -87,7 +87,7 @@ class RoPE:
             t = rs.rope_scaling.get("rope_type", rs.rope_scaling.get("type"))
         match t:
             case None:
-                self.inv_freq, self.attn_factor = self._rope_params_default
+                self.inv_freq, self.attn_factor = self._rope_params_default()
             case "default":
                 self.inv_freq, self.attn_factor = self._rope_params_default()
             case "llama3":


### PR DESCRIPTION
Specifically: https://huggingface.co/collections/ByteDance-Seed/seed-oss-68a609f4201e788db05b5dcd

36B dense, 12T pretraining, but what's extremely interesting to me is:

>  Trained with up-to-512K long context natively.

> Research-Friendly: Given that the inclusion of synthetic instruction data in pre-training may affect the post-training research, we released pre-trained models both with and without instruction data, providing the research community with more diverse options.

For the instruct:

> RULER (128K): 94.6

With nothing *odd* like Qwen3's YaRN.

> We recommend sampling with temperature=1.1 and top_p=0.95.

> Users can flexibly specify the model's thinking budget.


***

Transformers support isn't pulled in yet:

https://github.com/Fazziekey/transformers/tree/seed

I looked at the vllm PR. Keeping in mind I am but a end-user here, I can't find any functional difference between it and Qwen2, other than dual chunk attention, which we don't need?

[Qwen2](https://github.com/FoolPlayer/vllm/blob/seed-oss/vllm/model_executor/models/qwen2.py) vs [SeedOss](https://github.com/FoolPlayer/vllm/blob/seed-oss/vllm/model_executor/models/seed_oss.py): https://www.diffchecker.com/mxcVxOL3/

Hence I'm trying out Qwen2's config and a workaround for the specified 'Default' rope scaling type. It's quantizing now.