### PR TITLE
test(eval): add flashinfer regression and benchmark coverage

### DIFF
--- a/doc/mla_support_matrix.md
+++ b/doc/mla_support_matrix.md
@@ -1,0 +1,54 @@
+# MLA Support Matrix (vLLM Reference Parity)
+
+This document tracks MLA-family model support against vLLM's implementations and records whether support is:
+
+- `Implemented`: architecture/parser/loading path exists in exllamav3
+- `Validated`: local runtime checks completed (config parse, model graph, block forward, or full E2E)
+
+## Support policy
+
+A model is considered "supported" only when all of the following are true:
+
+1. Architecture string is registered and resolves to a matching config/model class.
+2. Required parser/preprocessor path (including multimodal) is present.
+3. Tensor key mapping and projection layout are handled without custom manual patching per model.
+4. Runtime validation passes at least block-forward smoke, and preferably end-to-end generation.
+
+---
+
+## MLA-family models in vLLM and exllamav3 status
+
+| Model architecture (vLLM) | exllamav3 status | Validation status | Notes |
+|---|---|---|---|
+| `DeepseekForCausalLM` | Implemented | Config/model instantiation path available | Alias to DeepSeek V2 path, matching vLLM behavior |
+| `DeepseekV2ForCausalLM` | Implemented | Previously validated with local DeepSeek-V2-Lite flow | Uses `DeepseekV2MLAAttention` |
+| `DeepseekV3ForCausalLM` | Implemented | Config/model instantiation path available | Alias to DeepSeek V2 path, matching vLLM behavior |
+| `GlmMoeDsaForCausalLM` | Implemented | Config/model instantiation path available | Alias to DeepSeek V2 path, matching vLLM behavior |
+| `Qwen3_5ForConditionalGeneration` | Implemented | Quantized EN/KO generation smoke validated | Qwen3.5 linear/full attention mix + MM parser path |
+| `Qwen3_5MoeForConditionalGeneration` | Implemented | Quantized EN/KO generation smoke validated | Split GDN projections and split MoE experts mapping handled |
+| `DeepseekV32ForCausalLM` | Not implemented | Not validated | Requires vLLM-specific V3.2 indexer/cache path (`DeepseekV32Indexer*`) not present in exllamav3 |
+| `Glm4MoeLiteForCausalLM` | Not implemented | Not validated | Requires GLM4-MoE-Lite-specific decoder/load-weight path and additional mapping logic |
+| `MiniCPM3ForCausalLM` | Not implemented | Not validated | Separate latent attention implementation and model-specific loader path required |
+| `OpenPanguForCausalLM` | Not implemented | Not validated | Separate MLA module + config/weight mapping not yet added |
+| `KimiLinear*` MLA family | Not implemented | Not validated | Distinct Kimi MLA path and kernels/mappings required |
+| `LongCatFlash*` MLA family | Not implemented | Not validated | Distinct LongCat MLA path and model-specific mappings required |
+
+---
+
+## What was added for Qwen3.5 parity
+
+- New architecture module for:
+  - `Qwen3_5ForConditionalGeneration`
+  - `Qwen3_5MoeForConditionalGeneration`
+- Qwen3.5 parser reuse of Qwen3-VL preprocessing path.
+- GatedDeltaNet split-projection support (`in_proj_qkv/in_proj_z/in_proj_a/in_proj_b`).
+- MoE split expert tensor loading compatibility for Qwen3.5 tensor layout.
+
+---
+
+## Validation caveat
+
+For very large FP16 checkpoints (e.g., 35B class), full end-to-end generation may be constrained by available VRAM.
+In such cases, support is reported as implemented with block-forward validation until quantized checkpoints are available for full runtime validation.
+
+Current status note (2026-02-26): Qwen3.5 35B A3B quantization completed. Split GDN projection handling was corrected and quantized EN/KO generation smoke tests now pass.

--- a/eval/compare_q_exllamav3.py
+++ b/eval/compare_q_exllamav3.py
@@ -37,6 +37,6 @@ def load_exllamav3(model_dir: str | list):
 
 def fwd_exllamav3(model_instance, input_ids: torch.Tensor):
     input_ids = input_ids.cpu()
-    output = model_instance.forward(input_ids, {"attn_mode": "flash_attn_nc"})
+    output = model_instance.forward(input_ids, {"attn_mode": "auto_nc"})
     output[..., model_instance.config.vocab_size:] = float("-inf")
     return output

