### PR TITLE
Add tensor parallel support for MiniMax M2 Q/K norms

### DIFF
--- a/exllamav3/architecture/minimax_m2.py
+++ b/exllamav3/architecture/minimax_m2.py
@@ -165,8 +165,8 @@ class MiniMaxM2Model(Model):
         # Activate all experts during H capture pass in quantization
         self.calibration_all_experts = True
 
-        # TODO: Q/K norms span all heads, so TP requires an additional step to reduce variance across ranks
-        self.caps.update({"supports_tp": False})
+        # Q/K norms span all heads - TP support uses variance all-reduce across ranks
+        self.caps.update({"supports_tp": True})
 
 
     @override


### PR DESCRIPTION
I was looking for a tensor-parallel inference option to serve MiniMax M2 that can work with an odd number of GPUs so I ended up trying exllamav3, only to learn that it does not yet support TP for MiniMax. I instructed Claude to look into the vLLM implementation and make the necessary changes in exllamav3. After some iterations it came up with this implementation which allows me to load https://huggingface.co/turboderp/MiniMax-M2-exl3 using 5x RTX A5000 in tensor parallel mode. It produces coherent results and appears to utilize all five GPUs during PP and TG (observed in nvtop).

Since I do not know your policy about AI generated code and submissions I am leaving this PR here as-is, leaving it to your discretion whether to merge it or not.

Fixes: #130

Below is Claude's description of the change:

MiniMax M2 uses Q/K RMSNorm with span_heads=True, which normalizes across ALL heads at each sequence position. When using tensor parallelism, heads are split across devices, so each device only sees a subset of heads and computes incorrect local variance.

The fix follows vLLM's approach:
- Compute local sum of squares on each TP rank
- All-reduce the sum across ranks
- Divide by global dimension to get true global mean
- Apply normalization with corrected global variance

Key changes:
- attn.py: Add apply_qk_norms_tp() method with variance all-reduce
- attn.py: Modify tp_export/tp_import to handle span_heads norms
- rmsnorm.py: Preserve span_heads in tp_export, handle 1D tensors in split
- minimax_m2.py: Enable TP support (supports_tp: True)