### PR TITLE
arch_list: Strip NVIDIA arch suffixes (sm_120a, sm_90a, etc.)

### DIFF
--- a/exllamav3/util/arch_list.py
+++ b/exllamav3/util/arch_list.py
@@ -16,7 +16,8 @@ def maybe_set_arch_list_env():
     arch_list = []
     for i in range(torch.cuda.device_count()):
         capability = torch.cuda.get_device_capability(i)
-        supported_sm = [int(arch.split('_')[1])
+        # Strip known NVIDIA suffixes: 'a' (accelerated) or 'f' (family)
+        supported_sm = [int(arch.split('_')[1].rstrip('af'))
                         for arch in torch.cuda.get_arch_list() if 'sm_' in arch]
         if not supported_sm:
             continue


### PR DESCRIPTION
PyTorch built with TORCH_CUDA_ARCH_LIST=12.0a reports 'sm_120a' in get_arch_list(), causing int() to crash. This strips known NVIDIA suffixes ('a' for accelerated, 'f' for family).