--- a/eval/gateway_regression_smoke.py
+++ b/eval/gateway_regression_smoke.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Gateway regression smoke test for OpenAI-compatible streaming endpoint.
+
+Designed for local serving checks (e.g. tabby/OpenAI API proxy) without starting
+another server process. Uses curl + SSE parsing, matching the user's manual flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class Case:
+    name: str
+    user_prompt: str
+    expect_hangul: bool = False
+    expect_latin: bool = False
+    max_tokens: int = 192
+
+
+SYSTEM_PROMPT_DEFAULT = (
+    "당신은 친절한 AI입니다. 생각과 응답 모두 입력된 언어와 동일한 언어로 작성하세요."
+)
+
+
+CASES: list[Case] = [
+    Case(
+        name="en_basic",
+        user_prompt="Hello! Reply in English in one or two short sentences.",
+        expect_latin=True,
+    ),
+    Case(
+        name="ko_basic",
+        user_prompt="안녕하세요! 한국어로만 짧게 인사해 주세요.",
+        expect_hangul=True,
+    ),
+    Case(
+        name="ko_math",
+        user_prompt="54*33 풀이와 답을 한국어로 작성하고 마지막 줄에는 답만 적어주세요.",
+        expect_hangul=True,
+    ),
+]
+
+
+def _build_payload(model: str, system_prompt: str, case: Case, temperature: float) -> str:
+    payload = {
+        "model": model,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": temperature,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": case.user_prompt},
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _looks_gibberish(text: str) -> bool:
+    t = text.lower()
+    if "\ufffd" in text:
+        return True
+    indicators = ["-sup", "viste", "nodoc", "ellini"]
+    hits = sum(t.count(k) for k in indicators)
+    return hits >= 6
+
+
+def _run_stream(endpoint: str, api_key: str, payload: str, timeout_sec: float):
+    cmd = [
+        "curl",
+        "-sN",
+        endpoint,
+        "-H",
+        "Content-Type: application/json",
+        "-H",
+        f"Authorization: Bearer {api_key}",
+        "-d",
+        payload,
+    ]
+
+    started = time.perf_counter()
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    usage = None
+    timed_out = False
+    out = ""
+    try:
+        cp = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_sec,
+            check=False,
+        )
+        out = cp.stdout or ""
+    except subprocess.TimeoutExpired as e:
+        timed_out = True
+        if isinstance(e.stdout, bytes):
+            out = e.stdout.decode("utf-8", errors="replace")
+        else:
+            out = e.stdout or ""
+
+    elapsed = time.perf_counter() - started
+    for line in out.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if data == "[DONE]":
+            continue
+
+        try:
+            obj = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+
+        if isinstance(obj, dict) and obj.get("usage"):
+            usage = obj.get("usage")
+
+        choices = obj.get("choices") or []
+        if not choices:
+            continue
+        delta = (choices[0] or {}).get("delta") or {}
+        c = delta.get("content")
+        r = delta.get("reasoning")
+        if isinstance(c, str) and c:
+            content_parts.append(c)
+        if isinstance(r, str) and r:
+            reasoning_parts.append(r)
+
+    content = "".join(content_parts)
+    reasoning = "".join(reasoning_parts)
+    completion_tokens = None
+    if isinstance(usage, dict):
+        completion_tokens = usage.get("completion_tokens")
+
+    return {
+        "timeout": timed_out,
+        "elapsed_sec": elapsed,
+        "content": content,
+        "reasoning": reasoning,
+        "usage": usage,
+        "completion_tokens": completion_tokens,
+    }
+
+
+def _validate(case: Case, text: str) -> list[str]:
+    issues: list[str] = []
+    if not text.strip():
+        issues.append("empty_output")
+    if case.expect_hangul and re.search(r"[가-힣]", text) is None:
+        issues.append("missing_hangul")
+    if case.expect_latin and re.search(r"[A-Za-z]", text) is None:
+        issues.append("missing_latin")
+    if _looks_gibberish(text):
+        issues.append("gibberish_pattern")
+    return issues
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--endpoint", default="http://localhost:8088/v1/chat/completions")
+    ap.add_argument("--api_key", default=os.environ.get("OPENAI_API_KEY", ""))
+    ap.add_argument("--model", default="default")
+    ap.add_argument("--temperature", type=float, default=0.0)
+    ap.add_argument("--timeout_sec", type=float, default=120.0)
+    ap.add_argument("--min_gen_tps", type=float, default=0.0)
+    ap.add_argument("--system_prompt", default=SYSTEM_PROMPT_DEFAULT)
+    args = ap.parse_args()
+
+    if not args.api_key:
+        raise SystemExit("Missing --api_key (or OPENAI_API_KEY env)")
+
+    any_fail = False
+    print(f"Endpoint: {args.endpoint}")
+    print(f"Model:    {args.model}")
+    print("")
+
+    for case in CASES:
+        payload = _build_payload(args.model, args.system_prompt, case, args.temperature)
+        result = _run_stream(args.endpoint, args.api_key, payload, args.timeout_sec)
+
+        text = result["content"] if result["content"] else result["reasoning"]
+        issues = _validate(case, text)
+        if result["timeout"]:
+            issues.append("timeout")
+
+        gen_tps = None
+        ct = result["completion_tokens"]
+        if isinstance(ct, int) and ct > 0 and result["elapsed_sec"] > 0:
+            gen_tps = ct / result["elapsed_sec"]
+            if args.min_gen_tps > 0 and gen_tps < args.min_gen_tps:
+                issues.append(f"slow_gen_tps<{args.min_gen_tps}")
+
+        status = "PASS" if not issues else "FAIL"
+        if issues:
+            any_fail = True
+
+        print(f"[{case.name}] {status}")
+        print(f"  elapsed: {result['elapsed_sec']:.2f}s")
+        if gen_tps is not None:
+            print(f"  gen_tps: {gen_tps:.2f}")
+        print(f"  issues:  {issues}")
+        preview = text.replace("\n", " ")[:280]
+        print(f"  preview: {preview}")
+        print("")
+
+    if any_fail:
+        raise SystemExit(2)
+    print("All gateway regression smoke checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/perf.py
+++ b/eval/perf.py
@@ -2,6 +2,7 @@ import sys, os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from exllamav3.util.progress import ProgressBar
 from exllamav3.util.misc import Timer, cuda_sync_active
+from exllamav3.constants import PAGE_SIZE
 from exllamav3 import model_init
 import torch
 import argparse
@@ -19,7 +20,7 @@ col_gray = "\u001b[37;1m"
 
 @lru_cache
 def cached_ids(length):
-    return torch.arange(length, dtype = torch.long).unsqueeze(0)
+    return torch.ones((1, length), dtype = torch.long)
 
 
 def get_lengths(max_length):
@@ -31,13 +32,35 @@ def get_lengths(max_length):
     return lengths
 
 
+def cache_seq_len(length: int) -> int:
+    return max(((length + PAGE_SIZE - 1) // PAGE_SIZE) * PAGE_SIZE, PAGE_SIZE)
+
+
 faux_recurrent_states = None
 
 
-def measure_prefill(args, model, cache, warmup = False):
+def resolve_benchmark_attn_backend(config) -> str:
+    from exllamav3.modules.attn import (
+        has_flash_attn_backend,
+        has_flashinfer_backend,
+        resolve_auto_attention_backend,
+    )
+
+    return resolve_auto_attention_backend(
+        config,
+        has_flash_attn_backend(),
+        has_flashinfer_backend(),
+    )
+
+
+def measure_prefill(args, model, cache, attn_mode: str, warmup = False):
     global faux_recurrent_states
     chunk_size = args.chunk_size
-    lengths = get_lengths(chunk_size if warmup else args.max_length)
+    lengths = [
+        length
+        for length in get_lengths(chunk_size if warmup else args.max_length)
+        if cache_seq_len(length) <= cache.max_num_tokens
+    ]
 
     progress = 0
     results = {}
@@ -54,10 +77,10 @@ def measure_prefill(args, model, cache, warmup = False):
                 chunks = [(i, min(i + chunk_size, end)) for i in range(start, end, chunk_size)]
                 for start, end in chunks:
                     params = {
-                        "attn_mode": "flash_attn",
+                        "attn_mode": attn_mode,
                         "cache": cache,
                         "past_len": start,
-                        "batch_shape": (1, max(length, 256)),
+                        "batch_shape": (1, cache_seq_len(length)),
                     }
                     if "recurrent_states" in model.caps and start > 0:
                         for v in faux_recurrent_states.values():
@@ -79,10 +102,14 @@ def measure_prefill(args, model, cache, warmup = False):
     return results
 
 
-def measure_generate(args, model, cache, warmup = False):
+def measure_generate(args, model, cache, attn_mode: str, warmup = False):
     global faux_recurrent_states
     chunk_size = args.chunk_size
-    lengths = [0] + get_lengths(chunk_size if warmup else args.max_length)
+    lengths = [
+        length
+        for length in [0] + get_lengths(chunk_size if warmup else args.max_length)
+        if cache_seq_len(length + 1) <= cache.max_num_tokens
+    ]
     progress = 0
     results = {}
     max_progress = len(lengths)
@@ -92,10 +119,10 @@ def measure_generate(args, model, cache, warmup = False):
             with Timer() as t:
                 for _ in range(100):
                     params = {
-                        "attn_mode": "flash_attn",
+                        "attn_mode": attn_mode,
                         "cache": cache,
                         "past_len": length,
-                        "batch_shape": (1, max(length, 256)),
+                        "batch_shape": (1, cache_seq_len(length + 1)),
                     }
                     if "recurrent_states" in model.caps and length > 0:
                         for v in faux_recurrent_states.values():
@@ -124,21 +151,23 @@ def main(args):
 
     model, config, cache, tokenizer = model_init.init(args, max_chunk_size = args.chunk_size)
     bpw_layer, bpw_head, vram_bits = model.get_storage_info()
+    attn_mode = resolve_benchmark_attn_backend(config)
 
     print(f" -- Bitrate: {bpw_layer:.2f} bpw / {bpw_head:.2f} bpw (head)")
     print(f" -- Chunk size: {args.chunk_size}")
+    print(f" -- Attention backend: {attn_mode}")
     print()
 
     # Test prefill
-    measure_prefill(args, model, cache, warmup = True)
+    measure_prefill(args, model, cache, attn_mode, warmup = True)
     print(f"{col_yellow}Prefill:{col_default}")
-    prefill_results = measure_prefill(args, model, cache)
+    prefill_results = measure_prefill(args, model, cache, attn_mode)
     print()
 
     # Test generation
-    measure_generate(args, model, cache, warmup = True)
+    measure_generate(args, model, cache, attn_mode, warmup = True)
     print(f"{col_yellow}Generation{col_default}")
-    generate_results = measure_generate(args, model, cache)
+    generate_results = measure_generate(args, model, cache, attn_mode)
     print()
 
 

--- a/eval/ppl.py
+++ b/eval/ppl.py
@@ -61,7 +61,7 @@ def main(args):
         for row in range(eval_ids.shape[0]):
             pb.update(row)
             input_ids = eval_ids[row:row + 1, :]
-            logits = model.forward(input_ids, {"attn_mode": "flash_attn_nc"})
+            logits = model.forward(input_ids, {"attn_mode": "auto_nc"})
             logits = logits[:, :-1, :vocab_size].float()
             logits += 1e-10
             log_probs = F.log_softmax(logits, dim = -1)

--- a/eval/quality_regression_en_zh.py
+++ b/eval/quality_regression_en_zh.py
@@ -1,0 +1,395 @@
+import argparse
+import os
+import re
+import statistics
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from exllamav3 import model_init
+
+
+@dataclass
+class Case:
+    name: str
+    lang: str  # "en" | "zh"
+    prompt: str
+    max_new_tokens: int = 96
+
+
+CASES: list[Case] = [
+    Case(
+        name="en_reasoning_science",
+        lang="en",
+        prompt=(
+            "Answer in English only. Explain why the sky looks blue in 3-4 sentences, "
+            "then give one everyday example."
+        ),
+    ),
+    Case(
+        name="en_math_word_problem",
+        lang="en",
+        prompt=(
+            "Answer in English only. A shop sells pencils at $2 each. "
+            "If I buy 17 pencils and pay with $50, show the steps and final change."
+        ),
+    ),
+    Case(
+        name="en_instruction_json",
+        lang="en",
+        prompt=(
+            "Return ONLY valid JSON with keys summary and risks. "
+            "Text: The team migrated the API gateway and reduced timeout errors, "
+            "but monitoring coverage is still incomplete."
+        ),
+    ),
+    Case(
+        name="en_logic",
+        lang="en",
+        prompt=(
+            "Answer in English only. If all roses are flowers and some flowers fade quickly, "
+            "what can and cannot be concluded about roses? Keep it concise."
+        ),
+    ),
+    Case(
+        name="en_short_translation",
+        lang="en",
+        prompt=(
+            "Translate this to natural English and explain one key nuance: "
+            "“先把问题拆开，再逐步验证。”"
+        ),
+    ),
+    Case(
+        name="zh_reasoning_science",
+        lang="zh",
+        prompt=(
+            "请只用中文回答：简要解释为什么天空看起来是蓝色的，"
+            "并给出一个日常生活中的例子。"
+        ),
+    ),
+    Case(
+        name="zh_math_steps",
+        lang="zh",
+        prompt="请用中文给出简要过程，最后一行只写答案：54*33",
+    ),
+    Case(
+        name="zh_instruction_json",
+        lang="zh",
+        prompt=(
+            "只输出合法JSON，键为“总结”和“风险”。"
+            "文本：团队迁移了API网关，超时错误减少，但监控覆盖仍不完整。"
+        ),
+    ),
+    Case(
+        name="zh_logic",
+        lang="zh",
+        prompt=(
+            "请只用中文回答：已知“所有A都是B，部分B是C”，"
+            "分别说明能推出和不能推出的结论。"
+        ),
+    ),
+    Case(
+        name="zh_rewrite",
+        lang="zh",
+        prompt=(
+            "请将下面这句话改写成更正式的中文，保持原意："
+            "“先把问题拆开，再逐步验证。”"
+        ),
+    ),
+]
+
+
+def _build_args(model_dir: str, cache_size: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_dir=model_dir,
+        gpu_split=None,
+        load_metrics=False,
+        override=None,
+        tensor_parallel=False,
+        tp_backend="native",
+        tp_max_parallelism_attn=None,
+        tp_max_parallelism_mlp=None,
+        tp_max_parallelism_moe=None,
+        tp_max_parallelism_linear=None,
+        tp_moe_tensor_split=False,
+        load_verbose=False,
+        cache_size=cache_size,
+        cache_quant=None,
+    )
+
+
+def decode_one(tokenizer, ids: torch.Tensor) -> str:
+    text = tokenizer.decode(ids, decode_special_tokens=False)
+    if isinstance(text, list):
+        return text[0]
+    return text
+
+
+@torch.inference_mode()
+def generate_greedy(model, cache, tokenizer, prompt: str, max_new_tokens: int):
+    input_ids = tokenizer.hf_chat_template(
+        [{"role": "user", "content": prompt}],
+        add_generation_prompt=True,
+    )
+    if input_ids.shape[-1] < 2:
+        raise RuntimeError("Prompt is too short after tokenization")
+
+    prefill_params = {
+        "attn_mode": "auto",
+        "cache": cache,
+        "past_len": 0,
+        "batch_shape": (1, cache.max_num_tokens),
+    }
+    model.prefill(
+        input_ids=input_ids[:, :-1],
+        params=prefill_params,
+    )
+
+    cur = input_ids[:, -1:]
+    gen_ids: list[int] = []
+    recurrent_states = prefill_params.get("recurrent_states")
+    for i in range(max_new_tokens):
+        params = {
+            "attn_mode": "auto",
+            "cache": cache,
+            "past_len": input_ids.shape[-1] - 1 + i,
+            "batch_shape": (1, cache.max_num_tokens),
+            "recurrent_states": recurrent_states,
+        }
+        logits = model.forward(cur, params)
+        recurrent_states = params.get("recurrent_states")
+        next_id = torch.argmax(logits[:, -1, :], dim=-1, keepdim=True)
+        tid = next_id.item()
+        if tokenizer.eos_token_id is not None and tid == tokenizer.eos_token_id:
+            break
+        gen_ids.append(tid)
+        cur = next_id
+
+    if len(gen_ids) == 0:
+        return input_ids, [], "", 0
+    gen_tensor = torch.tensor([gen_ids], dtype=torch.long)
+    text = decode_one(tokenizer, gen_tensor)
+    return input_ids, gen_ids, text, len(gen_ids)
+
+
+@torch.inference_mode()
+def score_continuation_nll(model, cache, prompt_ids: torch.Tensor, continuation_ids: list[int]) -> float:
+    if len(continuation_ids) == 0:
+        return float("nan")
+
+    prefill_params = {
+        "attn_mode": "auto",
+        "cache": cache,
+        "past_len": 0,
+        "batch_shape": (1, cache.max_num_tokens),
+    }
+    model.prefill(
+        input_ids=prompt_ids[:, :-1],
+        params=prefill_params,
+    )
+
+    past_len = prompt_ids.shape[-1] - 1
+    cur = prompt_ids[:, -1:]
+    nll_sum = 0.0
+    recurrent_states = prefill_params.get("recurrent_states")
+
+    for tid in continuation_ids:
+        params = {
+            "attn_mode": "auto",
+            "cache": cache,
+            "past_len": past_len,
+            "batch_shape": (1, cache.max_num_tokens),
+            "recurrent_states": recurrent_states,
+        }
+        logits = model.forward(cur, params)
+        recurrent_states = params.get("recurrent_states")
+        logp = F.log_softmax(logits[:, -1, :], dim=-1)[0, tid]
+        nll_sum += float(-logp)
+        cur = torch.tensor([[tid]], dtype=torch.long)
+        past_len += 1
+
+    return nll_sum / len(continuation_ids)
+
+
+def token_match_ratio(a: list[int], b: list[int]) -> float:
+    m = min(len(a), len(b))
+    if m == 0:
+        return 0.0
+    same = sum(1 for i in range(m) if a[i] == b[i])
+    return same / m
+
+
+def prefix_match_len(a: list[int], b: list[int]) -> int:
+    m = min(len(a), len(b))
+    for i in range(m):
+        if a[i] != b[i]:
+            return i
+    return m
+
+
+def replacement_char_count(text: str) -> int:
+    return text.count("\ufffd")
+
+
+def lang_presence_score(text: str, lang: str) -> float:
+    if not text:
+        return 0.0
+    if lang == "en":
+        alpha = len(re.findall(r"[A-Za-z]", text))
+        return alpha / max(len(text), 1)
+    cjk = len(re.findall(r"[\u4e00-\u9fff]", text))
+    return cjk / max(len(text), 1)
+
+
+def repetition_score(text: str) -> float:
+    toks = text.split()
+    if len(toks) < 6:
+        return 0.0
+    tri = {}
+    for i in range(len(toks) - 2):
+        key = (toks[i], toks[i + 1], toks[i + 2])
+        tri[key] = tri.get(key, 0) + 1
+    if not tri:
+        return 0.0
+    return max(tri.values()) / max(len(toks) - 2, 1)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ref_model_dir", type=str, required=True)
+    parser.add_argument("--quant_model_dir", type=str, required=True)
+    parser.add_argument("--cache_size", type=int, default=4096)
+    parser.add_argument("--max_cases", type=int, default=10)
+    args = parser.parse_args()
+
+    selected_cases = CASES[: args.max_cases]
+    results_ref = {}
+    results_quant = {}
+
+    print(f"REF MODEL:   {args.ref_model_dir}")
+    print(f"QUANT MODEL: {args.quant_model_dir}")
+    print(f"CASES:       {len(selected_cases)}")
+    print("")
+
+    # Pass 1: reference model (generation + self NLL on its continuation)
+    model, config, cache, tokenizer = model_init.init(
+        _build_args(args.ref_model_dir, args.cache_size),
+        load_tokenizer=True,
+        quiet=True,
+        progress=False,
+        max_chunk_size=4096,
+    )
+    for case in selected_cases:
+        prompt_ids, gen_ids, text, gen_len = generate_greedy(
+            model=model,
+            cache=cache,
+            tokenizer=tokenizer,
+            prompt=case.prompt,
+            max_new_tokens=case.max_new_tokens,
+        )
+        nll_ref = score_continuation_nll(model, cache, prompt_ids, gen_ids)
+        results_ref[case.name] = {
+            "case": case,
+            "prompt_ids": prompt_ids,
+            "gen_ids": gen_ids,
+            "text": text,
+            "gen_len": gen_len,
+            "nll_ref": nll_ref,
+        }
+        print(f"[REF:{case.name}] gen_len={gen_len} nll={nll_ref:.4f}")
+    model.unload()
+
+    print("")
+
+    # Pass 2: quant model (generation + NLL on reference continuation)
+    model_q, config_q, cache_q, tokenizer_q = model_init.init(
+        _build_args(args.quant_model_dir, args.cache_size),
+        load_tokenizer=True,
+        quiet=True,
+        progress=False,
+        max_chunk_size=4096,
+    )
+    for case in selected_cases:
+        ref = results_ref[case.name]
+        prompt_ids_q, gen_ids_q, text_q, gen_len_q = generate_greedy(
+            model=model_q,
+            cache=cache_q,
+            tokenizer=tokenizer_q,
+            prompt=case.prompt,
+            max_new_tokens=case.max_new_tokens,
+        )
+        nll_q_on_ref = score_continuation_nll(
+            model_q,
+            cache_q,
+            prompt_ids_q,
+            ref["gen_ids"],
+        )
+        results_quant[case.name] = {
+            "gen_ids": gen_ids_q,
+            "text": text_q,
+            "gen_len": gen_len_q,
+            "nll_q_on_ref": nll_q_on_ref,
+        }
+        print(f"[QNT:{case.name}] gen_len={gen_len_q} nll_on_ref={nll_q_on_ref:.4f}")
+    model_q.unload()
+
+    print("\n=== Detailed Report ===")
+    all_match = []
+    all_delta_nll = []
+    all_ref_repl = []
+    all_q_repl = []
+    all_lang_ref = []
+    all_lang_q = []
+    all_rep_ref = []
+    all_rep_q = []
+
+    for case in selected_cases:
+        ref = results_ref[case.name]
+        qnt = results_quant[case.name]
+        ratio = token_match_ratio(ref["gen_ids"], qnt["gen_ids"])
+        pml = prefix_match_len(ref["gen_ids"], qnt["gen_ids"])
+        repl_ref = replacement_char_count(ref["text"])
+        repl_q = replacement_char_count(qnt["text"])
+        lang_ref = lang_presence_score(ref["text"], case.lang)
+        lang_q = lang_presence_score(qnt["text"], case.lang)
+        rep_ref = repetition_score(ref["text"])
+        rep_q = repetition_score(qnt["text"])
+        delta_nll = qnt["nll_q_on_ref"] - ref["nll_ref"]
+
+        all_match.append(ratio)
+        all_delta_nll.append(delta_nll)
+        all_ref_repl.append(repl_ref)
+        all_q_repl.append(repl_q)
+        all_lang_ref.append(lang_ref)
+        all_lang_q.append(lang_q)
+        all_rep_ref.append(rep_ref)
+        all_rep_q.append(rep_q)
+
+        print(
+            f"[{case.name}] "
+            f"match={ratio:.3f} prefix={pml} "
+            f"nll_ref={ref['nll_ref']:.4f} nll_q_on_ref={qnt['nll_q_on_ref']:.4f} delta={delta_nll:+.4f} "
+            f"repl(ref/q)={repl_ref}/{repl_q} lang(ref/q)={lang_ref:.3f}/{lang_q:.3f} "
+            f"repeat(ref/q)={rep_ref:.3f}/{rep_q:.3f}"
+        )
+        print(f"  REF: {ref['text'][:220].replace(chr(10), ' ')}")
+        print(f"  QNT: {qnt['text'][:220].replace(chr(10), ' ')}")
+
+    print("\n=== Summary ===")
+    print(f"avg_token_match_ratio: {statistics.mean(all_match):.4f}")
+    print(f"avg_delta_nll_q_minus_ref_on_ref_cont: {statistics.mean(all_delta_nll):+.4f}")
+    print(f"max_delta_nll_q_minus_ref_on_ref_cont: {max(all_delta_nll):+.4f}")
+    print(f"replacement_chars_total_ref: {sum(all_ref_repl)}")
+    print(f"replacement_chars_total_quant: {sum(all_q_repl)}")
+    print(f"avg_lang_presence_ref: {statistics.mean(all_lang_ref):.4f}")
+    print(f"avg_lang_presence_quant: {statistics.mean(all_lang_q):.4f}")
+    print(f"avg_repetition_score_ref: {statistics.mean(all_rep_ref):.4f}")
+    print(f"avg_repetition_score_quant: {statistics.mean(all_rep_q):.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/quality_smoke_multilingual.py
+++ b/eval/quality_smoke_multilingual.py
@@ -1,0 +1,177 @@
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from exllamav3 import model_init
+
+
+@dataclass
+class PromptCase:
+    name: str
+    prompt: str
+    expect_hangul: bool
+    expect_latin: bool
+
+
+PROMPTS = [
+    PromptCase(
+        name="english_reasoning",
+        prompt=(
+            "Answer in English only. Explain briefly why the sky appears blue, "
+            "then give one everyday example."
+        ),
+        expect_hangul=False,
+        expect_latin=True,
+    ),
+    PromptCase(
+        name="korean_reasoning",
+        prompt=(
+            "한국어로만 답하세요. 하늘이 파란 이유를 간단히 설명하고 "
+            "일상 예시를 한 가지 들어주세요."
+        ),
+        expect_hangul=True,
+        expect_latin=False,
+    ),
+    PromptCase(
+        name="korean_math",
+        prompt=(
+            "한국어로 풀이를 보여주고 마지막 줄에는 답만 적어주세요. "
+            "문제: 54*33"
+        ),
+        expect_hangul=True,
+        expect_latin=False,
+    ),
+]
+
+
+def _decode_one(tokenizer, ids: torch.Tensor) -> str:
+    out = tokenizer.decode(ids, decode_special_tokens=False)
+    if isinstance(out, list):
+        return out[0]
+    return out
+
+
+@torch.inference_mode()
+def generate_greedy(
+    model,
+    cache,
+    tokenizer,
+    prompt: str,
+    max_new_tokens: int,
+    use_decode_wrapper: bool,
+):
+    input_ids = tokenizer.hf_chat_template(
+        [{"role": "user", "content": prompt}],
+        add_generation_prompt=True,
+    )
+    if input_ids.shape[-1] < 2:
+        raise RuntimeError("Prompt is too short after tokenization")
+
+    prefill_params = {
+        "attn_mode": "auto",
+        "cache": cache,
+        "past_len": 0,
+        "batch_shape": (1, cache.max_num_tokens),
+        "flashinfer_use_decode_wrapper": use_decode_wrapper,
+    }
+    model.prefill(
+        input_ids=input_ids[:, :-1],
+        params=prefill_params,
+    )
+
+    cur = input_ids[:, -1:]
+    gen_ids = []
+    recurrent_states = prefill_params.get("recurrent_states")
+
+    for i in range(max_new_tokens):
+        params = {
+            "attn_mode": "auto",
+            "cache": cache,
+            "past_len": input_ids.shape[-1] - 1 + i,
+            "batch_shape": (1, cache.max_num_tokens),
+            "flashinfer_use_decode_wrapper": use_decode_wrapper,
+            "recurrent_states": recurrent_states,
+        }
+        logits = model.forward(cur, params)
+        recurrent_states = params.get("recurrent_states")
+        next_id = torch.argmax(logits[:, -1, :], dim=-1, keepdim=True)
+        token_id = next_id.item()
+        if tokenizer.eos_token_id is not None and token_id == tokenizer.eos_token_id:
+            break
+        gen_ids.append(token_id)
+        cur = next_id
+
+    if len(gen_ids) == 0:
+        return "", 0
+    gen_tensor = torch.tensor([gen_ids], dtype=torch.long)
+    text = _decode_one(tokenizer, gen_tensor)
+    return text, len(gen_ids)
+
+
+def validate_text(text: str, expect_hangul: bool, expect_latin: bool):
+    issues = []
+    if "\ufffd" in text:
+        issues.append("contains_unicode_replacement_char")
+    if expect_hangul and re.search(r"[가-힣]", text) is None:
+        issues.append("missing_hangul")
+    if expect_latin and re.search(r"[A-Za-z]", text) is None:
+        issues.append("missing_latin")
+    return issues
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    model_init.add_args(parser, default_cache_size=4096)
+    parser.add_argument("--max_new_tokens", type=int, default=96)
+    parser.add_argument(
+        "--mode",
+        choices=["on", "off", "both"],
+        default="both",
+        help="decode wrapper usage",
+    )
+    args = parser.parse_args()
+
+    model, config, cache, tokenizer = model_init.init(
+        args,
+        load_tokenizer=True,
+        quiet=True,
+        progress=False,
+        max_chunk_size=4096,
+    )
+
+    modes = [True, False] if args.mode == "both" else [args.mode == "on"]
+    has_failures = False
+
+    for case in PROMPTS:
+        print(f"\n=== {case.name} ===")
+        print(f"PROMPT: {case.prompt}")
+        for use_decode_wrapper in modes:
+            label = "decode_wrapper_on" if use_decode_wrapper else "decode_wrapper_off"
+            text, n_tokens = generate_greedy(
+                model=model,
+                cache=cache,
+                tokenizer=tokenizer,
+                prompt=case.prompt,
+                max_new_tokens=args.max_new_tokens,
+                use_decode_wrapper=use_decode_wrapper,
+            )
+            issues = validate_text(text, case.expect_hangul, case.expect_latin)
+            status = "PASS" if len(issues) == 0 else "FAIL"
+            if issues:
+                has_failures = True
+            print(f"[{label}] {status} tokens={n_tokens} issues={issues}")
+            print(f"[{label}] OUTPUT: {text}\n")
+
+    if has_failures:
+        raise SystemExit(2)
+
+    print("All multilingual smoke checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/smoke_qwen3_5_arch.py
+++ b/eval/smoke_qwen3_5_arch.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Lightweight smoke checks for Qwen3.5 architecture integration.
+
+Checks:
+1) Config/architecture resolution
+2) Model graph construction
+3) One linear-attn block forward
+4) One full-attn block forward
+
+Optional:
+5) Attempt full model load (can fail on low VRAM for FP16 checkpoints)
+"""
+
+import argparse
+import sys
+import torch
+
+from exllamav3 import Config, Model
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", required=True)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--full_load", action="store_true")
+    ap.add_argument("--reserve_per_device", default=None, help="e.g. 0.25,0.25")
+    args = ap.parse_args()
+
+    cfg = Config.from_directory(args.model_dir)
+    print("[INFO] architecture:", cfg.architecture)
+    if cfg.architecture not in ("Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration"):
+        fail(f"Unexpected architecture: {cfg.architecture}")
+
+    model = Model.from_config(cfg)
+    print("[INFO] model graph ok")
+
+    # Verify split projection path exists for linear attention blocks
+    first_block = model.modules[model.first_block_idx]
+    if not hasattr(first_block.attn, "qkv_proj") and not hasattr(first_block.attn, "qkvz_proj"):
+        fail("Expected Qwen3.5 linear attention projection attributes not found")
+
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this smoke check")
+
+    device = torch.device(args.device)
+    hidden_size = cfg.hidden_size
+
+    # First linear-attn block
+    idx_linear = model.first_block_idx
+    blk_linear = model.modules[idx_linear]
+    blk_linear.load(device)
+    x = torch.randn((1, 8, hidden_size), device=device, dtype=torch.half)
+    with torch.inference_mode():
+        y = blk_linear.forward(x, params={})
+    print("[INFO] linear block forward:", blk_linear.key, tuple(y.shape))
+    blk_linear.unload()
+
+    # First full-attn block
+    if "full_attention" not in cfg.layer_types:
+        fail("No full_attention layer found in layer_types")
+    idx_full = model.first_block_idx + cfg.layer_types.index("full_attention")
+    blk_full = model.modules[idx_full]
+    blk_full.load(device)
+    x = torch.randn((1, 8, hidden_size), device=device, dtype=torch.half)
+    with torch.inference_mode():
+        y = blk_full.forward(x, params={})
+    print("[INFO] full block forward:", blk_full.key, tuple(y.shape))
+    blk_full.unload()
+
+    if args.full_load:
+        reserve = None
+        if args.reserve_per_device:
+            reserve = [float(x) for x in args.reserve_per_device.split(",")]
+        print("[INFO] attempting full model load")
+        try:
+            model.load(reserve_per_device=reserve)
+            print("[INFO] full model load ok")
+            model.unload()
+        except Exception as e:
+            print("[WARN] full model load failed:", repr(e))
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    print("[PASS] qwen3.5 smoke checks complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refresh the eval/regression branch onto `v0.0.24`
- update `eval/perf.py` for the current runtime/backend flow
- add gateway smoke, multilingual quality smoke, Qwen3.5 architecture smoke, and MLA support matrix documentation
- switch `compare_q_exllamav3.py` and `ppl.py` to the backend-auto path used by the refreshed runtime

## Notes
- This PR is evaluation/documentation only
- No runtime, kernel, or conversion logic is modified here

## Validation
- `python -m py_compile eval/compare_q_exllamav3.py eval/perf.py eval/ppl.py eval/gateway_regression_smoke.py eval/quality_regression_en_zh.py eval/quality_smoke_multilingual.py eval/smoke_qwen3_5_arch.py`
