### PR TITLE
feat: add module_start/module_end to mp_model_forward for hybrid PP+TP

### DIFF
--- a/exllamav3/model/model_tp_fn.py
+++ b/exllamav3/model/model_tp_fn.py
@@ -177,6 +177,8 @@ def mp_model_forward(
     params: dict,
     last_kv_module_idx: int,
     prefill: bool,
+    module_start: int = 0,
+    module_end: int | None = None,
 ):
     """
     Forward pass for parallel slice of a model
@@ -184,7 +186,8 @@ def mp_model_forward(
     backend = local_context["backend"]
     backend.fwd_barrier()
 
-    modules = local_context["modules"]
+    all_modules = local_context["modules"]
+    modules = all_modules[module_start:module_end]
     consumer = local_context["inf_consumer"]
 
     for tensor_param in [


### PR DESCRIPTION
## Summary

Adds two optional keyword parameters — `module_start` and `module_end` — to `mp_model_forward` in `model_tp_fn.py`. This allows restricting the TP forward pass to a subset of modules, enabling hybrid pipeline-parallel + tensor-parallel execution.

**+3 lines, 1 line altered. Fully backward compatible.**

## Use case

4-GPU node with 2 NVLink pairs connected via PCIe:

```
GPU 0+1 (NVLink): TP=2, layers 0..N/2     ← fast intra-pair all_reduce
GPU 2+3 (NVLink): TP=2, layers N/2..N     ← fast intra-pair all_reduce
Between pairs: 1 activation transfer/token  ← minimal PCIe traffic
```

Without this change, `mp_model_forward` always iterates ALL modules — there's no way to tell a TP rank "only run modules 0-32 this call". With it:

```python
# PP stage 0: run layers 0-32
tp_worker_dispatch(dev, mp_model_forward, (x, params, last_kv, False, 0, 32))

# Transfer activation to stage 1

# PP stage 1: run layers 32-64
tp_worker_dispatch(dev, mp_model_forward, (x, params, last_kv, False, 32, 64))
```

## Change

```diff
 def mp_model_forward(
     local_context, shared_input, params, last_kv_module_idx, prefill,
+    module_start: int = 0,
+    module_end: int | None = None,
 ):
-    modules = local_context["modules"]
+    all_modules = local_context["modules"]
+    modules = all_modules[module_start:module_end]
```

## Backward compatibility

No existing caller passes `module_start`/`module_end`, so `[0:None]` = full list = unchanged behavior. No performance impact (list slice of ~128 pointers is negligible vs GPU forward pass).

## Note on `last_kv_module_idx`

When using a module range, the caller must pass a slice-relative `last_kv_module_idx` (subtract `module_start`). This PR deliberately keeps the diff minimal by not changing that semantic — the caller is responsible.