### PR TITLE
Allow explicit compatibility tensor dtype casts

### DIFF
--- a/exllamav3/loader/safetensors.py
+++ b/exllamav3/loader/safetensors.py
@@ -252,6 +252,7 @@ class SafetensorsCollection:
         optional: bool = False,
         allow_bf16: bool = False,
         float2half: bool = False,
+        cast_dtype: torch.dtype | None = None,
         no_defer: bool = False,
         transpose: bool = False,
         pad_to: tuple = None,
@@ -268,6 +269,8 @@ class SafetensorsCollection:
             tensor = self.new_tensors[key].to(device)
             if transpose:
                 tensor = tensor.T.contiguous()
+            if cast_dtype is not None and tensor.dtype != cast_dtype:
+                tensor = tensor.to(cast_dtype)
             return tensor
 
         if not key in self.tensor_file_map:
@@ -296,6 +299,11 @@ class SafetensorsCollection:
             beg += esize * numel * fidx
             end = beg + esize * numel
             bytesize = end - beg
+
+        if cast_dtype is not None:
+            # Dtype casts happen after the tensor is materialized, so keep these small compatibility
+            # loads out of the deferred path rather than expanding deferred bookkeeping.
+            no_defer = True
 
         load_method = self.load_method
         if load_method == "mt_fread" and self.deferred_mode and not no_defer:
@@ -375,6 +383,8 @@ class SafetensorsCollection:
                         padded = torch.zeros(pad_to, dtype = tensor.dtype, device = tensor.device)
                         padded[tuple(slice(0, s) for s in tensor.shape)].copy_(tensor)
                         tensor = padded
+                    if cast_dtype is not None and tensor.dtype != cast_dtype:
+                        tensor = tensor.to(cast_dtype)
                     tensor = tensor.contiguous()
                     self.metrics.direct_tensors += 1
 
@@ -393,6 +403,8 @@ class SafetensorsCollection:
                             padded = torch.zeros(pad_to, dtype = tensor.dtype, device = tensor.device)
                             padded[tuple(slice(0, s) for s in tensor.shape)].copy_(tensor)
                             tensor = padded
+                        if cast_dtype is not None and tensor.dtype != cast_dtype:
+                            tensor = tensor.to(cast_dtype)
                         tensor = tensor.to(device).contiguous()
                     self.metrics.direct_tensors += 1
 

--- a/exllamav3/modules/gated_delta_net.py
+++ b/exllamav3/modules/gated_delta_net.py
@@ -443,7 +443,13 @@ class GatedDeltaNet(Module):
     @override
     def load(self, device: torch.Device, **kwargs):
         super().load(device)
-        self.a_log = self.config.stc.get_tensor(self.key_a_log, self.device, optional = False, allow_bf16 = True)
+        self.a_log = self.config.stc.get_tensor(
+            self.key_a_log,
+            self.device,
+            optional = False,
+            allow_bf16 = True,
+            cast_dtype = torch.float,
+        )
         self.dt_bias = self.config.stc.get_tensor(self.key_dt_bias, self.device, optional = False, allow_bf16 = True)
         self.conv1d_weight = self.config.stc.get_tensor(self.key_conv1d_weight, self.device, optional = False, allow_bf16 = True)
         self.conv1d_bias = self.config.stc.get_tensor(self.key_conv1d_bias, self.device, optional = True, allow_bf16 = True)

--- a/tests/test_checkpoint_cast_dtype.py
+++ b/tests/test_checkpoint_cast_dtype.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import torch
+from safetensors.torch import save_file
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from exllamav3.loader.safetensors import SafetensorsCollection
+
+
+def test_cast_dtype_promotes_bf16_tensor(tmp_path):
+    tensor = torch.tensor([1.0, -2.0, 3.5], dtype = torch.bfloat16)
+    save_file({"state.A_log": tensor}, tmp_path / "model.safetensors")
+
+    stc = SafetensorsCollection(str(tmp_path), load_method = "python")
+    loaded = stc.get_tensor(
+        "state.A_log",
+        device = "cpu",
+        allow_bf16 = True,
+        cast_dtype = torch.float,
+    )
+
+    assert loaded.dtype == torch.float
+    torch.testing.assert_close(loaded, tensor.float())
+
+
+def test_cast_dtype_leaves_bf16_tensor_unchanged_when_not_requested(tmp_path):
+    tensor = torch.tensor([1.0, -2.0, 3.5], dtype = torch.bfloat16)
+    save_file({"state.dt_bias": tensor}, tmp_path / "model.safetensors")
+
+    stc = SafetensorsCollection(str(tmp_path), load_method = "python")
+    loaded = stc.get_tensor(
+        "state.dt_bias",
+        device = "cpu",
+        allow_bf16 = True,
+    )
+
+    assert loaded.dtype == torch.bfloat16
+    torch.testing.assert_close(loaded, tensor)


### PR DESCRIPTION
This is a small compatibility improvement for architecture-preserving checkpoint format variation. The goal is not to support arbitrary model-specific rewrites, but to make required state tensor loading more robust when modified checkpoints keep the same module graph while changing storage dtype.

Some modified checkpoints resave required state tensors at a lower precision than the receiving op expects. This can happen after resaves, merges, abliterations, repacks, or other tooling that keeps the architecture but rewrites tensor storage or dtype.

This adds an opt-in `cast_dtype` argument to `SafetensorsCollection.get_tensor()` and uses it for `GatedDeltaNet` `A_log`, which the fused path expects in float.

The cast is explicit, happens after materialization, and leaves unrelated tensors such as `dt_bias` on their current path.

Adds focused tests for cast and no-cast behavior.