### PR TITLE
Add experimental layer_map support for virtual block replays

### DIFF
--- a/exllamav3/cache/cache.py
+++ b/exllamav3/cache/cache.py
@@ -79,6 +79,7 @@ class Cache:
         model: Model,
         max_num_tokens: int,
         layer_type: Type[CacheLayer] | None = None,
+        layer_map: list[int] | None = None,
         **kwargs
     ):
         """
@@ -113,11 +114,35 @@ class Cache:
         # self.recurrent_layer_type = recurrent_layer_type or RecurrentLayer_fp16
 
         cl = self.model.get_cache_layers()
-        self.num_layers = len(cl)
-        self.layers = {
-            attn.layer_idx: self.layer_type(self.config, attn, id(self), self.max_num_tokens, **kwargs)
-            for attn in cl
-        }
+        if layer_map is None:
+            layer_map = getattr(model, "layer_map", None)
+
+        self.layer_map = None
+        if layer_map is None:
+            self.num_layers = len(cl)
+            self.layers = {
+                attn.layer_idx: self.layer_type(self.config, attn, id(self), self.max_num_tokens, **kwargs)
+                for attn in cl
+            }
+        else:
+            layer_map = list(layer_map)
+            if not layer_map:
+                raise ValueError("layer_map must contain at least one entry.")
+            layer_idx_to_pos = {attn.layer_idx: pos for pos, attn in enumerate(cl)}
+            mapped = []
+            for idx in layer_map:
+                if 0 <= idx < len(cl):
+                    mapped.append(idx)
+                elif idx in layer_idx_to_pos:
+                    mapped.append(layer_idx_to_pos[idx])
+                else:
+                    raise ValueError(f"layer_map index {idx} is invalid for cache layers.")
+            self.layer_map = mapped
+            self.num_layers = len(mapped)
+            self.layers = {
+                v_idx: self.layer_type(self.config, cl[p_idx], id(self), self.max_num_tokens, **kwargs)
+                for v_idx, p_idx in enumerate(mapped)
+            }
 
         self.attach_to_model()
 
@@ -132,10 +157,17 @@ class Cache:
             model = self.model
 
         cl = model.get_cache_layers()
-        for module in cl:
-            layer = self.layers[module.layer_idx]
-            assert layer not in module.cache_layers, "Cannot attach cache twice to the same model."
-            module.cache_layers.append(layer)
+        if self.layer_map is None:
+            for module in cl:
+                layer = self.layers[module.layer_idx]
+                assert layer not in module.cache_layers, "Cannot attach cache twice to the same model."
+                module.cache_layers.append(layer)
+        else:
+            for v_idx, p_idx in enumerate(self.layer_map):
+                module = cl[p_idx]
+                layer = self.layers[v_idx]
+                assert layer not in module.cache_layers, "Cannot attach cache twice to the same model."
+                module.cache_layers.append(layer)
 
 
     def detach_from_model(self, model: Model | None = None):
@@ -146,9 +178,15 @@ class Cache:
             model = self.model
 
         cl = model.get_cache_layers()
-        for module in cl:
-            layer = self.layers[module.layer_idx]
-            module.cache_layers.remove(layer)
+        if self.layer_map is None:
+            for module in cl:
+                layer = self.layers[module.layer_idx]
+                module.cache_layers.remove(layer)
+        else:
+            for v_idx, p_idx in enumerate(self.layer_map):
+                module = cl[p_idx]
+                layer = self.layers[v_idx]
+                module.cache_layers.remove(layer)
 
 
     def get_layer(self, idx: int, cache_seqlens: torch.Tensor, block_table: torch.Tensor) -> tuple:

--- a/exllamav3/exllamav3_ext/avx2_target.cpp
+++ b/exllamav3/exllamav3_ext/avx2_target.cpp
@@ -2,6 +2,7 @@
 
 bool is_avx2_supported()
 {
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
     static bool avx2_check = false;
     static bool avx2_supported = false;
     if (avx2_check) return avx2_supported;
@@ -16,4 +17,7 @@ bool is_avx2_supported()
     // if (avx2_supported) printf("AVX2 supported\n");
     // else printf("AVX2 not supported\n");
     return avx2_supported;
+#else
+    return false;
+#endif
 }

--- a/exllamav3/exllamav3_ext/avx2_target.h
+++ b/exllamav3/exllamav3_ext/avx2_target.h
@@ -6,9 +6,14 @@
 
 bool is_avx2_supported();
 
-#ifdef __linux__
-    #define AVX2_TARGET __attribute__((target("avx2")))
-    #define AVX2_TARGET_OPTIONAL __attribute__((target_clones("avx2","default")))
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+    #ifdef __linux__
+        #define AVX2_TARGET __attribute__((target("avx2")))
+        #define AVX2_TARGET_OPTIONAL __attribute__((target_clones("avx2","default")))
+    #else
+        #define AVX2_TARGET
+        #define AVX2_TARGET_OPTIONAL
+    #endif
 #else
     #define AVX2_TARGET
     #define AVX2_TARGET_OPTIONAL

--- a/exllamav3/exllamav3_ext/parallel/all_reduce_cpu_avx2.cpp
+++ b/exllamav3/exllamav3_ext/parallel/all_reduce_cpu_avx2.cpp
@@ -1,3 +1,24 @@
+#if !defined(__x86_64__) && !defined(_M_X64) && !defined(__i386__) && !defined(_M_IX86)
+#include "all_reduce_cpu_avx2.h"
+#include <stdexcept>
+
+void enable_fast_fp()
+{
+    throw std::runtime_error("AVX2 is not supported on this architecture.");
+}
+
+void perform_cpu_reduce
+(
+    PGContext*,
+    size_t,
+    uint32_t,
+    uint8_t*,
+    size_t
+)
+{
+    throw std::runtime_error("AVX2 is not supported on this architecture.");
+}
+#else
 #include <immintrin.h>
 #include "all_reduce_cpu_avx2.h"
 #include "../avx2_target.h"
@@ -219,3 +240,4 @@ void perform_cpu_reduce
         num_chunks--;
     }
 }
+#endif

--- a/exllamav3/model/model.py
+++ b/exllamav3/model/model.py
@@ -29,6 +29,7 @@ class Model(Model_TPMixin, Model_LSMixin):
         self.last_kv_module_idx = None
         self.logit_layer_idx = None
         self.first_block_idx = None
+        self.layer_map = None
 
         # Calibration options
         self.calibration_all_experts = False

--- a/exllamav3/model/model_ls.py
+++ b/exllamav3/model/model_ls.py
@@ -43,6 +43,24 @@ class Model_LSMixin:
     def default_load_params(self):
         return {}
 
+    def _resolve_layer_map(self, params: dict):
+        layer_map = params.get("layer_map")
+        if layer_map is None:
+            layer_map = getattr(self, "layer_map", None)
+        return layer_map
+
+    def _split_block_modules(self, modules: list, last_kv_module_idx: int):
+        first_block_idx = getattr(self, "first_block_idx", None)
+        if first_block_idx is None or last_kv_module_idx is None:
+            return None
+        if first_block_idx > last_kv_module_idx:
+            return None
+        return (
+            modules[:first_block_idx],
+            modules[first_block_idx:last_kv_module_idx + 1],
+            modules[last_kv_module_idx + 1:],
+        )
+
 
     def _load_autosplit(
         self,
@@ -185,13 +203,49 @@ class Model_LSMixin:
         last_kv_module_idx: int,
         modules: list,
     ):
-        for idx, module in enumerate(modules):
-            params["prefill"] = (idx == last_kv_module_idx)
+        layer_map = self._resolve_layer_map(params)
+        if not layer_map:
+            for idx, module in enumerate(modules):
+                params["prefill"] = (idx == last_kv_module_idx)
+                x = module.prepare_for_device(x, params)
+                x = module.forward(x, params)
+                if idx == last_kv_module_idx:
+                    break
+            del params["prefill"]
+            return None
+
+        split = self._split_block_modules(modules, last_kv_module_idx)
+        if split is None:
+            raise ValueError("layer_map requires first_block_idx and last_kv_module_idx to be set.")
+
+        prefix, blocks, _ = split
+        layer_map = list(layer_map)
+        num_blocks = len(blocks)
+        if not layer_map:
+            raise ValueError("layer_map must contain at least one block index.")
+        if any(idx < 0 or idx >= num_blocks for idx in layer_map):
+            raise ValueError("layer_map indices out of range for block list.")
+
+        for module in prefix:
             x = module.prepare_for_device(x, params)
             x = module.forward(x, params)
-            if idx == last_kv_module_idx:
+
+        prev_override = params.get("layer_idx_override", None)
+        last_virtual_idx = len(layer_map) - 1
+        for virtual_idx, physical_idx in enumerate(layer_map):
+            params["prefill"] = (virtual_idx == last_virtual_idx)
+            params["layer_idx_override"] = virtual_idx
+            module = blocks[physical_idx]
+            x = module.prepare_for_device(x, params)
+            x = module.forward(x, params)
+            if virtual_idx == last_virtual_idx:
                 break
+
         del params["prefill"]
+        if prev_override is None:
+            params.pop("layer_idx_override", None)
+        else:
+            params["layer_idx_override"] = prev_override
         return None
 
 
@@ -202,10 +256,49 @@ class Model_LSMixin:
         last_kv_module_idx: int,
         modules: list,
     ):
-        for idx, module in enumerate(modules):
+        layer_map = self._resolve_layer_map(params)
+        if not layer_map:
+            for idx, module in enumerate(modules):
+                if module.caps.get("logits_output") and (num := params.get("last_tokens_only")):
+                    x = x[..., -num:, :].contiguous()
+                x = module.prepare_for_device(x, params)
+                x = module.forward(x, params)
+            return x
+
+        split = self._split_block_modules(modules, last_kv_module_idx)
+        if split is None:
+            raise ValueError("layer_map requires first_block_idx and last_kv_module_idx to be set.")
+
+        prefix, blocks, suffix = split
+        layer_map = list(layer_map)
+        num_blocks = len(blocks)
+        if not layer_map:
+            raise ValueError("layer_map must contain at least one block index.")
+        if any(idx < 0 or idx >= num_blocks for idx in layer_map):
+            raise ValueError("layer_map indices out of range for block list.")
+
+        for module in prefix:
+            if module.caps.get("logits_output") and (num := params.get("last_tokens_only")):
+                x = x[..., -num:, :].contiguous()
+            x = module.prepare_for_device(x, params)
+            x = module.forward(x, params)
+
+        prev_override = params.get("layer_idx_override", None)
+        for virtual_idx, physical_idx in enumerate(layer_map):
+            params["layer_idx_override"] = virtual_idx
+            module = blocks[physical_idx]
+            if module.caps.get("logits_output") and (num := params.get("last_tokens_only")):
+                x = x[..., -num:, :].contiguous()
+            x = module.prepare_for_device(x, params)
+            x = module.forward(x, params)
+        if prev_override is None:
+            params.pop("layer_idx_override", None)
+        else:
+            params["layer_idx_override"] = prev_override
+
+        for module in suffix:
             if module.caps.get("logits_output") and (num := params.get("last_tokens_only")):
                 x = x[..., -num:, :].contiguous()
             x = module.prepare_for_device(x, params)
             x = module.forward(x, params)
         return x
-

--- a/exllamav3/modules/attn.py
+++ b/exllamav3/modules/attn.py
@@ -675,7 +675,8 @@ class Attention(Module):
         if self.has_split_cache:
             cache_k, cache_v = self.tp_cache_lookup[cache].get_kv(cache_seqlens, block_table)
         else:
-            cache_k, cache_v = cache.get_layer(self.layer_idx, cache_seqlens, block_table)
+            layer_idx = params.get("layer_idx_override", self.layer_idx)
+            cache_k, cache_v = cache.get_layer(layer_idx, cache_seqlens, block_table)
 
         o = flash_attn_with_kvcache(
             q = q,
@@ -694,7 +695,8 @@ class Attention(Module):
         if self.has_split_cache:
             self.tp_cache_lookup[cache].update_kv(cache_seqlens, block_table, cache_k, cache_v, seqlen)
         else:
-            cache.update_layer(self.layer_idx, cache_seqlens, block_table, cache_k, cache_v, seqlen)
+            layer_idx = params.get("layer_idx_override", self.layer_idx)
+            cache.update_layer(layer_idx, cache_seqlens, block_table, cache_k, cache_v, seqlen)
 
         if self.headwise_gate: o *= g.sigmoid().unsqueeze(-1)
         o = o.view((bsz, seqlen, self.num_q_heads * self.head_dim))


### PR DESCRIPTION
This adds experimental `layer_map` support for replaying physical transformer
blocks as virtual execution layers, mainly for weight-sharing relayer research.

Changes:
- add `model.layer_map`
- teach `forward_ls` / `prefill_ls` to split prefix/block/suffix modules and
  replay block modules through a virtual `layer_map`
- pass `layer_idx_override` into attention cache lookup/update so duplicate
  virtual passes get distinct KV slots
- let `Cache` accept or inherit `layer_map` and attach cache layers by virtual
  index
- guard AVX2-only CPU code paths on non-x86 architectures to avoid build issues
  on aarch64

Local validation:
- rebased onto upstream `v0.0.26`
- validated against local ExLlama multilingual hidden-state extraction on
  MiniMax M2.5 EXL3 and GLM 4.7 EXL3
- rebuilt the local precompiled ExLlama image on top of this branch

Scope note:
- this is aimed at the local single-split (`forward_ls`) path used for
  relayer-style analysis; it does not attempt to add tensor-parallel support
  for virtual layer replay
