### PR TITLE
feat(nemotron): add NemotronH architecture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The official and recommended backend server for ExLlamaV3 is [TabbyAPI](https://
 - **Mistral**, **Ministral 3**, **Devstral 2** etc. (MistralForCausalLM, Mistral3ForConditionalGeneration) *- multimodal*
 - **Mixtral** (MixtralForCausalLM)
 - **NanoChat** (NanoChatForCausalLM)
+- **Nemotron H** (NemotronHForCausalLM)
 - **Olmo 3.1** (Olmo3ForCausalLM)
 - **Olmo-Hybrid** (OlmoHybridForCausalLM)
 - **Phi3**, **Phi4** (Phi3ForCausalLM)

--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -24,6 +24,7 @@ from .mistral import MistralModel
 from .mistral3 import Mistral3Model
 from .mixtral import MixtralModel
 from .nanochat import NanoChatModel
+from .nemotron_h import NemotronHModel
 from .olmo3 import Olmo3Model
 from .olmohybrid import OlmoHybridModel
 from .phi3 import Phi3Model
@@ -73,6 +74,7 @@ ARCHITECTURES = {
         Mistral3Model,
         MixtralModel,
         NanoChatModel,
+        NemotronHModel,
         Olmo3Model,
         OlmoHybridModel,
         Phi3Model,

--- a/exllamav3/architecture/nemotron_h.py
+++ b/exllamav3/architecture/nemotron_h.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from typing_extensions import override
+import math
+import torch
+
+from ..model.config import Config, no_default
+from ..model.model import Model
+from ..modules import Attention, Embedding, Linear, MLP, RMSNorm, TransformerBlock
+from ..modules.attn import prepare_for_attn
+from ..modules.gated_delta_net import prepare_for_recurrence
+from ..modules.nemotron_h_mamba import NemotronHMamba2
+from ..modules.nemotron_h_moe import NemotronHMoE
+from ..util.rope import RopeStyle
+
+
+class NemotronHConfig(Config):
+    arch_string = "NemotronHForCausalLM"
+
+    def __init__(
+        self,
+        directory: str,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            {"text": NemotronHModel},
+            **kwargs,
+        )
+
+        self.hidden_size = self.read_cfg(int, "hidden_size", no_default)
+        self.intermediate_size = self.read_cfg(int, "intermediate_size", no_default)
+        self.num_hidden_layers = self.read_cfg(int, "num_hidden_layers", no_default)
+        self.tie_word_embeddings = self.read_cfg(bool, "tie_word_embeddings", False)
+        self.layer_norm_epsilon = self.read_cfg(float, "layer_norm_epsilon", 1e-5)
+
+        self.num_q_heads = self.read_cfg(int, "num_attention_heads", no_default)
+        self.num_kv_heads = self.read_cfg(int, "num_key_value_heads", self.num_q_heads)
+        self.head_dim = self.read_cfg(int, "head_dim", self.hidden_size // self.num_q_heads)
+        self.attention_bias = self.read_cfg(bool, "attention_bias", False)
+
+        self.hybrid_override_pattern = self.read_cfg(str, "hybrid_override_pattern", no_default)
+        if len(self.hybrid_override_pattern) != self.num_hidden_layers:
+            raise ValueError("hybrid_override_pattern must match num_hidden_layers")
+        invalid = set(self.hybrid_override_pattern) - {"M", "*", "E", "-"}
+        if invalid:
+            raise ValueError(f"Unsupported NemotronH layer types: {sorted(invalid)}")
+        self.layer_types = [
+            "mamba" if c == "M" else
+            "attention" if c == "*" else
+            "moe" if c == "E" else
+            "mlp"
+            for c in self.hybrid_override_pattern
+        ]
+
+        self.mlp_hidden_act = self.read_cfg(str, "mlp_hidden_act", "relu2")
+        self.ssm_state_size = self.read_cfg(int, "ssm_state_size", no_default)
+        self.mamba_num_heads = self.read_cfg(int, "mamba_num_heads", no_default)
+        self.mamba_head_dim = self.read_cfg(int, "mamba_head_dim", no_default)
+        self.mamba_n_groups = self.read_cfg(int, ["mamba_n_groups", "n_groups"], 8)
+        self.mamba_d_conv = self.read_cfg(int, ["mamba_d_conv", "conv_kernel"], 4)
+        self.mamba_hidden_act = self.read_cfg(str, "mamba_hidden_act", "silu")
+        self.time_step_limit = tuple(
+            self.read_cfg(list, ["mamba_dt_limit", "time_step_limit"], [0.0, math.inf])
+        )
+        self.use_conv_bias = self.read_cfg(bool, ["mamba_conv_bias", "use_conv_bias"], True)
+        self.use_bias = self.read_cfg(bool, "use_bias", False)
+
+        self.n_routed_experts = self.read_cfg(int, "n_routed_experts", 0)
+        self.n_shared_experts = self.read_cfg(int, "n_shared_experts", 1)
+        self.moe_intermediate_size = self.read_cfg(int, "moe_intermediate_size", 0)
+        self.moe_shared_expert_intermediate_size = self.read_cfg(int, "moe_shared_expert_intermediate_size", 0)
+        self.num_experts_per_tok = self.read_cfg(int, "num_experts_per_tok", 1)
+        self.routed_scaling_factor = self.read_cfg(float, "routed_scaling_factor", 1.0)
+        self.n_group = self.read_cfg(int, "n_group", 1)
+        self.topk_group = self.read_cfg(int, "topk_group", 1)
+        self.norm_topk_prob = self.read_cfg(bool, "norm_topk_prob", True)
+
+        self.rope_settings = self.read_rope_settings_default(
+            RopeStyle.NEOX,
+            default_rope_theta = 10000,
+        )
+
+
+class NemotronHModel(Model):
+    config_class = NemotronHConfig
+
+    def __init__(
+        self,
+        config: NemotronHConfig,
+        key_prefix: str = "backbone",
+        **kwargs,
+    ):
+        super().__init__(config, **kwargs)
+        self.key_prefix = key_prefix
+
+        self.modules += [
+            Embedding(
+                config = config,
+                key = f"{key_prefix}.embeddings",
+                vocab_size = config.vocab_size,
+                hidden_size = config.hidden_size,
+            )
+        ]
+
+        self.first_block_idx = len(self.modules)
+
+        for idx, layer_type in enumerate(config.layer_types):
+            norm = RMSNorm(
+                config = config,
+                key = f"{key_prefix}.layers.{idx}.norm",
+                rms_norm_eps = config.layer_norm_epsilon,
+            )
+
+            if layer_type == "mamba":
+                block = TransformerBlock(
+                    config = config,
+                    key = f"{key_prefix}.layers.{idx}",
+                    layer_idx = idx,
+                    attn_norm = norm,
+                    attn = NemotronHMamba2(
+                        config = config,
+                        key = f"{key_prefix}.layers.{idx}.mixer",
+                        layer_idx = idx,
+                        hidden_size = config.hidden_size,
+                        num_heads = config.mamba_num_heads,
+                        head_dim = config.mamba_head_dim,
+                        ssm_state_size = config.ssm_state_size,
+                        n_groups = config.mamba_n_groups,
+                        conv_kernel_size = config.mamba_d_conv,
+                        rms_norm_eps = config.layer_norm_epsilon,
+                        time_step_limit = config.time_step_limit,
+                        qmap = "block.mamba",
+                        out_dtype = torch.float,
+                    ),
+                )
+            elif layer_type == "attention":
+                block = TransformerBlock(
+                    config = config,
+                    key = f"{key_prefix}.layers.{idx}",
+                    layer_idx = idx,
+                    attn_norm = norm,
+                    attn = Attention(
+                        config = config,
+                        key = f"{key_prefix}.layers.{idx}.mixer",
+                        layer_idx = idx,
+                        hidden_size = config.hidden_size,
+                        head_dim = config.head_dim,
+                        num_q_heads = config.num_q_heads,
+                        num_kv_heads = config.num_kv_heads,
+                        rope_settings = config.rope_settings,
+                        sm_scale = None,
+                        key_q = "q_proj",
+                        key_k = "k_proj",
+                        key_v = "v_proj",
+                        key_o = "o_proj",
+                        qmap = "block.attn",
+                        out_dtype = torch.float,
+                    ),
+                )
+            elif layer_type == "moe":
+                block = TransformerBlock(
+                    config = config,
+                    key = f"{key_prefix}.layers.{idx}",
+                    layer_idx = idx,
+                    mlp_norm = norm,
+                    mlp = NemotronHMoE(
+                        config = config,
+                        key = f"{key_prefix}.layers.{idx}.mixer",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.moe_intermediate_size,
+                        shared_intermediate_size = config.moe_shared_expert_intermediate_size * config.n_shared_experts,
+                        num_experts = config.n_routed_experts,
+                        num_experts_per_tok = config.num_experts_per_tok,
+                        routed_scaling_factor = config.routed_scaling_factor,
+                        n_group = config.n_group,
+                        topk_group = config.topk_group,
+                        norm_topk_prob = config.norm_topk_prob,
+                        qmap = "block.moe",
+                        out_dtype = torch.float,
+                    ),
+                )
+            else:
+                block = TransformerBlock(
+                    config = config,
+                    key = f"{key_prefix}.layers.{idx}",
+                    layer_idx = idx,
+                    mlp_norm = norm,
+                    mlp = MLP(
+                        config = config,
+                        key = f"{key_prefix}.layers.{idx}.mixer",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.intermediate_size,
+                        key_up = "up_proj",
+                        key_down = "down_proj",
+                        activation_fn = config.mlp_hidden_act,
+                        qmap = "block.mlp",
+                        interm_dtype = torch.half,
+                        out_dtype = torch.float,
+                    ),
+                )
+
+            self.modules.append(block)
+
+        cache_layers = [
+            i for i, layer_type in enumerate(config.layer_types)
+            if layer_type in ("mamba", "attention")
+        ]
+        self.last_kv_module_idx = self.first_block_idx + cache_layers[-1]
+
+        head_alt_key = None
+        if config.tie_word_embeddings and not self.config.stc.has_tensor("lm_head"):
+            head_alt_key = f"{key_prefix}.embeddings"
+
+        self.modules += [
+            RMSNorm(
+                config = config,
+                key = f"{key_prefix}.norm_f",
+                rms_norm_eps = config.layer_norm_epsilon,
+                out_dtype = torch.half,
+            ),
+            Linear(
+                config = config,
+                key = "lm_head",
+                qbits_key = "head_bits",
+                alt_key = head_alt_key,
+                in_features = config.hidden_size,
+                out_features = config.vocab_size,
+                qmap = "block",
+                caps = {"logits_output": True},
+            )
+        ]
+
+        self.logit_layer_idx = len(self.modules) - 1
+        self.caps.update({"recurrent_states": True})
+        self.caps.update({"supports_tp": False})
+        self.calibration_all_experts = True
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        input_ids = prepare_for_attn(input_ids, params)
+        prepare_for_recurrence(input_ids, params, self)
+        return input_ids
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        p = ""
+        if system_prompt:
+            p += f"<|im_start|>system\n"
+            p += f"{system_prompt}<|im_end|>\n"
+        p += f"<|im_start|>user\n"
+        p += f"{prompt}<|im_end|>\n"
+        p += f"<|im_start|>assistant\n"
+        return p

--- a/exllamav3/modules/__init__.py
+++ b/exllamav3/modules/__init__.py
@@ -16,3 +16,5 @@ from .qwen3_vl_pos_embedding import Qwen3VLPosEmbedding
 from .glm4v_pos_embedding import Glm4VPosEmbedding
 from .deepstack import DeepstackEmbed
 from .value_embeddings import ValueEmbeddings
+from .nemotron_h_mamba import NemotronHMamba2
+from .nemotron_h_moe import NemotronHMoE

--- a/exllamav3/modules/gated_delta_net.py
+++ b/exllamav3/modules/gated_delta_net.py
@@ -75,13 +75,13 @@ try:
     import causal_conv1d_cuda
     causal_conv1d_update_function = causal_conv1d_update_function_cu
     causal_conv1d_fwd_function = causal_conv1d_fwd_function_cu
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError, RuntimeError):
     causal_conv1d_update_function = causal_conv1d_update_function_torch
     causal_conv1d_fwd_function = causal_conv1d_fwd_function_torch
 
 try:
     from fla.ops.gated_delta_rule import chunk_gated_delta_rule
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError, RuntimeError):
     chunk_gated_delta_rule = None
 
 """

--- a/exllamav3/modules/nemotron_h_mamba.py
+++ b/exllamav3/modules/nemotron_h_mamba.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from typing_extensions import override
+import math
+import torch
+import torch.nn.functional as F
+
+from ..cache import CacheableState
+from ..model.config import Config
+from ..model.model_tp_alloc import TPAllocation
+from ..util.tensor import to2
+from . import Linear, Module
+
+
+class NemotronHMambaRecurrentState(CacheableState):
+
+    def __init__(
+        self,
+        position: int | None = 0,
+        positions: list[int] | None = None,
+        last_conv_state: torch.Tensor | None = None,
+        last_ssm_state: torch.Tensor | None = None,
+        batched: bool = False,
+    ):
+        super().__init__()
+        self.position = position
+        self.positions = positions
+        self.last_conv_state = last_conv_state
+        self.last_ssm_state = last_ssm_state
+        self.batched = batched
+
+    @override
+    def stash(self):
+        return NemotronHMambaRecurrentState(
+            self.position,
+            self.positions,
+            None if self.last_conv_state is None else self.last_conv_state.cpu(),
+            None if self.last_ssm_state is None else self.last_ssm_state.cpu(),
+            self.batched,
+        )
+
+    @override
+    def unstash(self, device):
+        return NemotronHMambaRecurrentState(
+            self.position,
+            self.positions,
+            None if self.last_conv_state is None else self.last_conv_state.to(device, non_blocking = True),
+            None if self.last_ssm_state is None else self.last_ssm_state.to(device, non_blocking = True),
+            self.batched,
+        )
+
+    @override
+    def get_size(self):
+        total = 0
+        if self.last_conv_state is not None:
+            total += self.last_conv_state.element_size() * self.last_conv_state.numel()
+        if self.last_ssm_state is not None:
+            total += self.last_ssm_state.element_size() * self.last_ssm_state.numel()
+        return total
+
+    def collect_batch(self, batch: list[NemotronHMambaRecurrentState]):
+        positions = [b.position for b in batch]
+        if batch[0].last_conv_state is None or batch[0].last_ssm_state is None:
+            return NemotronHMambaRecurrentState(None, positions, None, None, True)
+        lcs = torch.cat([b.last_conv_state for b in batch], dim = 0)
+        lss = torch.cat([b.last_ssm_state for b in batch], dim = 0)
+        return NemotronHMambaRecurrentState(None, positions, lcs, lss, True)
+
+    def distribute_batch(self, batch: list[NemotronHMambaRecurrentState]):
+        for i, b in enumerate(batch):
+            if self.last_conv_state is not None:
+                b.last_conv_state.copy_(self.last_conv_state[i:i+1, ...])
+            if self.last_ssm_state is not None:
+                b.last_ssm_state.copy_(self.last_ssm_state[i:i+1, ...])
+            b.position = self.positions[i]
+
+
+class NemotronHMamba2(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        layer_idx: int,
+        hidden_size: int,
+        num_heads: int,
+        head_dim: int,
+        ssm_state_size: int,
+        n_groups: int,
+        conv_kernel_size: int,
+        rms_norm_eps: float,
+        time_step_limit: tuple[float, float] = (0.0, math.inf),
+        key_in_proj: str = "in_proj",
+        key_out_proj: str = "out_proj",
+        key_a_log: str = "A_log",
+        key_d: str = "D",
+        key_dt_bias: str = "dt_bias",
+        key_conv1d: str = "conv1d",
+        key_norm: str = "norm",
+        qmap: str | None = None,
+        out_dtype: torch.dtype | None = torch.float,
+    ):
+        super().__init__(config, key, None)
+        self.module_name = "NemotronHMamba2"
+
+        self.layer_idx = layer_idx
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.ssm_state_size = ssm_state_size
+        self.n_groups = n_groups
+        self.conv_kernel_size = conv_kernel_size
+        self.rms_norm_eps = rms_norm_eps
+        self.out_dtype = out_dtype
+        self.time_step_limit = time_step_limit
+
+        self.intermediate_size = self.num_heads * self.head_dim
+        self.group_size = self.intermediate_size // self.n_groups
+        self.conv_dim = self.intermediate_size + 2 * self.n_groups * self.ssm_state_size
+        self.projection_size = self.intermediate_size + self.conv_dim + self.num_heads
+
+        self.key_a_log = f"{key}.{key_a_log}"
+        self.key_d = f"{key}.{key_d}"
+        self.key_dt_bias = f"{key}.{key_dt_bias}"
+        self.key_conv1d_weight = f"{key}.{key_conv1d}.weight"
+        self.key_conv1d_bias = f"{key}.{key_conv1d}.bias"
+        self.key_norm_weight = f"{key}.{key_norm}.weight"
+
+        self.in_proj = Linear(
+            config = config,
+            key = f"{key}.{key_in_proj}",
+            in_features = hidden_size,
+            out_features = self.projection_size,
+            qmap = qmap + ".input" if qmap else None,
+        )
+        self.out_proj = Linear(
+            config = config,
+            key = f"{key}.{key_out_proj}",
+            in_features = self.intermediate_size,
+            out_features = hidden_size,
+            qmap = qmap + ".output" if qmap else None,
+            out_dtype = out_dtype,
+        )
+        self.register_submodule(self.in_proj)
+        self.register_submodule(self.out_proj)
+
+        self.a_log = None
+        self.d = None
+        self.dt_bias = None
+        self.conv1d_weight = None
+        self.conv1d_bias = None
+        self.norm_weight = None
+
+        self.caps.update({"recurrent_cache": True})
+
+    @override
+    def optimizer_targets(self):
+        return [[self.in_proj.optimizer_targets(), self.out_proj.optimizer_targets()]]
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.a_log = self.config.stc.get_tensor(self.key_a_log, self.device)
+        self.d = self.config.stc.get_tensor(self.key_d, self.device)
+        self.dt_bias = self.config.stc.get_tensor(self.key_dt_bias, self.device)
+        self.conv1d_weight = self.config.stc.get_tensor(self.key_conv1d_weight, self.device)
+        self.conv1d_bias = self.config.stc.get_tensor(self.key_conv1d_bias, self.device, optional = True)
+        self.norm_weight = self.config.stc.get_tensor(self.key_norm_weight, self.device)
+
+    @override
+    def unload(self):
+        super().unload()
+        self.a_log = None
+        self.d = None
+        self.dt_bias = None
+        self.conv1d_weight = None
+        self.conv1d_bias = None
+        self.norm_weight = None
+
+    @override
+    def weights_numel(self):
+        total = super().weights_numel()
+        for tensor in (
+            self.a_log,
+            self.d,
+            self.dt_bias,
+            self.conv1d_weight,
+            self.conv1d_bias,
+            self.norm_weight,
+        ):
+            if tensor is not None:
+                total += tensor.numel()
+        return total
+
+    def _empty_conv_state(self, batch_size: int, dtype: torch.dtype, device: torch.device):
+        return torch.zeros(
+            (batch_size, self.conv_dim, self.conv_kernel_size),
+            dtype = dtype,
+            device = device,
+        )
+
+    def _empty_ssm_state(self, batch_size: int, device: torch.device):
+        return torch.zeros(
+            (batch_size, self.num_heads, self.head_dim, self.ssm_state_size),
+            dtype = torch.float,
+            device = device,
+        )
+
+    def _conv_step(self, x_t: torch.Tensor, conv_state: torch.Tensor):
+        conv_state = torch.cat([conv_state[..., 1:], x_t.unsqueeze(-1).to(conv_state.dtype)], dim = -1)
+        weight = self.conv1d_weight.squeeze(1).unsqueeze(0)
+        y = (conv_state * weight).sum(dim = -1)
+        if self.conv1d_bias is not None:
+            y = y + self.conv1d_bias
+        y = F.silu(y)
+        return y, conv_state
+
+    def _repeat_groups(self, x: torch.Tensor):
+        repeats = self.num_heads // self.n_groups
+        if repeats == 1:
+            return x
+        return x.repeat_interleave(repeats, dim = 1)
+
+    def _gated_group_rmsnorm(self, x: torch.Tensor, gate: torch.Tensor):
+        input_dtype = x.dtype
+        x = x.float() * F.silu(gate.float())
+        prefix = x.shape[:-1]
+        x = x.view(*prefix, self.n_groups, self.group_size)
+        variance = x.square().mean(dim = -1, keepdim = True)
+        x = x * torch.rsqrt(variance + self.rms_norm_eps)
+        x = x.view(*prefix, self.intermediate_size)
+        x = x * self.norm_weight.float()
+        return x.to(input_dtype)
+
+    def _ssm_step(
+        self,
+        hidden_t: torch.Tensor,
+        b_t: torch.Tensor,
+        c_t: torch.Tensor,
+        dt_t: torch.Tensor,
+        ssm_state: torch.Tensor,
+    ):
+        hidden_heads = hidden_t.view(-1, self.num_heads, self.head_dim).float()
+
+        dt = F.softplus(dt_t.float().unsqueeze(-1) + self.dt_bias.float().view(1, self.num_heads, 1))
+        dt = torch.clamp(dt, self.time_step_limit[0], self.time_step_limit[1])
+
+        b_t = b_t.view(-1, self.n_groups, self.ssm_state_size).float()
+        c_t = c_t.view(-1, self.n_groups, self.ssm_state_size).float()
+        b_t = self._repeat_groups(b_t)
+        c_t = self._repeat_groups(c_t)
+
+        a = -torch.exp(self.a_log.float()).view(1, self.num_heads, 1, 1)
+        d_a = torch.exp(dt.unsqueeze(-1) * a)
+        d_b = dt.unsqueeze(-1) * b_t.unsqueeze(2)
+
+        ssm_state = ssm_state.float() * d_a + d_b * hidden_heads.unsqueeze(-1)
+        y = torch.matmul(ssm_state, c_t.unsqueeze(-1)).squeeze(-1)
+        y = y + hidden_heads * self.d.float().view(1, self.num_heads, 1)
+        return y.reshape(-1, self.intermediate_size), ssm_state
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+
+        batch_size, seq_len, _ = x.shape
+        projected_states = self.in_proj.forward(x, params)
+        if projected_states.shape[-1] != self.projection_size:
+            projected_states = projected_states[..., :self.projection_size].contiguous()
+        _, _, gate, conv_input, dt = projected_states.split(
+            [0, 0, self.intermediate_size, self.conv_dim, self.num_heads],
+            dim = -1,
+        )
+
+        rs = None
+        save_state = False
+        recurrent_states = params.get("recurrent_states")
+        if recurrent_states is not None:
+            rs = recurrent_states.get(self.layer_idx)
+            save_state = rs is not None
+
+        if rs is not None and rs.last_conv_state is not None and rs.last_ssm_state is not None:
+            conv_state = rs.last_conv_state
+            ssm_state = rs.last_ssm_state
+        else:
+            conv_state = self._empty_conv_state(batch_size, x.dtype, x.device)
+            ssm_state = self._empty_ssm_state(batch_size, x.device)
+
+        outputs = []
+        for i in range(seq_len):
+            conv_out, conv_state = self._conv_step(conv_input[:, i, :], conv_state)
+            hidden_t, b_t, c_t = torch.split(
+                conv_out,
+                [self.intermediate_size, self.n_groups * self.ssm_state_size, self.n_groups * self.ssm_state_size],
+                dim = -1,
+            )
+            y_t, ssm_state = self._ssm_step(hidden_t, b_t, c_t, dt[:, i, :], ssm_state)
+            y_t = self._gated_group_rmsnorm(y_t.to(x.dtype), gate[:, i, :])
+            outputs.append(y_t)
+
+        y = torch.stack(outputs, dim = 1)
+        y = self.out_proj.forward(y, params)
+
+        if save_state:
+            rs.last_conv_state = conv_state
+            rs.last_ssm_state = ssm_state
+            if not rs.batched:
+                rs.position += seq_len
+            else:
+                rs.positions = [r + seq_len for r in rs.positions]
+
+        return to2(y, out_dtype, self.out_dtype)
+
+    @override
+    def get_tensors(self):
+        t = super().get_tensors()
+        for tensor, key in (
+            (self.a_log, self.key_a_log),
+            (self.d, self.key_d),
+            (self.dt_bias, self.key_dt_bias),
+            (self.conv1d_weight, self.key_conv1d_weight),
+            (self.conv1d_bias, self.key_conv1d_bias),
+            (self.norm_weight, self.key_norm_weight),
+        ):
+            if tensor is not None:
+                t[key] = tensor
+        return t
+
+    def new_recurrent_state(self):
+        return NemotronHMambaRecurrentState()
+
+    def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        raise NotImplementedError()
+
+    def tp_export(self, plan, producer):
+        raise NotImplementedError()
+
+    @staticmethod
+    def tp_import(local_context, exported, plan, **kwargs):
+        raise NotImplementedError()

--- a/exllamav3/modules/nemotron_h_moe.py
+++ b/exllamav3/modules/nemotron_h_moe.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing_extensions import override
+import torch
+
+from ..model.config import Config
+from ..model.model_tp_alloc import TPAllocation
+from ..util.tensor import to2
+from . import Linear, MLP, Module
+
+
+class NemotronHMoE(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        hidden_size: int,
+        intermediate_size: int,
+        shared_intermediate_size: int,
+        num_experts: int,
+        num_experts_per_tok: int,
+        routed_scaling_factor: float,
+        n_group: int,
+        topk_group: int,
+        norm_topk_prob: bool,
+        key_gate: str = "gate",
+        key_shared_experts: str = "shared_experts",
+        key_experts: str = "experts.{expert_idx}",
+        key_e_score_bias: str = "gate.e_score_correction_bias",
+        qmap: str | None = None,
+        out_dtype: torch.dtype | None = torch.float,
+    ):
+        super().__init__(config, key, None)
+        self.module_name = "NemotronHMoE"
+
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.shared_intermediate_size = shared_intermediate_size
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.routed_scaling_factor = routed_scaling_factor
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.norm_topk_prob = norm_topk_prob
+        self.out_dtype = out_dtype
+
+        self.e_score_correction_bias_key = f"{key}.{key_e_score_bias}"
+        self.e_score_correction_bias = None
+
+        self.routing_gate = Linear(
+            config = config,
+            key = f"{key}.{key_gate}",
+            in_features = hidden_size,
+            out_features = num_experts,
+            qmap = None,
+            out_dtype = torch.float,
+            pad_to = 1,
+        )
+        self.register_submodule(self.routing_gate)
+
+        if shared_intermediate_size > 0:
+            self.shared_experts = MLP(
+                config = config,
+                key = f"{key}.{key_shared_experts}",
+                hidden_size = hidden_size,
+                intermediate_size = shared_intermediate_size,
+                key_up = "up_proj",
+                key_down = "down_proj",
+                activation_fn = "relu2",
+                qmap = qmap + ".shared" if qmap else None,
+                interm_dtype = torch.half,
+                out_dtype = torch.float,
+            )
+            self.register_submodule(self.shared_experts)
+        else:
+            self.shared_experts = None
+
+        self.experts = []
+        for idx in range(num_experts):
+            expert = MLP(
+                config = config,
+                key = f"{key}.{key_experts}".replace("{expert_idx}", str(idx)),
+                hidden_size = hidden_size,
+                intermediate_size = intermediate_size,
+                key_up = "up_proj",
+                key_down = "down_proj",
+                activation_fn = "relu2",
+                qmap = qmap + f".expert.{idx}" if qmap else None,
+                interm_dtype = torch.half,
+                out_dtype = torch.float,
+            )
+            self.experts.append(expert)
+            self.register_submodule(expert)
+
+    @override
+    def optimizer_targets(self):
+        targets = [self.routing_gate.optimizer_targets()]
+        if self.shared_experts is not None:
+            targets.append(self.shared_experts.optimizer_targets())
+        targets += [expert.optimizer_targets() for expert in self.experts]
+        return targets
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.e_score_correction_bias = self.config.stc.get_tensor(
+            self.e_score_correction_bias_key,
+            self.device,
+            optional = True,
+            allow_bf16 = True,
+        )
+
+    @override
+    def unload(self):
+        super().unload()
+        self.e_score_correction_bias = None
+
+    @override
+    def weights_numel(self):
+        total = super().weights_numel()
+        if self.e_score_correction_bias is not None:
+            total += self.e_score_correction_bias.numel()
+        return total
+
+    def _select_experts(self, scores: torch.Tensor, params: dict):
+        activate_all_experts = params.get("activate_all_experts")
+        if activate_all_experts:
+            topk_indices = (
+                torch.arange(self.num_experts, dtype = torch.long, device = scores.device)
+                .repeat(scores.shape[0], 1)
+            )
+            topk_weights = scores
+        else:
+            scores_for_choice = scores
+            if self.e_score_correction_bias is not None:
+                scores_for_choice = scores_for_choice + self.e_score_correction_bias.float().unsqueeze(0)
+
+            if self.n_group > 1:
+                group_scores = (
+                    scores_for_choice.view(-1, self.n_group, self.num_experts // self.n_group)
+                    .topk(2, dim = -1)[0]
+                    .sum(dim = -1)
+                )
+                group_idx = torch.topk(group_scores, k = self.topk_group, dim = -1, sorted = False)[1]
+                group_mask = torch.zeros_like(group_scores)
+                group_mask.scatter_(1, group_idx, 1)
+                score_mask = (
+                    group_mask.unsqueeze(-1)
+                    .expand(-1, self.n_group, self.num_experts // self.n_group)
+                    .reshape(-1, self.num_experts)
+                )
+                scores_for_choice = scores_for_choice.masked_fill(~score_mask.bool(), 0.0)
+
+            topk_indices = torch.topk(
+                scores_for_choice,
+                k = self.num_experts_per_tok,
+                dim = -1,
+                sorted = False,
+            )[1]
+            topk_weights = scores.gather(1, topk_indices)
+
+        if self.norm_topk_prob:
+            topk_weights = topk_weights / (topk_weights.sum(dim = -1, keepdim = True) + 1e-20)
+        topk_weights = topk_weights * self.routed_scaling_factor
+        return topk_indices, topk_weights
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+
+        orig_shape = x.shape
+        hidden_states = x.view(-1, self.hidden_size)
+
+        router_logits = self.routing_gate.forward(hidden_states, params)
+        scores = router_logits.sigmoid()
+        topk_indices, topk_weights = self._select_experts(scores, params)
+
+        final_hidden_states = torch.zeros(
+            hidden_states.shape,
+            dtype = torch.float,
+            device = hidden_states.device,
+        )
+
+        for expert_idx in topk_indices.unique(sorted = False).tolist():
+            token_indices, weight_indices = torch.where(topk_indices == expert_idx)
+            if token_indices.numel() == 0:
+                continue
+            expert_input = hidden_states[token_indices]
+            expert_output = self.experts[expert_idx].forward(expert_input, params)
+            expert_weights = topk_weights[token_indices, weight_indices].to(expert_output.dtype).unsqueeze(-1)
+            final_hidden_states.index_add_(0, token_indices, expert_output * expert_weights)
+
+        if self.shared_experts is not None:
+            final_hidden_states += self.shared_experts.forward(hidden_states, params)
+        final_hidden_states = final_hidden_states.view(orig_shape)
+        return to2(final_hidden_states, out_dtype, self.out_dtype)
+
+    @override
+    def get_tensors(self):
+        t = super().get_tensors()
+        if self.e_score_correction_bias is not None:
+            t[self.e_score_correction_bias_key] = self.e_score_correction_bias
+        return t
+
+    def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        raise NotImplementedError()
+
+    def tp_export(self, plan, producer):
+        raise NotImplementedError()
+
+    @staticmethod
+    def tp_import(local_context, exported, plan, **kwargs):
+        raise NotImplementedError()

--- a/tests/smoke_nemotron_h_arch.py
+++ b/tests/smoke_nemotron_h_arch.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Lightweight smoke checks for NemotronH architecture integration.
+
+Checks:
+1) Config/architecture resolution
+2) Model graph construction
+3) One Mamba block forward
+4) Mamba recurrent state consistency (full sequence vs token-by-token)
+5) One MoE block forward
+6) One attention block forward
+
+Optional:
+7) Attempt full model load
+"""
+
+import argparse
+import sys
+import torch
+
+from exllamav3 import Config, Model
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def first_layer_idx(layer_types: list[str], name: str) -> int:
+    try:
+        return layer_types.index(name)
+    except ValueError as exc:
+        raise RuntimeError(f"No {name} layer found") from exc
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", required=True)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--seq_len", type=int, default=8)
+    ap.add_argument("--full_load", action="store_true")
+    ap.add_argument("--reserve_per_device", default=None, help="e.g. 0.25,0.25")
+    args = ap.parse_args()
+
+    cfg = Config.from_directory(args.model_dir)
+    print("[INFO] architecture:", cfg.architecture)
+    if cfg.architecture != "NemotronHForCausalLM":
+        fail(f"Unexpected architecture: {cfg.architecture}")
+
+    model = Model.from_config(cfg)
+    print("[INFO] model graph ok")
+
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this smoke check")
+
+    device = torch.device(args.device)
+    hidden_size = cfg.hidden_size
+    tol = 5e-2
+
+    idx_mamba = model.first_block_idx + first_layer_idx(cfg.layer_types, "mamba")
+    blk_mamba = model.modules[idx_mamba]
+    blk_mamba.load(device)
+    x = torch.randn((1, args.seq_len, hidden_size), device=device, dtype=torch.half)
+    with torch.inference_mode():
+        y_full = blk_mamba.forward(x, params={})
+    print("[INFO] mamba block forward:", blk_mamba.key, tuple(y_full.shape))
+
+    rs = blk_mamba.attn.new_recurrent_state()
+    params = {"recurrent_states": {blk_mamba.layer_idx: rs}}
+    y_steps = []
+    with torch.inference_mode():
+        for i in range(args.seq_len):
+            y_steps.append(blk_mamba.forward(x[:, i:i+1, :], params=params))
+    y_step = torch.cat(y_steps, dim=1)
+    diff = (y_full - y_step).abs().max().item()
+    print("[INFO] mamba recurrent max diff:", diff)
+    if diff > tol:
+        fail(f"Mamba recurrent consistency check failed: diff={diff}")
+    blk_mamba.unload()
+
+    idx_moe = model.first_block_idx + first_layer_idx(cfg.layer_types, "moe")
+    blk_moe = model.modules[idx_moe]
+    blk_moe.load(device)
+    x = torch.randn((1, args.seq_len, hidden_size), device=device, dtype=torch.half)
+    with torch.inference_mode():
+        y = blk_moe.forward(x, params={})
+    print("[INFO] moe block forward:", blk_moe.key, tuple(y.shape))
+    blk_moe.unload()
+
+    idx_attn = model.first_block_idx + first_layer_idx(cfg.layer_types, "attention")
+    blk_attn = model.modules[idx_attn]
+    blk_attn.load(device)
+    x = torch.randn((1, args.seq_len, hidden_size), device=device, dtype=torch.half)
+    with torch.inference_mode():
+        y = blk_attn.forward(x, params={"attn_mode": "flash_attn_nc", "position": 0})
+    print("[INFO] attention block forward:", blk_attn.key, tuple(y.shape))
+    blk_attn.unload()
+
+    if args.full_load:
+        reserve = None
+        if args.reserve_per_device:
+            reserve = [float(x) for x in args.reserve_per_device.split(",")]
+        print("[INFO] attempting full model load")
+        try:
+            if reserve is not None:
+                model.load(reserve_per_device=reserve)
+            else:
+                model.load(device=device)
+            print("[INFO] full model load ok")
+            model.unload()
+        except Exception as e:
+            print("[WARN] full model load failed:", repr(e))
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    print("[PASS] nemotron-h smoke checks complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
- add `NemotronHForCausalLM` architecture support
- implement Nemotron H Mamba2 and nongated `relu2` MoE blocks
- keep EXL3 conversion compatible with the new block types
- add smoke coverage and docs

Validation:
- `python tests/smoke_nemotron_h_arch.py --model_dir <Nemotron-3-Nano checkpoint> --device cuda:0`
- local EXL3 conversion completed for Nemotron-3-Nano
- quantized output load and short generation check passed

Scope:
- focused on `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`
- tensor parallel support is not included in this PR