### PR TITLE
generator: always reconstruct held text when replacement chars appear

### DIFF
--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -652,8 +652,9 @@ class Job:
         if filter_eos_condition:
             return emit(results, emit_eos = True, emit_held = True, eos_reason = "end_filter")
 
-        # Hold text if it contains an incomplete character
-        if 1 <= self.held_text.count("�") < 5:
+        # Hold text if it contains an incomplete character. Always attempt
+        # reconstruction when replacement characters are present.
+        if "�" in self.held_text:
             test_decode = self.generator.tokenizer.decode(
                 self.held_tokens.torch(),
                 decode_special_tokens = self.decode_special_tokens


### PR DESCRIPTION
## Summary
- Hold text whenever `�` appears and always attempt reconstruction from held token IDs.
- Removes the previous `1 <= count(�) < 5` threshold that could leak broken streamed text for some byte-fallback boundaries.
- Keeps behavior scoped to generator text assembly only (no convert/quant changes).

## Why
Some outputs could temporarily contain exactly five replacement characters in `held_text`, which skipped reconstruction and emitted broken text (e.g. `�����`) even though decoding the same token IDs was valid.

## Validation
- Reproduced stream/decode mismatch before patch and confirmed match after patch in local regression checks.
- Built and smoke-tested runtime paths used during verification without touching conversion/quantization code.