### PR TITLE
feat(gemma4): add Gemma4 multimodal architecture support

### DIFF
--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -9,6 +9,7 @@ from .ernie4_5_moe import Ernie4_5MoEModel
 from .exaone4 import Exaone4Model
 from .gemma2 import Gemma2Model
 from .gemma3 import Gemma3Model, Gemma3TextModel
+from .gemma4 import Gemma4TextModel
 from .glm4 import Glm4Model
 from .glm4_moe import Glm4MoeModel
 from .glm4v import Glm4VModel
@@ -58,6 +59,7 @@ ARCHITECTURES = {
         Gemma2Model,
         Gemma3Model,
         Gemma3TextModel,
+        Gemma4TextModel,
         Glm4Model,
         Glm4MoeModel,
         Glm4VModel,

--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import json
-import math
 import os
 from types import SimpleNamespace
 
-import numpy as np
 import torch
-from PIL import Image
 from typing_extensions import override
 
 from ..model.config import Config
@@ -22,125 +19,74 @@ from ..modules import (
     Gemma4MoEFeedForward,
     Gemma4MoETransformerBlock,
     Gemma4TransformerBlock,
-    Gemma4VisionAttention,
-    Gemma4VisionPatchEmbedder,
-    Gemma4VisionPooler,
-    Gemma4VisionProjector,
-    Gemma4VisionStandardize,
 )
 from ..modules.attn import prepare_for_attn
-from ..tokenizer import MMEmbedding, Tokenizer
 from ..util.file import no_default
 from ..util.rope import RopeStyle
-from ..util.vision import convert_to_rgb
+from .gemma4_mm import Gemma4VisionModel, set_gemma4_vision_groups
 
 
-def _set_gemma4_vision_groups(
+def _detect_gemma4_profile(config: "Gemma4Config") -> str:
+    if (
+        config.num_hidden_layers == 60 and
+        not config.enable_moe_block and
+        config.num_kv_heads == 16 and
+        config.num_global_kv_heads == 4
+    ):
+        return "31b_dense"
+
+    if (
+        config.num_hidden_layers == 30 and
+        config.enable_moe_block and
+        config.num_kv_heads == 8 and
+        config.num_global_kv_heads == 2
+    ):
+        return "26b_a4b_moe"
+
+    return "generic"
+
+
+def _filter_gemma4_indexed_embeddings(
     input_ids: torch.Tensor,
     params: dict,
-    boi_token_id: int | None,
-    eoi_token_id: int | None,
 ) -> None:
     indexed_embeddings = params.get("indexed_embeddings") or []
     if not indexed_embeddings:
-        params.pop("vision_group_ids", None)
+        params.pop("indexed_embeddings", None)
         return
 
-    vision_group_ids = torch.full(input_ids.shape, -1, dtype = torch.int32)
-    group_index = 0
-    for embedding in indexed_embeddings:
-        mask = (input_ids >= embedding.first_index) & (input_ids < embedding.last_index)
-        if not mask.any():
-            continue
+    active_embeddings = [
+        embedding
+        for embedding in indexed_embeddings
+        if ((input_ids >= embedding.first_index) & (input_ids < embedding.last_index)).any().item()
+    ]
 
-        for row in range(input_ids.shape[0]):
-            row_mask = mask[row]
-            if not row_mask.any():
-                continue
-
-            positions = torch.nonzero(row_mask, as_tuple = False).flatten()
-            start = int(positions[0].item())
-            end = int(positions[-1].item())
-
-            vision_group_ids[row, start : end + 1] = group_index
-
-        group_index += 1
-
-    if group_index > 0:
-        params["vision_group_ids"] = vision_group_ids
+    if active_embeddings:
+        params["indexed_embeddings"] = active_embeddings
     else:
-        params.pop("vision_group_ids", None)
+        params.pop("indexed_embeddings", None)
 
 
-def _get_aspect_ratio_preserving_size(
-    height: int,
-    width: int,
-    patch_size: int,
-    max_patches: int,
-    pooling_kernel_size: int,
-) -> tuple[int, int]:
-    total_px = height * width
-    target_px = max_patches * (patch_size ** 2)
-    factor = math.sqrt(target_px / total_px)
-    ideal_height = factor * height
-    ideal_width = factor * width
-    side_mult = pooling_kernel_size * patch_size
+def _update_gemma4_reconstruct_mode(
+    params: dict,
+    profile: str,
+    has_mm_request: bool,
+) -> None:
+    temp_flag = "_gemma4_temp_reconstruct"
 
-    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
-    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
+    if profile != "26b_a4b_moe":
+        if params.pop(temp_flag, False):
+            params.pop("reconstruct", None)
+        return
 
-    if target_height == 0 and target_width == 0:
-        raise ValueError(
-            "Attempting to resize to a 0 x 0 image. "
-            f"Resized height should be divisible by pooling_kernel_size * patch_size = {side_mult}."
-        )
-
-    max_side_length = (max_patches // (pooling_kernel_size ** 2)) * side_mult
-    if target_height == 0:
-        target_height = side_mult
-        target_width = min(int(math.floor(width / height)) * side_mult, max_side_length)
-    elif target_width == 0:
-        target_width = side_mult
-        target_height = min(int(math.floor(height / width)) * side_mult, max_side_length)
-
-    if target_height * target_width > target_px:
-        raise ValueError(
-            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] exceeds patch budget"
-        )
-
-    return target_height, target_width
-
-
-def _convert_image_to_patches(image: np.ndarray, patch_size: int) -> np.ndarray:
-    num_channels, image_height, image_width = image.shape
-    num_patches_height = image_height // patch_size
-    num_patches_width = image_width // patch_size
-    patched_image = image.reshape(num_channels, num_patches_height, patch_size, num_patches_width, patch_size)
-    patched_image = patched_image.transpose(1, 3, 2, 4, 0)
-    patched_image = patched_image.reshape(num_patches_height * num_patches_width, -1)
-    return patched_image
-
-
-def _pad_patches_and_positions(
-    patches: np.ndarray,
-    positions: np.ndarray,
-    target_length: int,
-) -> tuple[np.ndarray, np.ndarray]:
-    current_length = patches.shape[0]
-    if current_length > target_length:
-        raise ValueError(
-            f"Cannot pad Gemma4 patches from {current_length} down to target length {target_length}"
-        )
-
-    padding_length = target_length - current_length
-    if padding_length == 0:
-        return patches, positions
-
-    patch_paddings = [(0, padding_length)] + [(0, 0)] * (patches.ndim - 1)
-    position_paddings = [(0, padding_length), (0, 0)]
-    patches = np.pad(patches, patch_paddings, mode = "constant", constant_values = 0)
-    positions = np.pad(positions, position_paddings, mode = "constant", constant_values = -1)
-    return patches, positions
+    if has_mm_request:
+        if "reconstruct" not in params:
+            params["reconstruct"] = True
+            params[temp_flag] = True
+        else:
+            params.pop(temp_flag, None)
+    elif params.pop(temp_flag, False):
+        params.pop("reconstruct", None)
 
 
 class Gemma4Config(Config):
@@ -278,9 +224,12 @@ class Gemma4TextModel(Model):
         **kwargs
     ):
         super().__init__(config, **kwargs)
+        profile = _detect_gemma4_profile(config)
+        is_31b_dense = profile == "31b_dense"
         self.caps.update({
-            "supports_tp": False,
+            "supports_tp": is_31b_dense,
             "atomic_mm_prefill": True,
+            "gemma4_profile": profile,
         })
 
         self.modules += [
@@ -431,7 +380,14 @@ class Gemma4TextModel(Model):
 
     @override
     def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
-        _set_gemma4_vision_groups(input_ids, params, self.config.boi_token_id, self.config.eoi_token_id)
+        has_mm_request = bool(params.get("indexed_embeddings"))
+        _filter_gemma4_indexed_embeddings(input_ids, params)
+        _update_gemma4_reconstruct_mode(
+            params,
+            self.caps.get("gemma4_profile", "generic"),
+            has_mm_request = has_mm_request,
+        )
+        set_gemma4_vision_groups(input_ids, params, self.config.boi_token_id, self.config.eoi_token_id)
         return prepare_for_attn(input_ids, params)
 
 
@@ -443,242 +399,3 @@ class Gemma4TextModel(Model):
         p += f"<|turn>user\n{prompt}<turn|>\n"
         p += "<|turn>model\n"
         return p
-
-
-class Gemma4VisionModel(Model):
-
-    @staticmethod
-    @override
-    def get_additional_compiled_tensors(config: Gemma4Config) -> dict:
-        return (
-            config.stc.list_tensors(prefix = "model.vision_tower") |
-            config.stc.list_tensors(prefix = "model.embed_vision")
-        )
-
-
-    def __init__(
-        self,
-        config: Gemma4Config,
-        **kwargs,
-    ):
-        super().__init__(config, **kwargs)
-        self.config = config
-        self.caps.update({
-            "image_input": True,
-            "supports_tp": False,
-        })
-        v = self.config.vision
-
-        self.modules += [
-            Gemma4VisionPatchEmbedder(
-                config = config,
-                key = "model.vision_tower.patch_embedder",
-                hidden_size = v.hidden_size,
-                patch_dim = v.patch_dim,
-            )
-        ]
-
-        for idx in range(v.num_hidden_layers):
-            key = f"model.vision_tower.encoder.layers.{idx}"
-            self.modules.append(
-                TransformerBlock(
-                    config = config,
-                    key = key,
-                    layer_idx = idx,
-                    attn_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.input_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                    ),
-                    attn = Gemma4VisionAttention(
-                        config = config,
-                        key = f"{key}.self_attn",
-                        layer_idx = idx,
-                        hidden_size = v.hidden_size,
-                        head_dim = v.head_dim,
-                        num_q_heads = v.num_q_heads,
-                        num_kv_heads = v.num_kv_heads,
-                        rope_theta = v.rope_theta,
-                        rms_norm_eps = v.rms_norm_eps,
-                    ),
-                    attn_post_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.post_attention_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                        out_dtype = torch.float,
-                    ),
-                    mlp_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.pre_feedforward_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                    ),
-                    mlp = GatedMLP(
-                        config = config,
-                        key = f"{key}.mlp",
-                        hidden_size = v.hidden_size,
-                        intermediate_size = v.intermediate_size,
-                        key_up = "up_proj.linear",
-                        key_gate = "gate_proj.linear",
-                        key_down = "down_proj.linear",
-                        activation_fn = "gelu",
-                        qmap = "block.mlp",
-                    ),
-                    mlp_post_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.post_feedforward_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                        out_dtype = torch.float,
-                    ),
-                )
-            )
-
-        self.modules += [
-            Gemma4VisionPooler(
-                config = config,
-                key = "model.vision_tower.pooler",
-                hidden_size = v.hidden_size,
-            )
-        ]
-
-        if v.standardize:
-            self.modules += [
-                Gemma4VisionStandardize(
-                    config = config,
-                    key = "model.vision_tower",
-                )
-            ]
-
-        self.modules += [
-            Gemma4VisionProjector(
-                config = config,
-                key = "model.embed_vision.embedding_projection",
-                in_features = v.hidden_size,
-                out_features = config.hidden_size,
-                rms_norm_eps = v.rms_norm_eps,
-            ),
-        ]
-
-
-    @override
-    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
-        return input_ids
-
-
-    def default_load_shape_dtype(self, chunk_size):
-        return (
-            1,
-            self.config.vision.max_patches,
-            self.config.vision.patch_dim,
-        ), torch.half
-
-
-    def default_load_params(self, chunk_size):
-        h_patches = 45
-        w_patches = self.config.vision.max_patches // h_patches
-        grid_x, grid_y = np.meshgrid(np.arange(w_patches), np.arange(h_patches), indexing = "xy")
-        position_ids = np.stack([grid_x, grid_y], axis = -1).reshape(self.config.vision.max_patches, 2)
-        return {
-            "input_ids": torch.zeros((1, self.config.vision.max_patches, self.config.vision.patch_dim), dtype = torch.half),
-            "image_position_ids": torch.from_numpy(position_ids).unsqueeze(0).to(torch.long),
-            "image_output_length": self.config.vision_pp.max_soft_tokens,
-            "causal": False,
-        }
-
-
-    def preprocess(
-        self,
-        image: Image.Image,
-    ) -> tuple[torch.Tensor, torch.Tensor, int, tuple[int, int]]:
-        vpp = self.config.vision_pp
-        image = convert_to_rgb(image)
-        old_size = image.size
-        width, height = old_size
-        target_height, target_width = _get_aspect_ratio_preserving_size(
-            height = height,
-            width = width,
-            patch_size = vpp.patch_size,
-            max_patches = self.config.vision.max_patches,
-            pooling_kernel_size = vpp.pooling_kernel_size,
-        )
-
-        if (target_width, target_height) != old_size:
-            image = image.resize((target_width, target_height), resample = Image.Resampling(vpp.resample))
-
-        image_np = np.array(image).astype(np.float32)
-        image_np = image_np.transpose(2, 0, 1)
-
-        if vpp.do_rescale:
-            image_np *= vpp.rescale_factor
-
-        if vpp.do_normalize:
-            image_mean = np.asarray(vpp.image_mean, dtype = np.float32).reshape(-1, 1, 1)
-            image_std = np.asarray(vpp.image_std, dtype = np.float32).reshape(-1, 1, 1)
-            image_np = (image_np - image_mean) / image_std
-
-        patches = _convert_image_to_patches(image_np, vpp.patch_size)
-        num_soft_tokens = patches.shape[0] // (vpp.pooling_kernel_size ** 2)
-
-        patch_height = image_np.shape[-2] // vpp.patch_size
-        patch_width = image_np.shape[-1] // vpp.patch_size
-        grid_x, grid_y = np.meshgrid(np.arange(patch_width), np.arange(patch_height), indexing = "xy")
-        positions = np.stack([grid_x, grid_y], axis = -1).reshape(patches.shape[0], 2)
-
-        patches, positions = _pad_patches_and_positions(
-            patches,
-            positions,
-            self.config.vision.max_patches,
-        )
-
-        pixel_values = torch.from_numpy(patches).half().unsqueeze(0)
-        image_position_ids = torch.from_numpy(positions).to(torch.long).unsqueeze(0)
-        return pixel_values, image_position_ids, num_soft_tokens, (target_width, target_height)
-
-
-    def get_image_embeddings(
-        self,
-        tokenizer: Tokenizer,
-        image: Image.Image | list[Image.Image],
-        text_alias: str | None = None,
-    ):
-        if isinstance(image, list):
-            assert text_alias is None, "Cannot apply a single alias to a list of images"
-            return [self.get_image_embeddings(tokenizer, i) for i in image]
-
-        pixel_values, image_position_ids, _, prep_size = self.preprocess(image)
-        params = {
-            "causal": False,
-            "image_position_ids": image_position_ids,
-            "image_output_length": self.config.vision_pp.max_soft_tokens,
-        }
-        embedding_tensor = self.forward(
-            pixel_values,
-            params = params,
-        ).cpu()
-        pooler_mask = params.get("image_pooler_mask")
-        if pooler_mask is not None:
-            pooler_mask = pooler_mask.cpu()
-            embedding_tensor = embedding_tensor[0][pooler_mask[0]].unsqueeze(0)
-            num_soft_tokens = int(pooler_mask[0].sum().item())
-        else:
-            num_soft_tokens = embedding_tensor.shape[1]
-
-        boi_token_id = tokenizer.single_id("<|image>")
-        image_token_id = tokenizer.single_id("<|image|>")
-        eoi_token_id = tokenizer.single_id("<image|>")
-        token_string = torch.tensor(
-            [[boi_token_id] + [image_token_id] * num_soft_tokens + [eoi_token_id]],
-            dtype = torch.long,
-        )
-        token_string[:, 1:-1] = -1
-
-        mme = MMEmbedding(
-            embeddings = embedding_tensor[0],
-            text_alias = text_alias,
-            token_string = token_string,
-        )
-        mme.metadata.update({
-            "original_size": image.size,
-            "preprocessed_size": prep_size,
-            "model_architecture": self.config.architecture,
-        })
-        return mme

--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -1,0 +1,684 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+from PIL import Image
+from typing_extensions import override
+
+from ..model.config import Config
+from ..model.model import Model
+from ..modules import (
+    Embedding,
+    GatedMLP,
+    Linear,
+    RMSNorm,
+    TransformerBlock,
+    Gemma4Attention,
+    Gemma4MoEFeedForward,
+    Gemma4MoETransformerBlock,
+    Gemma4TransformerBlock,
+    Gemma4VisionAttention,
+    Gemma4VisionPatchEmbedder,
+    Gemma4VisionPooler,
+    Gemma4VisionProjector,
+    Gemma4VisionStandardize,
+)
+from ..modules.attn import prepare_for_attn
+from ..tokenizer import MMEmbedding, Tokenizer
+from ..util.file import no_default
+from ..util.rope import RopeStyle
+from ..util.vision import convert_to_rgb
+
+
+def _set_gemma4_vision_groups(
+    input_ids: torch.Tensor,
+    params: dict,
+    boi_token_id: int | None,
+    eoi_token_id: int | None,
+) -> None:
+    indexed_embeddings = params.get("indexed_embeddings") or []
+    if not indexed_embeddings:
+        params.pop("vision_group_ids", None)
+        return
+
+    vision_group_ids = torch.full(input_ids.shape, -1, dtype = torch.int32)
+    group_index = 0
+    for embedding in indexed_embeddings:
+        mask = (input_ids >= embedding.first_index) & (input_ids < embedding.last_index)
+        if not mask.any():
+            continue
+
+        for row in range(input_ids.shape[0]):
+            row_mask = mask[row]
+            if not row_mask.any():
+                continue
+
+            positions = torch.nonzero(row_mask, as_tuple = False).flatten()
+            start = int(positions[0].item())
+            end = int(positions[-1].item())
+
+            vision_group_ids[row, start : end + 1] = group_index
+
+        group_index += 1
+
+    if group_index > 0:
+        params["vision_group_ids"] = vision_group_ids
+    else:
+        params.pop("vision_group_ids", None)
+
+
+def _get_aspect_ratio_preserving_size(
+    height: int,
+    width: int,
+    patch_size: int,
+    max_patches: int,
+    pooling_kernel_size: int,
+) -> tuple[int, int]:
+    total_px = height * width
+    target_px = max_patches * (patch_size ** 2)
+    factor = math.sqrt(target_px / total_px)
+    ideal_height = factor * height
+    ideal_width = factor * width
+    side_mult = pooling_kernel_size * patch_size
+
+    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
+    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
+
+    if target_height == 0 and target_width == 0:
+        raise ValueError(
+            "Attempting to resize to a 0 x 0 image. "
+            f"Resized height should be divisible by pooling_kernel_size * patch_size = {side_mult}."
+        )
+
+    max_side_length = (max_patches // (pooling_kernel_size ** 2)) * side_mult
+    if target_height == 0:
+        target_height = side_mult
+        target_width = min(int(math.floor(width / height)) * side_mult, max_side_length)
+    elif target_width == 0:
+        target_width = side_mult
+        target_height = min(int(math.floor(height / width)) * side_mult, max_side_length)
+
+    if target_height * target_width > target_px:
+        raise ValueError(
+            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] exceeds patch budget"
+        )
+
+    return target_height, target_width
+
+
+def _convert_image_to_patches(image: np.ndarray, patch_size: int) -> np.ndarray:
+    num_channels, image_height, image_width = image.shape
+    num_patches_height = image_height // patch_size
+    num_patches_width = image_width // patch_size
+    patched_image = image.reshape(num_channels, num_patches_height, patch_size, num_patches_width, patch_size)
+    patched_image = patched_image.transpose(1, 3, 2, 4, 0)
+    patched_image = patched_image.reshape(num_patches_height * num_patches_width, -1)
+    return patched_image
+
+
+def _pad_patches_and_positions(
+    patches: np.ndarray,
+    positions: np.ndarray,
+    target_length: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    current_length = patches.shape[0]
+    if current_length > target_length:
+        raise ValueError(
+            f"Cannot pad Gemma4 patches from {current_length} down to target length {target_length}"
+        )
+
+    padding_length = target_length - current_length
+    if padding_length == 0:
+        return patches, positions
+
+    patch_paddings = [(0, padding_length)] + [(0, 0)] * (patches.ndim - 1)
+    position_paddings = [(0, padding_length), (0, 0)]
+    patches = np.pad(patches, patch_paddings, mode = "constant", constant_values = 0)
+    positions = np.pad(positions, position_paddings, mode = "constant", constant_values = -1)
+    return patches, positions
+
+
+class Gemma4Config(Config):
+    arch_string = "Gemma4ForConditionalGeneration"
+
+    def __init__(
+        self,
+        directory: str,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            {"text": Gemma4TextModel, "vision": Gemma4VisionModel},
+            **kwargs
+        )
+
+        self.image_token_id = self.read_cfg(int, "image_token_id", None)
+        self.boi_token_id = self.read_cfg(int, "boi_token_id", None)
+        self.eoi_token_id = self.read_cfg(int, "eoi_token_id", None)
+        self.vision_soft_tokens_per_image = self.read_cfg(int, "vision_soft_tokens_per_image", no_default)
+
+        self.head_dim = self.read_cfg(int, "text_config->head_dim", no_default)
+        self.global_head_dim = self.read_cfg(int, "text_config->global_head_dim", self.head_dim)
+        self.hidden_size = self.read_cfg(int, "text_config->hidden_size", no_default)
+        self.num_q_heads = self.read_cfg(int, "text_config->num_attention_heads", no_default)
+        self.num_kv_heads = self.read_cfg(int, "text_config->num_key_value_heads", self.num_q_heads)
+        self.num_global_kv_heads = self.read_cfg(
+            int,
+            "text_config->num_global_key_value_heads",
+            self.num_kv_heads
+        )
+        self.num_hidden_layers = self.read_cfg(int, "text_config->num_hidden_layers", no_default)
+        self.tie_word_embeddings = self.read_cfg(bool, "text_config->tie_word_embeddings", False)
+        self.attention_k_eq_v = self.read_cfg(bool, "text_config->attention_k_eq_v", False)
+        self.use_bidirectional_attention = self.read_cfg(str, "text_config->use_bidirectional_attention", None)
+
+        self.layer_types = self.read_cfg(list, "text_config->layer_types", no_default)
+        assert len(self.layer_types) == self.num_hidden_layers, \
+            "Length of text_config->layer_types key doesn't match number of hidden layers"
+
+        self.sliding_window = self.read_cfg(int, "text_config->sliding_window", -1)
+        self.swa_pattern = []
+        for layer_type in self.layer_types:
+            match layer_type:
+                case "sliding_attention":
+                    self.swa_pattern.append(self.sliding_window)
+                case "full_attention":
+                    self.swa_pattern.append(-1)
+                case _:
+                    raise ValueError(f"Unknown layer type in layer_types: {layer_type}")
+
+        self.assert_cfg(str, "text_config->hidden_activation", "gelu_pytorch_tanh", True)
+        self.intermediate_size = self.read_cfg(int, "text_config->intermediate_size", no_default)
+
+        self.rms_norm_eps = self.read_cfg(float, "text_config->rms_norm_eps", no_default)
+        self.attn_logit_softcapping = self.read_cfg(float, "text_config->attn_logit_softcapping", 0.0)
+        self.final_logit_softcapping = self.read_cfg(float, "text_config->final_logit_softcapping", 0.0)
+
+        self.hidden_size_per_layer_input = self.read_cfg(int, "text_config->hidden_size_per_layer_input", 0)
+        if self.hidden_size_per_layer_input:
+            raise NotImplementedError("Gemma4 per-layer inputs are not implemented yet")
+
+        self.enable_moe_block = self.read_cfg(bool, "text_config->enable_moe_block", False)
+        self.num_experts = self.read_cfg(int, "text_config->num_experts", 0)
+        self.num_experts_per_tok = self.read_cfg(int, "text_config->top_k_experts", 0)
+        self.moe_intermediate_size = self.read_cfg(int, "text_config->moe_intermediate_size", 0)
+        if self.enable_moe_block:
+            assert self.num_experts > 0, "Gemma4 MoE requires text_config->num_experts"
+            assert self.num_experts_per_tok > 0, "Gemma4 MoE requires text_config->top_k_experts"
+            assert self.moe_intermediate_size > 0, "Gemma4 MoE requires text_config->moe_intermediate_size"
+
+        self.rope_settings_local = self.read_rope_settings_default(
+            RopeStyle.NEOX,
+            default_rope_theta = 10000.0,
+            config_dict = self.read_cfg(dict, "text_config->rope_parameters->sliding_attention", {}),
+            override_type = self.read_cfg(
+                str,
+                "text_config->rope_parameters->sliding_attention->rope_type",
+                None,
+            )
+        )
+        self.rope_settings_full = self.read_rope_settings_default(
+            RopeStyle.NEOX,
+            default_rope_theta = 1000000.0,
+            config_dict = self.read_cfg(dict, "text_config->rope_parameters->full_attention", {}),
+            override_type = self.read_cfg(
+                str,
+                "text_config->rope_parameters->full_attention->rope_type",
+                None,
+            )
+        )
+        self.rope_settings_full.head_dim = self.global_head_dim
+
+        self.vision = SimpleNamespace()
+        self.vision.hidden_size = self.read_cfg(int, "vision_config->hidden_size", no_default)
+        self.vision.intermediate_size = self.read_cfg(int, "vision_config->intermediate_size", no_default)
+        self.vision.num_hidden_layers = self.read_cfg(int, "vision_config->num_hidden_layers", no_default)
+        self.vision.num_q_heads = self.read_cfg(int, "vision_config->num_attention_heads", no_default)
+        self.vision.num_kv_heads = self.read_cfg(int, "vision_config->num_key_value_heads", self.vision.num_q_heads)
+        self.vision.head_dim = self.read_cfg(int, "vision_config->head_dim", no_default)
+        self.vision.patch_size = self.read_cfg(int, "vision_config->patch_size", no_default)
+        self.vision.pooling_kernel_size = self.read_cfg(int, "vision_config->pooling_kernel_size", no_default)
+        self.vision.position_embedding_size = self.read_cfg(int, "vision_config->position_embedding_size", no_default)
+        self.vision.rms_norm_eps = self.read_cfg(float, "vision_config->rms_norm_eps", no_default)
+        self.vision.standardize = self.read_cfg(bool, "vision_config->standardize", False)
+        self.vision.rope_theta = self.read_cfg(float, "vision_config->rope_parameters->rope_theta", 100.0)
+        self.vision.num_channels = 3
+        self.vision.patch_dim = self.vision.num_channels * self.vision.patch_size ** 2
+
+        processor_path = os.path.join(self.directory, "processor_config.json")
+        with open(processor_path, encoding = "utf8") as f:
+            processor_config = json.load(f)
+        image_processor = processor_config["image_processor"]
+
+        self.vision_pp = SimpleNamespace()
+        self.vision_pp.do_convert_rgb = image_processor["do_convert_rgb"]
+        self.vision_pp.do_rescale = image_processor["do_rescale"]
+        self.vision_pp.do_normalize = image_processor["do_normalize"]
+        self.vision_pp.image_mean = image_processor["image_mean"]
+        self.vision_pp.image_std = image_processor["image_std"]
+        self.vision_pp.resample = image_processor["resample"]
+        self.vision_pp.rescale_factor = image_processor["rescale_factor"]
+        self.vision_pp.max_soft_tokens = image_processor["max_soft_tokens"]
+        self.vision_pp.patch_size = image_processor["patch_size"]
+        self.vision_pp.pooling_kernel_size = image_processor["pooling_kernel_size"]
+        self.vision.max_patches = self.vision_pp.max_soft_tokens * (self.vision_pp.pooling_kernel_size ** 2)
+
+
+class Gemma4TextModel(Model):
+    config_class = Gemma4Config
+
+    def __init__(
+        self,
+        config: Gemma4Config,
+        **kwargs
+    ):
+        super().__init__(config, **kwargs)
+        self.caps.update({
+            "supports_tp": False,
+            "atomic_mm_prefill": True,
+        })
+
+        self.modules += [
+            Embedding(
+                config = config,
+                key = "model.language_model.embed_tokens",
+                vocab_size = config.vocab_size,
+                hidden_size = config.hidden_size,
+                multiplier = config.hidden_size ** 0.5,
+            )
+        ]
+
+        self.first_block_idx = len(self.modules)
+
+        for idx in range(config.num_hidden_layers):
+            key = f"model.language_model.layers.{idx}"
+            layer_is_full = config.layer_types[idx] == "full_attention"
+
+            attn = Gemma4Attention(
+                config = config,
+                key = f"{key}.self_attn",
+                layer_idx = idx,
+                hidden_size = config.hidden_size,
+                head_dim = config.global_head_dim if layer_is_full else config.head_dim,
+                num_q_heads = config.num_q_heads,
+                num_kv_heads = (
+                    config.num_global_kv_heads
+                    if layer_is_full and config.attention_k_eq_v
+                    else config.num_kv_heads
+                ),
+                use_k_as_v = layer_is_full and config.attention_k_eq_v,
+                v_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.self_attn.v_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    unweighted = True,
+                ),
+                rope_settings = config.rope_settings_full if layer_is_full else config.rope_settings_local,
+                sm_scale = 1.0,
+                sliding_window = config.swa_pattern[idx],
+                key_q = "q_proj",
+                key_k = "k_proj",
+                key_v = "v_proj",
+                key_o = "o_proj",
+                qmap = "block.attn",
+                logit_softcapping = config.attn_logit_softcapping,
+                q_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.self_attn.q_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                k_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.self_attn.k_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+            )
+
+            common_kwargs = dict(
+                config = config,
+                key = key,
+                layer_idx = idx,
+                attn_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.input_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                attn = attn,
+                attn_post_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.post_attention_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    out_dtype = torch.float,
+                ),
+                mlp_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.pre_feedforward_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                mlp_post_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.post_feedforward_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    out_dtype = torch.float,
+                ),
+            )
+
+            if config.enable_moe_block:
+                mlp = Gemma4MoEFeedForward(
+                    config = config,
+                    key = key,
+                    hidden_size = config.hidden_size,
+                    intermediate_size = config.intermediate_size,
+                    moe_intermediate_size = config.moe_intermediate_size,
+                    num_experts = config.num_experts,
+                    num_experts_per_tok = config.num_experts_per_tok,
+                    rms_norm_eps = config.rms_norm_eps,
+                )
+                block = Gemma4MoETransformerBlock(
+                    mlp = mlp,
+                    **common_kwargs,
+                )
+            else:
+                block = Gemma4TransformerBlock(
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"{key}.mlp",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.intermediate_size,
+                        key_up = "up_proj",
+                        key_gate = "gate_proj",
+                        key_down = "down_proj",
+                        qmap = "block.mlp",
+                        activation_fn = "gelu",
+                    ),
+                    **common_kwargs,
+                )
+
+            self.modules.append(block)
+
+        self.last_kv_module_idx = len(self.modules) - 1
+
+        self.modules += [
+            RMSNorm(
+                config = config,
+                key = "model.language_model.norm",
+                rms_norm_eps = config.rms_norm_eps,
+                out_dtype = torch.half,
+            ),
+            Linear(
+                config = config,
+                key = "lm_head",
+                qbits_key = "head_bits",
+                alt_key = "model.language_model.embed_tokens" if config.tie_word_embeddings else None,
+                in_features = config.hidden_size,
+                out_features = config.vocab_size,
+                qmap = "block",
+                softcap = config.final_logit_softcapping,
+                caps = {"logits_output": True},
+            )
+        ]
+
+        self.logit_layer_idx = len(self.modules) - 1
+
+        if config.enable_moe_block:
+            self.calibration_all_experts = True
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        _set_gemma4_vision_groups(input_ids, params, self.config.boi_token_id, self.config.eoi_token_id)
+        return prepare_for_attn(input_ids, params)
+
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        p = "<bos>"
+        if system_prompt:
+            p += f"<|turn>system\n{system_prompt}<turn|>\n"
+        p += f"<|turn>user\n{prompt}<turn|>\n"
+        p += "<|turn>model\n"
+        return p
+
+
+class Gemma4VisionModel(Model):
+
+    @staticmethod
+    @override
+    def get_additional_compiled_tensors(config: Gemma4Config) -> dict:
+        return (
+            config.stc.list_tensors(prefix = "model.vision_tower") |
+            config.stc.list_tensors(prefix = "model.embed_vision")
+        )
+
+
+    def __init__(
+        self,
+        config: Gemma4Config,
+        **kwargs,
+    ):
+        super().__init__(config, **kwargs)
+        self.config = config
+        self.caps.update({
+            "image_input": True,
+            "supports_tp": False,
+        })
+        v = self.config.vision
+
+        self.modules += [
+            Gemma4VisionPatchEmbedder(
+                config = config,
+                key = "model.vision_tower.patch_embedder",
+                hidden_size = v.hidden_size,
+                patch_dim = v.patch_dim,
+            )
+        ]
+
+        for idx in range(v.num_hidden_layers):
+            key = f"model.vision_tower.encoder.layers.{idx}"
+            self.modules.append(
+                TransformerBlock(
+                    config = config,
+                    key = key,
+                    layer_idx = idx,
+                    attn_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.input_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn = Gemma4VisionAttention(
+                        config = config,
+                        key = f"{key}.self_attn",
+                        layer_idx = idx,
+                        hidden_size = v.hidden_size,
+                        head_dim = v.head_dim,
+                        num_q_heads = v.num_q_heads,
+                        num_kv_heads = v.num_kv_heads,
+                        rope_theta = v.rope_theta,
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_attention_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                    mlp_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.pre_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"{key}.mlp",
+                        hidden_size = v.hidden_size,
+                        intermediate_size = v.intermediate_size,
+                        key_up = "up_proj.linear",
+                        key_gate = "gate_proj.linear",
+                        key_down = "down_proj.linear",
+                        activation_fn = "gelu",
+                        qmap = "block.mlp",
+                    ),
+                    mlp_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                )
+            )
+
+        self.modules += [
+            Gemma4VisionPooler(
+                config = config,
+                key = "model.vision_tower.pooler",
+                hidden_size = v.hidden_size,
+            )
+        ]
+
+        if v.standardize:
+            self.modules += [
+                Gemma4VisionStandardize(
+                    config = config,
+                    key = "model.vision_tower",
+                )
+            ]
+
+        self.modules += [
+            Gemma4VisionProjector(
+                config = config,
+                key = "model.embed_vision.embedding_projection",
+                in_features = v.hidden_size,
+                out_features = config.hidden_size,
+                rms_norm_eps = v.rms_norm_eps,
+            ),
+        ]
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        return input_ids
+
+
+    def default_load_shape_dtype(self, chunk_size):
+        return (
+            1,
+            self.config.vision.max_patches,
+            self.config.vision.patch_dim,
+        ), torch.half
+
+
+    def default_load_params(self, chunk_size):
+        h_patches = 45
+        w_patches = self.config.vision.max_patches // h_patches
+        grid_x, grid_y = np.meshgrid(np.arange(w_patches), np.arange(h_patches), indexing = "xy")
+        position_ids = np.stack([grid_x, grid_y], axis = -1).reshape(self.config.vision.max_patches, 2)
+        return {
+            "input_ids": torch.zeros((1, self.config.vision.max_patches, self.config.vision.patch_dim), dtype = torch.half),
+            "image_position_ids": torch.from_numpy(position_ids).unsqueeze(0).to(torch.long),
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+            "causal": False,
+        }
+
+
+    def preprocess(
+        self,
+        image: Image.Image,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, tuple[int, int]]:
+        vpp = self.config.vision_pp
+        image = convert_to_rgb(image)
+        old_size = image.size
+        width, height = old_size
+        target_height, target_width = _get_aspect_ratio_preserving_size(
+            height = height,
+            width = width,
+            patch_size = vpp.patch_size,
+            max_patches = self.config.vision.max_patches,
+            pooling_kernel_size = vpp.pooling_kernel_size,
+        )
+
+        if (target_width, target_height) != old_size:
+            image = image.resize((target_width, target_height), resample = Image.Resampling(vpp.resample))
+
+        image_np = np.array(image).astype(np.float32)
+        image_np = image_np.transpose(2, 0, 1)
+
+        if vpp.do_rescale:
+            image_np *= vpp.rescale_factor
+
+        if vpp.do_normalize:
+            image_mean = np.asarray(vpp.image_mean, dtype = np.float32).reshape(-1, 1, 1)
+            image_std = np.asarray(vpp.image_std, dtype = np.float32).reshape(-1, 1, 1)
+            image_np = (image_np - image_mean) / image_std
+
+        patches = _convert_image_to_patches(image_np, vpp.patch_size)
+        num_soft_tokens = patches.shape[0] // (vpp.pooling_kernel_size ** 2)
+
+        patch_height = image_np.shape[-2] // vpp.patch_size
+        patch_width = image_np.shape[-1] // vpp.patch_size
+        grid_x, grid_y = np.meshgrid(np.arange(patch_width), np.arange(patch_height), indexing = "xy")
+        positions = np.stack([grid_x, grid_y], axis = -1).reshape(patches.shape[0], 2)
+
+        patches, positions = _pad_patches_and_positions(
+            patches,
+            positions,
+            self.config.vision.max_patches,
+        )
+
+        pixel_values = torch.from_numpy(patches).half().unsqueeze(0)
+        image_position_ids = torch.from_numpy(positions).to(torch.long).unsqueeze(0)
+        return pixel_values, image_position_ids, num_soft_tokens, (target_width, target_height)
+
+
+    def get_image_embeddings(
+        self,
+        tokenizer: Tokenizer,
+        image: Image.Image | list[Image.Image],
+        text_alias: str | None = None,
+    ):
+        if isinstance(image, list):
+            assert text_alias is None, "Cannot apply a single alias to a list of images"
+            return [self.get_image_embeddings(tokenizer, i) for i in image]
+
+        pixel_values, image_position_ids, _, prep_size = self.preprocess(image)
+        params = {
+            "causal": False,
+            "image_position_ids": image_position_ids,
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+        }
+        embedding_tensor = self.forward(
+            pixel_values,
+            params = params,
+        ).cpu()
+        pooler_mask = params.get("image_pooler_mask")
+        if pooler_mask is not None:
+            pooler_mask = pooler_mask.cpu()
+            embedding_tensor = embedding_tensor[0][pooler_mask[0]].unsqueeze(0)
+            num_soft_tokens = int(pooler_mask[0].sum().item())
+        else:
+            num_soft_tokens = embedding_tensor.shape[1]
+
+        boi_token_id = tokenizer.single_id("<|image>")
+        image_token_id = tokenizer.single_id("<|image|>")
+        eoi_token_id = tokenizer.single_id("<image|>")
+        token_string = torch.tensor(
+            [[boi_token_id] + [image_token_id] * num_soft_tokens + [eoi_token_id]],
+            dtype = torch.long,
+        )
+        token_string[:, 1:-1] = -1
+
+        mme = MMEmbedding(
+            embeddings = embedding_tensor[0],
+            text_alias = text_alias,
+            token_string = token_string,
+        )
+        mme.metadata.update({
+            "original_size": image.size,
+            "preprocessed_size": prep_size,
+            "model_architecture": self.config.architecture,
+        })
+        return mme

--- a/exllamav3/architecture/gemma4_mm.py
+++ b/exllamav3/architecture/gemma4_mm.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+from PIL import Image
+from typing_extensions import override
+
+from ..model.model import Model
+from ..modules import (
+    GatedMLP,
+    RMSNorm,
+    TransformerBlock,
+    Gemma4VisionAttention,
+    Gemma4VisionPatchEmbedder,
+    Gemma4VisionPooler,
+    Gemma4VisionProjector,
+    Gemma4VisionStandardize,
+)
+from ..tokenizer import MMEmbedding, Tokenizer
+from ..util.vision import convert_to_rgb
+
+if TYPE_CHECKING:
+    from .gemma4 import Gemma4Config
+
+
+def set_gemma4_vision_groups(
+    input_ids: torch.Tensor,
+    params: dict,
+    boi_token_id: int | None,
+    eoi_token_id: int | None,
+) -> None:
+    indexed_embeddings = params.get("indexed_embeddings") or []
+    if not indexed_embeddings:
+        params.pop("vision_group_ids", None)
+        return
+
+    vision_group_ids = torch.full(input_ids.shape, -1, dtype = torch.int32)
+    group_index = 0
+    for embedding in indexed_embeddings:
+        mask = (input_ids >= embedding.first_index) & (input_ids < embedding.last_index)
+        if not mask.any():
+            continue
+
+        for row in range(input_ids.shape[0]):
+            row_mask = mask[row]
+            if not row_mask.any():
+                continue
+
+            positions = torch.nonzero(row_mask, as_tuple = False).flatten()
+            start = int(positions[0].item())
+            end = int(positions[-1].item())
+            # Gemma4's multimodal bidirectional mask groups only the soft image
+            # tokens. BOI/EOI remain text tokens in HF/vLLM and should not be
+            # merged into the vision group span.
+            vision_group_ids[row, start : end + 1] = group_index
+
+        group_index += 1
+
+    if group_index > 0:
+        params["vision_group_ids"] = vision_group_ids
+    else:
+        params.pop("vision_group_ids", None)
+
+
+def _get_aspect_ratio_preserving_size(
+    height: int,
+    width: int,
+    patch_size: int,
+    max_patches: int,
+    pooling_kernel_size: int,
+) -> tuple[int, int]:
+    total_px = height * width
+    target_px = max_patches * (patch_size ** 2)
+    factor = math.sqrt(target_px / total_px)
+    ideal_height = factor * height
+    ideal_width = factor * width
+    side_mult = pooling_kernel_size * patch_size
+
+    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
+    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
+
+    if target_height == 0 and target_width == 0:
+        raise ValueError(
+            "Attempting to resize to a 0 x 0 image. "
+            f"Resized height should be divisible by pooling_kernel_size * patch_size = {side_mult}."
+        )
+
+    max_side_length = (max_patches // (pooling_kernel_size ** 2)) * side_mult
+    if target_height == 0:
+        target_height = side_mult
+        target_width = min(int(math.floor(width / height)) * side_mult, max_side_length)
+    elif target_width == 0:
+        target_width = side_mult
+        target_height = min(int(math.floor(height / width)) * side_mult, max_side_length)
+
+    if target_height * target_width > target_px:
+        raise ValueError(
+            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] exceeds patch budget"
+        )
+
+    return target_height, target_width
+
+
+def _convert_image_to_patches(image: np.ndarray, patch_size: int) -> np.ndarray:
+    num_channels, image_height, image_width = image.shape
+    num_patches_height = image_height // patch_size
+    num_patches_width = image_width // patch_size
+    patched_image = image.reshape(num_channels, num_patches_height, patch_size, num_patches_width, patch_size)
+    patched_image = patched_image.transpose(1, 3, 2, 4, 0)
+    patched_image = patched_image.reshape(num_patches_height * num_patches_width, -1)
+    return patched_image
+
+
+def _pad_patches_and_positions(
+    patches: np.ndarray,
+    positions: np.ndarray,
+    target_length: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    current_length = patches.shape[0]
+    if current_length > target_length:
+        raise ValueError(
+            f"Cannot pad Gemma4 patches from {current_length} down to target length {target_length}"
+        )
+
+    padding_length = target_length - current_length
+    if padding_length == 0:
+        return patches, positions
+
+    patch_paddings = [(0, padding_length)] + [(0, 0)] * (patches.ndim - 1)
+    position_paddings = [(0, padding_length), (0, 0)]
+    patches = np.pad(patches, patch_paddings, mode = "constant", constant_values = 0)
+    positions = np.pad(positions, position_paddings, mode = "constant", constant_values = -1)
+    return patches, positions
+
+
+class Gemma4VisionModel(Model):
+
+    @staticmethod
+    @override
+    def get_additional_compiled_tensors(config: "Gemma4Config") -> dict:
+        return (
+            config.stc.list_tensors(prefix = "model.vision_tower") |
+            config.stc.list_tensors(prefix = "model.embed_vision")
+        )
+
+
+    def __init__(
+        self,
+        config: "Gemma4Config",
+        **kwargs,
+    ):
+        super().__init__(config, **kwargs)
+        self.config = config
+        self.caps.update({
+            "image_input": True,
+            "supports_tp": False,
+        })
+        v = self.config.vision
+
+        self.modules += [
+            Gemma4VisionPatchEmbedder(
+                config = config,
+                key = "model.vision_tower.patch_embedder",
+                hidden_size = v.hidden_size,
+                patch_dim = v.patch_dim,
+            )
+        ]
+
+        for idx in range(v.num_hidden_layers):
+            key = f"model.vision_tower.encoder.layers.{idx}"
+            self.modules.append(
+                TransformerBlock(
+                    config = config,
+                    key = key,
+                    layer_idx = idx,
+                    attn_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.input_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn = Gemma4VisionAttention(
+                        config = config,
+                        key = f"{key}.self_attn",
+                        layer_idx = idx,
+                        hidden_size = v.hidden_size,
+                        head_dim = v.head_dim,
+                        num_q_heads = v.num_q_heads,
+                        num_kv_heads = v.num_kv_heads,
+                        rope_theta = v.rope_theta,
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_attention_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                    mlp_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.pre_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"{key}.mlp",
+                        hidden_size = v.hidden_size,
+                        intermediate_size = v.intermediate_size,
+                        key_up = "up_proj.linear",
+                        key_gate = "gate_proj.linear",
+                        key_down = "down_proj.linear",
+                        activation_fn = "gelu",
+                        qmap = "block.mlp",
+                    ),
+                    mlp_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                )
+            )
+
+        self.modules += [
+            Gemma4VisionPooler(
+                config = config,
+                key = "model.vision_tower.pooler",
+                hidden_size = v.hidden_size,
+            )
+        ]
+
+        if v.standardize:
+            self.modules += [
+                Gemma4VisionStandardize(
+                    config = config,
+                    key = "model.vision_tower",
+                )
+            ]
+
+        self.modules += [
+            Gemma4VisionProjector(
+                config = config,
+                key = "model.embed_vision.embedding_projection",
+                in_features = v.hidden_size,
+                out_features = config.hidden_size,
+                rms_norm_eps = v.rms_norm_eps,
+            ),
+        ]
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        return input_ids
+
+
+    def default_load_shape_dtype(self, chunk_size):
+        return (
+            1,
+            self.config.vision.max_patches,
+            self.config.vision.patch_dim,
+        ), torch.half
+
+
+    def default_load_params(self, chunk_size):
+        h_patches = 45
+        w_patches = self.config.vision.max_patches // h_patches
+        grid_x, grid_y = np.meshgrid(np.arange(w_patches), np.arange(h_patches), indexing = "xy")
+        position_ids = np.stack([grid_x, grid_y], axis = -1).reshape(self.config.vision.max_patches, 2)
+        return {
+            "input_ids": torch.zeros((1, self.config.vision.max_patches, self.config.vision.patch_dim), dtype = torch.half),
+            "image_position_ids": torch.from_numpy(position_ids).unsqueeze(0).to(torch.long),
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+            "causal": False,
+        }
+
+
+    def preprocess(
+        self,
+        image: Image.Image,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, tuple[int, int]]:
+        vpp = self.config.vision_pp
+        image = convert_to_rgb(image)
+        old_size = image.size
+        width, height = old_size
+        target_height, target_width = _get_aspect_ratio_preserving_size(
+            height = height,
+            width = width,
+            patch_size = vpp.patch_size,
+            max_patches = self.config.vision.max_patches,
+            pooling_kernel_size = vpp.pooling_kernel_size,
+        )
+
+        if (target_width, target_height) != old_size:
+            image = image.resize((target_width, target_height), resample = Image.Resampling(vpp.resample))
+
+        image_np = np.array(image).astype(np.float32)
+        image_np = image_np.transpose(2, 0, 1)
+
+        if vpp.do_rescale:
+            image_np *= vpp.rescale_factor
+
+        if vpp.do_normalize:
+            image_mean = np.asarray(vpp.image_mean, dtype = np.float32).reshape(-1, 1, 1)
+            image_std = np.asarray(vpp.image_std, dtype = np.float32).reshape(-1, 1, 1)
+            image_np = (image_np - image_mean) / image_std
+
+        patches = _convert_image_to_patches(image_np, vpp.patch_size)
+        num_soft_tokens = patches.shape[0] // (vpp.pooling_kernel_size ** 2)
+
+        patch_height = image_np.shape[-2] // vpp.patch_size
+        patch_width = image_np.shape[-1] // vpp.patch_size
+        grid_x, grid_y = np.meshgrid(np.arange(patch_width), np.arange(patch_height), indexing = "xy")
+        positions = np.stack([grid_x, grid_y], axis = -1).reshape(patches.shape[0], 2)
+
+        patches, positions = _pad_patches_and_positions(
+            patches,
+            positions,
+            self.config.vision.max_patches,
+        )
+
+        pixel_values = torch.from_numpy(patches).half().unsqueeze(0)
+        image_position_ids = torch.from_numpy(positions).to(torch.long).unsqueeze(0)
+        return pixel_values, image_position_ids, num_soft_tokens, (target_width, target_height)
+
+
+    def get_image_embeddings(
+        self,
+        tokenizer: Tokenizer,
+        image: Image.Image | list[Image.Image],
+        text_alias: str | None = None,
+    ):
+        if isinstance(image, list):
+            assert text_alias is None, "Cannot apply a single alias to a list of images"
+            return [self.get_image_embeddings(tokenizer, i) for i in image]
+
+        pixel_values, image_position_ids, _, prep_size = self.preprocess(image)
+        params = {
+            "causal": False,
+            "image_position_ids": image_position_ids,
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+        }
+        embedding_tensor = self.forward(
+            pixel_values,
+            params = params,
+        ).cpu()
+        pooler_mask = params.get("image_pooler_mask")
+        if pooler_mask is not None:
+            pooler_mask = pooler_mask.cpu()
+            embedding_tensor = embedding_tensor[0][pooler_mask[0]].unsqueeze(0)
+            num_soft_tokens = int(pooler_mask[0].sum().item())
+        else:
+            num_soft_tokens = embedding_tensor.shape[1]
+
+        boi_token_id = tokenizer.single_id("<|image>")
+        image_token_id = tokenizer.single_id("<|image|>")
+        eoi_token_id = tokenizer.single_id("<image|>")
+        token_string = torch.tensor(
+            [[boi_token_id] + [image_token_id] * num_soft_tokens + [eoi_token_id]],
+            dtype = torch.long,
+        )
+        token_string[:, 1:-1] = -1
+
+        mme = MMEmbedding(
+            embeddings = embedding_tensor[0],
+            text_alias = text_alias,
+            token_string = token_string,
+        )
+        mme.metadata.update({
+            "original_size": image.size,
+            "preprocessed_size": prep_size,
+            "model_architecture": self.config.architecture,
+        })
+        return mme

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -909,6 +909,7 @@ class Job:
             self.time_first_prefill = time.time()
 
         progress = 0
+        atomic_mm_prefill = bool(self.embeddings) and self.generator.model.caps.get("atomic_mm_prefill", False)
         for seq in self.sequences:
             if seq.prefill_complete:
                 continue
@@ -922,26 +923,45 @@ class Job:
 
             p0 = prefill_start // PAGE_SIZE
             p1 = (prefill_end + PAGE_SIZE - 1) // PAGE_SIZE
-            for local_idx in range(p0, p1):
-                if 0 <= cp_pos <= seq.kv_position:
-                    break
-                page = seq.allocated_pages[local_idx]
-                if page.kv_position == PAGE_SIZE:
-                    prefill_start = (local_idx + 1) * PAGE_SIZE
-                    seq.kv_position = prefill_start
-                    self.cached_pages += 1
-                    page.can_revert = False
-                else:
-                    break
+            if not atomic_mm_prefill:
+                for local_idx in range(p0, p1):
+                    if 0 <= cp_pos <= seq.kv_position:
+                        break
+                    page = seq.allocated_pages[local_idx]
+                    if page.kv_position == PAGE_SIZE:
+                        prefill_start = (local_idx + 1) * PAGE_SIZE
+                        seq.kv_position = prefill_start
+                        self.cached_pages += 1
+                        page.can_revert = False
+                    else:
+                        break
 
-            p0 = prefill_start // PAGE_SIZE
-            for local_idx in range(p0, p1):
-                if 0 <= cp_pos <= seq.kv_position:
-                    break
-                page = seq.allocated_pages[local_idx]
-                if page.kv_position == PAGE_SIZE:
-                    prefill_end = local_idx * PAGE_SIZE
-                    break
+                p0 = prefill_start // PAGE_SIZE
+                for local_idx in range(p0, p1):
+                    if 0 <= cp_pos <= seq.kv_position:
+                        break
+                    page = seq.allocated_pages[local_idx]
+                    if page.kv_position == PAGE_SIZE:
+                        prefill_end = local_idx * PAGE_SIZE
+                        break
+
+            if atomic_mm_prefill:
+                seq_limit = len(seq.sequence_ids) - 1
+                seq_tokens = seq.sequence_ids.torch().view(-1)
+                while True:
+                    extended = False
+                    for embedding in self.embeddings:
+                        mask = (seq_tokens >= embedding.first_index) & (seq_tokens < embedding.last_index)
+                        if not mask.any():
+                            continue
+                        mm_positions = torch.nonzero(mask, as_tuple = False).flatten()
+                        mm_start = int(mm_positions[0])
+                        mm_end = int(mm_positions[-1]) + 1
+                        if prefill_start < mm_end and mm_start < prefill_end < mm_end:
+                            prefill_end = min(seq_limit, mm_end)
+                            extended = True
+                    if not extended:
+                        break
 
             if prefill_end <= prefill_start:
                 continue
@@ -954,7 +974,7 @@ class Job:
             # since the recurrent checkpoint will always be on a page boundary
             p0 = prefill_start // PAGE_SIZE
             p1 = prefill_end // PAGE_SIZE
-            if prefill_start == p0 * PAGE_SIZE and self.generator.recurrent_cache is None:
+            if prefill_start == p0 * PAGE_SIZE and self.generator.recurrent_cache is None and not atomic_mm_prefill:
                 prev_hash = None if p0 == 0 else seq.allocated_pages[p0 - 1].phash
                 best_match = 0
                 best_match_page = None

--- a/exllamav3/modules/__init__.py
+++ b/exllamav3/modules/__init__.py
@@ -16,3 +16,16 @@ from .qwen3_vl_pos_embedding import Qwen3VLPosEmbedding
 from .glm4v_pos_embedding import Glm4VPosEmbedding
 from .deepstack import DeepstackEmbed
 from .value_embeddings import ValueEmbeddings
+from .gemma4 import (
+    Gemma4Attention,
+    Gemma4Experts,
+    Gemma4MoEFeedForward,
+    Gemma4MoETransformerBlock,
+    Gemma4Router,
+    Gemma4TransformerBlock,
+    Gemma4VisionAttention,
+    Gemma4VisionPatchEmbedder,
+    Gemma4VisionPooler,
+    Gemma4VisionProjector,
+    Gemma4VisionStandardize,
+)

--- a/exllamav3/modules/gemma4.py
+++ b/exllamav3/modules/gemma4.py
@@ -1,0 +1,1362 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from typing_extensions import override
+
+from ..model.config import Config
+from ..model.model_tp_alloc import TPAllocation
+from ..util.rope import RoPE
+from ..util.tensor import get_for_device
+from ..constants import PAGE_SIZE
+from ..util.tensor import to2
+from . import Attention, GatedMLP, Linear, Module, RMSNorm, TransformerBlock
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2:]
+    return torch.cat((-x2, x1), dim = -1)
+
+
+def _apply_rotary_pos_emb(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    cos = cos.unsqueeze(2)
+    sin = sin.unsqueeze(2)
+    return (x * cos) + (_rotate_half(x) * sin)
+
+
+def _apply_multidimensional_rope(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    ndim = 2
+    channels_per_dim = 2 * (x.shape[-1] // (2 * ndim))
+    if channels_per_dim <= 0:
+        raise ValueError(f"Invalid multidimensional RoPE channel count: {x.shape[-1]}")
+
+    split_sizes = [channels_per_dim] * ndim
+    remainder = x.shape[-1] - channels_per_dim * ndim
+    if remainder > 0:
+        split_sizes.append(remainder)
+
+    x_parts = torch.split(x, split_sizes, dim = -1)
+    cos_parts = torch.split(cos, channels_per_dim, dim = -1)
+    sin_parts = torch.split(sin, channels_per_dim, dim = -1)
+    out_parts = [
+        _apply_rotary_pos_emb(x_part, cos_part, sin_part)
+        for x_part, cos_part, sin_part in zip(x_parts[:ndim], cos_parts, sin_parts)
+    ]
+    if remainder > 0:
+        out_parts.append(x_parts[-1])
+    return torch.cat(out_parts, dim = -1)
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+class Gemma4VisionRoPE:
+
+    def __init__(
+        self,
+        device: torch.device,
+        head_dim: int,
+        rope_theta: float,
+    ):
+        spatial_dim = head_dim // 2
+        self.device = device
+        self.inv_freq = 1.0 / (
+            rope_theta ** (
+                torch.arange(0, spatial_dim, 2, dtype = torch.int64, device = device).float() / spatial_dim
+            )
+        )
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        all_cos = []
+        all_sin = []
+        for i in range(2):
+            dim_position_ids = position_ids[:, :, i][:, None, :].float()
+            freqs = (inv_freq_expanded @ dim_position_ids).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim = -1)
+            all_cos.append(emb.cos())
+            all_sin.append(emb.sin())
+        cos = torch.cat(all_cos, dim = -1).to(dtype = x.dtype, device = x.device)
+        sin = torch.cat(all_sin, dim = -1).to(dtype = x.dtype, device = x.device)
+        return cos, sin
+
+
+class Gemma4Attention(Attention):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        layer_idx: int,
+        hidden_size: int,
+        head_dim: int,
+        num_q_heads: int,
+        num_kv_heads: int,
+        use_k_as_v: bool,
+        v_norm: RMSNorm | None,
+        **kwargs,
+    ):
+        key_v = kwargs.get("key_v")
+        super().__init__(
+            config=config,
+            key=key,
+            layer_idx=layer_idx,
+            hidden_size=hidden_size,
+            head_dim=head_dim,
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            key_v=kwargs["key_k"] if use_k_as_v else key_v,
+            **{k: v for k, v in kwargs.items() if k != "key_v"},
+        )
+
+        self.use_k_as_v = use_k_as_v
+        if use_k_as_v:
+            self.modules.remove(self.v_proj)
+            self.v_proj = None
+
+        self.v_norm = v_norm
+        self.register_submodule(self.v_norm)
+
+
+    def _get_vision_group_ids(self, params: dict) -> torch.Tensor | None:
+        group_ids = get_for_device(params, "vision_group_ids", self.device, None)
+        if group_ids is None:
+            return None
+        if group_ids.numel() == 0 or not (group_ids >= 0).any():
+            return None
+        return group_ids
+
+
+    def _build_mm_mask(
+        self,
+        bsz: int,
+        seqlen: int,
+        total_lens: torch.Tensor,
+        cache_seqlens: torch.Tensor | None,
+        vision_group_ids: torch.Tensor | None,
+        q_dtype: torch.dtype,
+        device: torch.device,
+        causal: bool,
+    ) -> torch.Tensor:
+        max_total = int(total_lens.max())
+        mask = torch.full(
+            (bsz, 1, seqlen, max_total),
+            torch.finfo(q_dtype).min,
+            dtype = q_dtype,
+            device = device,
+        )
+        for b in range(bsz):
+            total = int(total_lens[b])
+            if total == 0:
+                continue
+            past = int(cache_seqlens[b]) if cache_seqlens is not None else 0
+            full_groups = None
+            if vision_group_ids is not None:
+                full_groups = torch.full((total,), -1, dtype = torch.int32, device = device)
+                full_groups[past : past + seqlen] = vision_group_ids[b]
+            for qi in range(seqlen):
+                q_abs = past + qi
+                if not causal:
+                    start = 0 if self.sliding_window < 0 else max(0, q_abs - self.sliding_window)
+                    end = total if self.sliding_window < 0 else min(total, q_abs + self.sliding_window + 1)
+                    mask[b, 0, qi, start:end] = 0
+                else:
+                    end = min(total, q_abs + 1)
+                    start = 0 if self.sliding_window < 0 else max(0, q_abs - self.sliding_window)
+                    if end > start:
+                        mask[b, 0, qi, start:end] = 0
+                if full_groups is not None:
+                    q_group = int(full_groups[q_abs])
+                    if q_group >= 0:
+                        same_group = full_groups[:total] == q_group
+                        mask[b, 0, qi, same_group] = 0
+        return mask
+
+
+    def _mm_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        scale = self.sm_scale if self.sm_scale is not None else self.head_dim ** -0.5
+        if self.logit_softcapping:
+            if self.gqa and k.shape[1] != q.shape[1]:
+                repeat = q.shape[1] // k.shape[1]
+                k = k.repeat_interleave(repeat, dim = 1)
+                v = v.repeat_interleave(repeat, dim = 1)
+            scores = torch.matmul(q.float(), k.transpose(-1, -2).float()) * scale
+            scores = torch.tanh(scores / self.logit_softcapping) * self.logit_softcapping
+            scores = scores + mask.float()
+            probs = torch.softmax(scores, dim = -1, dtype = torch.float32)
+            return torch.matmul(probs, v.float()).to(q.dtype)
+
+        return F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask = mask,
+            is_causal = False,
+            enable_gqa = self.gqa,
+            scale = scale,
+        )
+
+
+    def optimizer_targets(self):
+        q = self.q_proj.optimizer_targets()
+        k = self.k_proj.optimizer_targets()
+        o = self.o_proj.optimizer_targets()
+        return [[q, k, o]]
+
+
+    def load_local(self, device, **kwargs):
+
+        if self.num_kv_heads == 0:
+            return
+
+        for cl in self.cache_layers:
+            cl.alloc(device)
+
+        if self.rope_settings:
+            self.rope = RoPE(
+                device,
+                self.rope_settings,
+            )
+
+        if self.q_norm and isinstance(self.q_norm, RMSNorm) and not self.q_norm.span_heads:
+            self.q_norm_tensor = self.q_norm.weight.data
+            self.k_norm_tensor = self.k_norm.weight.data
+
+
+    def project_qkv(self, x: torch.Tensor, params: dict) -> tuple:
+        bsz, q_len, _ = x.shape
+        q = self.q_proj.forward(x, params)
+
+        if self.interleaved_gate:
+            q, g = torch.chunk(q.view(bsz, q_len, -1, self.head_dim * 2), 2, dim = -1)
+            g = g.reshape(bsz, q_len, -1)
+        elif self.g_proj:
+            g = self.g_proj.forward(x, params)
+        else:
+            g = None
+
+        k = self.k_proj.forward(x, params)
+        v = k if self.v_proj is None else self.v_proj.forward(x, params)
+
+        if self.v_norm is not None:
+            v = v.view(bsz, q_len, self.num_kv_heads, self.head_dim)
+            v = self.v_norm.forward(v, params, out_dtype = torch.half)
+            v = v.view(bsz, q_len, self.num_kv_heads * self.head_dim)
+
+        return q, k, v, g
+
+
+    def _write_cache_pages(
+        self,
+        cache_tensor: torch.Tensor,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        values: torch.Tensor,
+    ) -> None:
+        bsz, seqlen, _, _ = values.shape
+        for b in range(bsz):
+            start = int(cache_seqlens[b])
+            for t in range(seqlen):
+                pos = start + t
+                page = int(block_table[b, pos // PAGE_SIZE])
+                page_pos = pos % PAGE_SIZE
+                cache_tensor[page, page_pos].copy_(values[b, t], non_blocking = True)
+
+
+    def _gather_cache_pages(
+        self,
+        cache_tensor: torch.Tensor,
+        block_table: torch.Tensor,
+        total_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        bsz = block_table.shape[0]
+        max_total = int(total_lens.max())
+        gathered = torch.zeros(
+            (bsz, max_total, self.num_kv_heads, self.head_dim),
+            dtype = cache_tensor.dtype,
+            device = cache_tensor.device,
+        )
+        for b in range(bsz):
+            total = int(total_lens[b])
+            if total == 0:
+                continue
+            num_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+            pages = block_table[b, :num_pages].long()
+            flat = cache_tensor.index_select(0, pages).reshape(-1, self.num_kv_heads, self.head_dim)
+            gathered[b, :total].copy_(flat[:total], non_blocking = True)
+        return gathered
+
+
+    def decode_flash_attn_fallback(
+        self,
+        x: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        params: dict,
+    ):
+        cache = params.get("cache")
+        block_table = get_for_device(params, "block_table", self.device)
+        cache_seqlens = get_for_device(params, "cache_seqlens", self.device)
+        position = params.get("position", 0)
+        positions = get_for_device(params, "positions", self.device, None)
+        position_ids = get_for_device(params, "position_ids", self.device, None)
+        inv_freq = get_for_device(params, "inv_freq", self.device, None)
+        causal = params.get("causal", True)
+        vision_group_ids = self._get_vision_group_ids(params)
+        if self.sliding_window < 0:
+            vision_group_ids = None
+
+        q, k, v, g = self.project_qkv(x, params)
+        q = q.view(bsz, seqlen, self.num_q_heads, self.head_dim)
+        k = k.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+
+        if self.q_norm:
+            if self.tp_span_heads_norm:
+                q, k = self.apply_qk_norms_tp(q, k, params)
+            elif not self.rope or self.q_norm_tensor is None:
+                q = self.q_norm.forward(q, params, out_dtype = torch.half)
+                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+
+        if self.rope:
+            q, k = self.rope.apply(
+                q, k,
+                position,
+                positions,
+                position_ids,
+                True,
+                self.q_norm_tensor if not self.tp_span_heads_norm else None,
+                self.k_norm_tensor if not self.tp_span_heads_norm else None,
+                self.norm_eps,
+                self.norm_constant_bias,
+                inv_freq,
+                self.post_rope_norm
+            )
+
+        cache_k, cache_v = cache.get_layer(self.layer_idx, cache_seqlens, block_table)
+        self._write_cache_pages(cache_k, block_table, cache_seqlens, k)
+        self._write_cache_pages(cache_v, block_table, cache_seqlens, v)
+
+        total_lens = cache_seqlens + seqlen
+        all_k = self._gather_cache_pages(cache_k, block_table, total_lens).transpose(1, 2)
+        all_v = self._gather_cache_pages(cache_v, block_table, total_lens).transpose(1, 2)
+        q = q.transpose(1, 2)
+        mask = self._build_mm_mask(
+            bsz,
+            seqlen,
+            total_lens,
+            cache_seqlens,
+            vision_group_ids,
+            q.dtype,
+            q.device,
+            causal,
+        )
+        o = self._mm_attention(q, all_k, all_v, mask)
+
+        cache_layer = cache.layers[self.layer_idx]
+        if hasattr(cache_layer, "qk"):
+            cache.update_layer(self.layer_idx, cache_seqlens, block_table, k, v, seqlen)
+
+        if self.headwise_gate:
+            o *= g.sigmoid().unsqueeze(-1)
+        o = o.transpose(1, 2).contiguous().reshape((bsz, seqlen, self.num_q_heads * self.head_dim))
+        if self.interleaved_gate:
+            o *= g.sigmoid()
+
+        return self.project_o(o, bsz, seqlen, params)
+
+
+    def decode_sdpa_nc(
+        self,
+        x: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        params: dict,
+    ):
+        causal = params.get("causal", True)
+        position = params.get("position", 0)
+        positions = get_for_device(params, "positions", self.device, None)
+        position_ids = get_for_device(params, "position_ids", self.device, None)
+        inv_freq = get_for_device(params, "inv_freq", self.device, None)
+        vision_group_ids = self._get_vision_group_ids(params)
+        if self.sliding_window < 0:
+            vision_group_ids = None
+
+        q, k, v, g = self.project_qkv(x, params)
+        q = q.view(bsz, seqlen, self.num_q_heads, self.head_dim)
+        k = k.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+
+        if self.q_norm:
+            if self.tp_span_heads_norm:
+                q, k = self.apply_qk_norms_tp(q, k, params)
+            elif not self.rope or self.q_norm_tensor is None:
+                q = self.q_norm.forward(q, params, out_dtype = torch.half)
+                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+
+        if self.rope:
+            q, k = self.rope.apply(
+                q, k,
+                position,
+                positions,
+                position_ids,
+                True,
+                self.q_norm_tensor if not self.tp_span_heads_norm else None,
+                self.k_norm_tensor if not self.tp_span_heads_norm else None,
+                self.norm_eps,
+                self.norm_constant_bias,
+                inv_freq,
+                self.post_rope_norm
+            )
+
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        if vision_group_ids is not None:
+            total_lens = torch.full((bsz,), seqlen, dtype = torch.int32, device = q.device)
+            mask = self._build_mm_mask(
+                bsz,
+                seqlen,
+                total_lens,
+                None,
+                vision_group_ids,
+                q.dtype,
+                q.device,
+                causal,
+            )
+            o = self._mm_attention(q, k, v, mask)
+        else:
+            o = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                is_causal = causal,
+                enable_gqa = self.gqa,
+                scale = self.sm_scale,
+            )
+
+        if self.headwise_gate:
+            o *= g.sigmoid().unsqueeze(-1)
+        o = o.transpose(1, 2).contiguous().reshape((bsz, seqlen, self.num_q_heads * self.head_dim))
+        if self.interleaved_gate:
+            o *= g.sigmoid()
+
+        return self.project_o(o, bsz, seqlen, params)
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        if self.num_kv_heads == 0:
+            x = torch.zeros_like(x, dtype = self.out_dtype)
+            return to2(x, out_dtype, self.out_dtype)
+
+        bsz, seqlen, _ = x.shape
+        attn_mode = params.get("attn_mode", "flash_attn_nc")
+        vision_group_ids = self._get_vision_group_ids(params)
+        if self.sliding_window < 0:
+            vision_group_ids = None
+
+        if self.head_dim > 256 or vision_group_ids is not None:
+            match attn_mode:
+                case "flash_attn_nc":
+                    x = self.decode_sdpa_nc(x, bsz, seqlen, params)
+                case "flash_attn":
+                    x = self.decode_flash_attn_fallback(x, bsz, seqlen, params)
+                case "sdpa_nc":
+                    x = self.decode_sdpa_nc(x, bsz, seqlen, params)
+                case _:
+                    raise ValueError(f"Unknown attn_mode: {attn_mode}")
+            return to2(x, out_dtype, self.out_dtype)
+
+        return super().forward(x, params, out_dtype)
+
+
+    def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        storage = 0
+        storage += self.q_proj.storage_size()
+        storage += self.k_proj.storage_size()
+        storage += self.o_proj.storage_size()
+        for cl in self.cache_layers:
+            storage += cl.storage_size()
+        overhead_d = 0
+        overhead_d += self.hidden_size * (self.out_dtype or torch.half).itemsize
+        overhead_s = 0
+        for cl in self.cache_layers:
+            overhead_s += cl.overhead_size()
+        overhead_s += 2 * self.num_q_heads * self.head_dim * torch.half.itemsize
+        overhead_s += 2 * self.num_kv_heads * self.head_dim * torch.half.itemsize
+        recons = max(
+            self.q_proj.recons_size(),
+            self.k_proj.recons_size(),
+            self.o_proj.recons_size(),
+        )
+        channel_width = 1
+        channels_to_split = self.num_kv_heads
+        while channel_width * self.head_dim < 128:
+            assert channels_to_split % 2 == 0, \
+                "Model's K/V heads cannot divide into 128-channel tensors"
+            channel_width *= 2
+            channels_to_split //= 2
+        assert (channel_width * self.head_dim) % 128 == 0, \
+            "Model's K/V heads cannot divide into 128-channel tensors"
+        return [
+            TPAllocation(
+                key = self.key,
+                channel_width = channel_width,
+                channel_unit = "heads",
+                storage_per_device = 0,
+                storage_to_split = storage,
+                overhead_per_device = overhead_d,
+                overhead_to_split = overhead_s,
+                recons_temp = recons,
+                channels_to_split = channels_to_split,
+                limit_key = "attn"
+            )
+        ]
+
+
+class Gemma4TransformerBlock(TransformerBlock):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        **kwargs,
+    ):
+        super().__init__(config=config, key=key, **kwargs)
+        self.layer_scalar_key = f"{key}.layer_scalar"
+        self.layer_scalar = None
+        self.layer_scalar_numel = 1
+
+
+    def optimizer_targets(self):
+        return super().optimizer_targets()
+
+
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        layer_scalar = self.config.stc.get_tensor(
+            self.layer_scalar_key,
+            device,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.layer_scalar = nn.Parameter(layer_scalar, requires_grad = False)
+        self.layer_scalar_numel = layer_scalar.numel()
+
+
+    def unload(self):
+        super().unload()
+        self.layer_scalar = None
+
+
+    def get_tensors(self):
+        if self.layer_scalar is None:
+            return {}
+        return {
+            self.layer_scalar_key: self.layer_scalar.data.contiguous(),
+        }
+
+
+    def weights_numel(self):
+        return super().weights_numel() + self.layer_scalar_numel
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        x = super().forward(x, params, out_dtype = None)
+        if self.layer_scalar is not None:
+            x = x * self.layer_scalar.to(dtype = x.dtype)
+        return to2(x, out_dtype, self.out_dtype)
+
+
+class Gemma4Router(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        hidden_size: int,
+        num_experts: int,
+        num_experts_per_tok: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.scalar_root_size = hidden_size ** -0.5
+        self.scale_key = f"{key}.scale"
+        self.per_expert_scale_key = f"{key}.per_expert_scale"
+        self.scale = None
+        self.per_expert_scale = None
+        self.extra_numel = 0
+
+        self.norm = RMSNorm(
+            config = config,
+            key = f"{key}.norm",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.float,
+            unweighted = True,
+        )
+        self.proj = Linear(
+            config = config,
+            key = f"{key}.proj",
+            in_features = hidden_size,
+            out_features = num_experts,
+            qmap = None,
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+        self.register_submodule(self.norm)
+        self.register_submodule(self.proj)
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.scale = self.config.stc.get_tensor(
+            self.scale_key,
+            device,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.per_expert_scale = self.config.stc.get_tensor(
+            self.per_expert_scale_key,
+            device,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.extra_numel = self.scale.numel() + self.per_expert_scale.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.scale = None
+        self.per_expert_scale = None
+        self.extra_numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.scale is None or self.per_expert_scale is None:
+            return {}
+        return {
+            self.scale_key: self.scale.data.contiguous(),
+            self.per_expert_scale_key: self.per_expert_scale.data.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return super().weights_numel() + self.extra_numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        y = self.norm.forward_torch(x, params, out_dtype = torch.float)
+        y = y * self.scale.to(dtype = y.dtype)
+        y *= self.scalar_root_size
+
+        logits = self.proj.forward(y.half(), params, out_dtype = torch.float).float()
+        probs = torch.softmax(logits, dim = -1)
+
+        if params.get("activate_all_experts"):
+            selected = (
+                torch.arange(self.num_experts, dtype = torch.long, device = x.device)
+                .repeat((x.shape[0], 1))
+            )
+            weights = probs * self.per_expert_scale.to(dtype = probs.dtype).unsqueeze(0)
+            return selected, weights
+
+        top_k_weights, top_k_index = torch.topk(
+            probs,
+            k = self.num_experts_per_tok,
+            dim = -1,
+        )
+        top_k_weights /= top_k_weights.sum(dim = -1, keepdim = True)
+        top_k_weights *= self.per_expert_scale[top_k_index].to(dtype = top_k_weights.dtype)
+        return top_k_index, top_k_weights
+
+
+class Gemma4Experts(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+        qmap: str,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_experts = num_experts
+
+        self.gates = []
+        self.ups = []
+        self.downs = []
+
+        fkey_gate_up = f"{key}.experts.gate_up_proj"
+        fkey_down = f"{key}.experts.down_proj"
+
+        for idx in range(num_experts):
+            gate = Linear(
+                config = config,
+                key = f"{key}.experts.{idx}.gate_proj",
+                fkey = fkey_gate_up,
+                fidx = idx,
+                frange = (0, intermediate_size),
+                frange_dim = 1,
+                in_features = hidden_size,
+                out_features = intermediate_size,
+                qmap = qmap + ".input",
+                out_dtype = torch.half,
+                transposed_load = True,
+                transpose_fused_weights = True,
+                ftranspose_after_load = False,
+                qgroup = key + ".experts.gud",
+            )
+            up = Linear(
+                config = config,
+                key = f"{key}.experts.{idx}.up_proj",
+                fkey = fkey_gate_up,
+                fidx = idx,
+                frange = (intermediate_size, intermediate_size * 2),
+                frange_dim = 1,
+                in_features = hidden_size,
+                out_features = intermediate_size,
+                qmap = qmap + ".input",
+                out_dtype = torch.half,
+                transposed_load = True,
+                transpose_fused_weights = True,
+                ftranspose_after_load = False,
+                qgroup = key + ".experts.gud",
+            )
+            down = Linear(
+                config = config,
+                key = f"{key}.experts.{idx}.down_proj",
+                fkey = fkey_down,
+                fidx = idx,
+                in_features = intermediate_size,
+                out_features = hidden_size,
+                qmap = qmap + f".{idx}.down",
+                out_dtype = torch.float,
+                allow_input_padding = True,
+                transposed_load = True,
+                transpose_fused_weights = True,
+                ftranspose_after_load = False,
+                qgroup = key + ".experts.gud",
+            )
+
+            self.gates.append(gate)
+            self.ups.append(up)
+            self.downs.append(down)
+            self.register_submodule(gate)
+            self.register_submodule(up)
+            self.register_submodule(down)
+
+
+    @override
+    def optimizer_targets(self):
+        g, u, d = [], [], []
+        for m in self.gates:
+            g += m.optimizer_targets()
+        for m in self.ups:
+            u += m.optimizer_targets()
+        for m in self.downs:
+            d += m.optimizer_targets()
+        return [[g + u, d]]
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        selected_experts: torch.Tensor,
+        routing_weights: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        y = x.view(-1, self.hidden_size)
+        final_hidden_states = torch.zeros_like(y, dtype = torch.float)
+
+        num_tokens, top_k = selected_experts.shape
+        flat_experts = selected_experts.reshape(-1)
+        flat_weights = routing_weights.reshape(-1).to(dtype = torch.float)
+        flat_tokens = torch.arange(num_tokens, device = y.device).repeat_interleave(top_k)
+
+        order = flat_experts.argsort()
+        expert_sorted = flat_experts[order]
+        token_sorted = flat_tokens[order]
+        weight_sorted = flat_weights[order]
+
+        expert_count = torch.bincount(expert_sorted, minlength = self.num_experts)
+        expert_ptr = torch.empty(self.num_experts + 1, dtype = torch.long, device = y.device)
+        expert_ptr[0] = 0
+        expert_ptr[1:] = expert_count.cumsum(0)
+
+        for expert_idx in range(self.num_experts):
+            start = int(expert_ptr[expert_idx])
+            end = int(expert_ptr[expert_idx + 1])
+            if start == end:
+                continue
+
+            top_x = token_sorted[start:end]
+            current_state = y.index_select(0, top_x)
+            gate = self.gates[expert_idx].forward(current_state, params)
+            up = self.ups[expert_idx].forward(current_state, params)
+            current_hidden_states = F.gelu(gate, approximate = "tanh") * up
+            current_hidden_states = self.downs[expert_idx].forward(current_hidden_states, params)
+            current_hidden_states *= weight_sorted[start:end].unsqueeze(1).to(dtype = current_hidden_states.dtype)
+            final_hidden_states.index_add_(0, top_x, current_hidden_states)
+
+        return to2(final_hidden_states.view(x.shape), out_dtype, torch.float)
+
+
+class Gemma4MoEFeedForward(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        hidden_size: int,
+        intermediate_size: int,
+        moe_intermediate_size: int,
+        num_experts: int,
+        num_experts_per_tok: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+
+        self.dense_mlp = GatedMLP(
+            config = config,
+            key = f"{key}.mlp",
+            hidden_size = hidden_size,
+            intermediate_size = intermediate_size,
+            key_up = "up_proj",
+            key_gate = "gate_proj",
+            key_down = "down_proj",
+            qmap = "block.mlp",
+            activation_fn = "gelu",
+            interm_dtype = torch.half,
+            out_dtype = torch.float,
+        )
+        self.dense_post_norm = RMSNorm(
+            config = config,
+            key = f"{key}.post_feedforward_layernorm_1",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.float,
+        )
+        self.routed_pre_norm = RMSNorm(
+            config = config,
+            key = f"{key}.pre_feedforward_layernorm_2",
+            rms_norm_eps = rms_norm_eps,
+        )
+        self.routed_post_norm = RMSNorm(
+            config = config,
+            key = f"{key}.post_feedforward_layernorm_2",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.float,
+        )
+        self.router = Gemma4Router(
+            config = config,
+            key = f"{key}.router",
+            hidden_size = hidden_size,
+            num_experts = num_experts,
+            num_experts_per_tok = num_experts_per_tok,
+            rms_norm_eps = rms_norm_eps,
+        )
+        self.experts = Gemma4Experts(
+            config = config,
+            key = key,
+            hidden_size = hidden_size,
+            intermediate_size = moe_intermediate_size,
+            num_experts = num_experts,
+            qmap = "block.mlp",
+        )
+
+        self.register_submodule(self.dense_mlp)
+        self.register_submodule(self.dense_post_norm)
+        self.register_submodule(self.routed_pre_norm)
+        self.register_submodule(self.routed_post_norm)
+        self.register_submodule(self.router)
+        self.register_submodule(self.experts)
+
+
+    @override
+    def optimizer_targets(self):
+        return [self.dense_mlp.optimizer_targets(), self.experts.optimizer_targets()]
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        dense = self.dense_mlp.forward(x, params)
+        dense = self.dense_post_norm.forward(dense, params)
+
+        selected_experts, routing_weights = self.router.forward(
+            residual.view(-1, self.hidden_size),
+            params,
+        )
+        routed_input = self.routed_pre_norm.forward(residual, params, out_dtype = torch.half)
+        routed = self.experts.forward(routed_input, selected_experts, routing_weights, params)
+        routed = self.routed_post_norm.forward(routed, params)
+
+        y = dense + routed
+        return to2(y, out_dtype, torch.float)
+
+
+class Gemma4MoETransformerBlock(Gemma4TransformerBlock):
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+
+        if self.attn:
+            y = self.attn_norm.forward(x, params, out_dtype = torch.half) if self.attn_norm else x.half()
+            y = self.attn.forward(y, params)
+            if params.get("prefill"):
+                return x
+            if self.attn_post_norm:
+                y = self.attn_post_norm.forward(y, params)
+            x = x + y
+
+        if self.mlp:
+            residual = x
+            y = self.mlp_norm.forward(x, params, out_dtype = torch.half) if self.mlp_norm else x.half()
+            y = self.mlp.forward(y, residual, params)
+            if self.mlp_post_norm:
+                y = self.mlp_post_norm.forward(y, params)
+            x = residual + y
+
+        if self.layer_scalar is not None:
+            x = x * self.layer_scalar.to(dtype = x.dtype)
+
+        return to2(x, out_dtype, self.out_dtype)
+
+
+class Gemma4VisionPatchEmbedder(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        hidden_size: int,
+        patch_dim: int,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+        self.position_embedding_size = config.vision.position_embedding_size
+        self.position_embedding_key = f"{key}.position_embedding_table"
+        self.position_embedding_table = None
+        self.position_embedding_numel = 0
+
+        self.input_proj = Linear(
+            config = config,
+            key = f"{key}.input_proj",
+            in_features = patch_dim,
+            out_features = hidden_size,
+            qmap = None,
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+        self.register_submodule(self.input_proj)
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.position_embedding_table = self.config.stc.get_tensor(
+            self.position_embedding_key,
+            device,
+            float2half = True,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.position_embedding_numel = self.position_embedding_table.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.position_embedding_table = None
+        self.position_embedding_numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.position_embedding_table is None:
+            return {}
+        return {
+            self.position_embedding_key: self.position_embedding_table.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return super().weights_numel() + self.position_embedding_numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        position_ids = get_for_device(params, "image_position_ids", self.device)
+        padding_positions = (position_ids == -1).all(dim = -1)
+        clamped_positions = position_ids.clamp(min = 0)
+        x = 2.0 * (x - 0.5)
+        hidden_states = self.input_proj.forward(x, params, out_dtype = torch.half)
+
+        pos_x = clamped_positions[..., 0].reshape(-1)
+        pos_y = clamped_positions[..., 1].reshape(-1)
+        table = self.position_embedding_table
+        pos_emb = table[0].index_select(0, pos_x) + table[1].index_select(0, pos_y)
+        pos_emb = pos_emb.view(position_ids.shape[0], position_ids.shape[1], self.hidden_size).to(hidden_states.dtype)
+        pos_emb = torch.where(padding_positions.unsqueeze(-1), torch.zeros_like(pos_emb), pos_emb)
+        hidden_states = hidden_states + pos_emb
+        return to2(hidden_states, out_dtype, torch.half)
+
+
+class Gemma4VisionAttention(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        layer_idx: int,
+        hidden_size: int,
+        head_dim: int,
+        num_q_heads: int,
+        num_kv_heads: int,
+        rope_theta: float,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.layer_idx = layer_idx
+        self.hidden_size = hidden_size
+        self.head_dim = head_dim
+        self.num_q_heads = num_q_heads
+        self.num_kv_heads = num_kv_heads
+        self.gqa = (num_q_heads != num_kv_heads)
+        self.rope_theta = rope_theta
+        self.rope = None
+
+        self.q_proj = Linear(config, f"{key}.q_proj.linear", hidden_size, num_q_heads * head_dim, qmap = None)
+        self.k_proj = Linear(config, f"{key}.k_proj.linear", hidden_size, num_kv_heads * head_dim, qmap = None)
+        self.v_proj = Linear(config, f"{key}.v_proj.linear", hidden_size, num_kv_heads * head_dim, qmap = None)
+        self.o_proj = Linear(config, f"{key}.o_proj.linear", num_q_heads * head_dim, hidden_size, qmap = None)
+        self.q_norm = RMSNorm(config, f"{key}.q_norm", rms_norm_eps = rms_norm_eps)
+        self.k_norm = RMSNorm(config, f"{key}.k_norm", rms_norm_eps = rms_norm_eps)
+        self.v_norm = RMSNorm(config, f"{key}.v_norm", rms_norm_eps = rms_norm_eps, unweighted = True)
+
+        self.register_submodule(self.q_proj)
+        self.register_submodule(self.k_proj)
+        self.register_submodule(self.v_proj)
+        self.register_submodule(self.o_proj)
+        self.register_submodule(self.q_norm)
+        self.register_submodule(self.k_norm)
+        self.register_submodule(self.v_norm)
+
+
+    @override
+    def optimizer_targets(self):
+        q = self.q_proj.optimizer_targets()
+        k = self.k_proj.optimizer_targets()
+        v = self.v_proj.optimizer_targets()
+        o = self.o_proj.optimizer_targets()
+        return [[q, k + v, o]]
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.rope = Gemma4VisionRoPE(device, self.head_dim, self.rope_theta)
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.rope = None
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        position_ids = get_for_device(params, "image_position_ids", self.device)
+        padding_positions = (position_ids == -1).all(dim = -1)
+        bsz, seqlen, _ = x.shape
+
+        q = self.q_proj.forward(x, params).view(bsz, seqlen, self.num_q_heads, self.head_dim)
+        k = self.k_proj.forward(x, params).view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.v_proj.forward(x, params).view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+
+        q = self.q_norm.forward(q, params, out_dtype = torch.half)
+        k = self.k_norm.forward(k, params, out_dtype = torch.half)
+        v = self.v_norm.forward(v, params, out_dtype = torch.half)
+
+        cos, sin = self.rope.forward(q, position_ids)
+        q = _apply_multidimensional_rope(q, cos, sin).transpose(1, 2)
+        k = _apply_multidimensional_rope(k, cos, sin).transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        if self.gqa:
+            repeat = self.num_q_heads // self.num_kv_heads
+            k = _repeat_kv(k, repeat)
+            v = _repeat_kv(v, repeat)
+
+        attn_mask = torch.zeros((bsz, 1, 1, seqlen), dtype = q.dtype, device = q.device)
+        attn_mask.masked_fill_(padding_positions.unsqueeze(1).unsqueeze(1), torch.finfo(q.dtype).min)
+
+        attn_weights = torch.matmul(q, k.transpose(2, 3)) * 1.0
+        attn_weights = attn_weights + attn_mask
+        attn_weights = torch.softmax(attn_weights, dim = -1, dtype = torch.float32).to(q.dtype)
+        y = torch.matmul(attn_weights, v)
+        y = y.transpose(1, 2).contiguous().view(bsz, seqlen, self.num_q_heads * self.head_dim)
+        y = self.o_proj.forward(y, params)
+        return to2(y, out_dtype, torch.half)
+
+
+class Gemma4VisionPooler(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        hidden_size: int,
+    ):
+        super().__init__(config, key, None)
+        self.root_hidden_size = hidden_size ** 0.5
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        position_ids = get_for_device(params, "image_position_ids", self.device)
+        output_length = int(params["image_output_length"])
+        if output_length > x.shape[1]:
+            raise ValueError(f"Cannot pool {x.shape[1]} patches to {output_length} soft tokens.")
+
+        padding_positions = (position_ids == -1).all(dim = -1)
+        x = x.masked_fill(padding_positions.unsqueeze(-1), 0.0)
+
+        if x.shape[1] != output_length:
+            input_seq_len = x.shape[1]
+            k = int((input_seq_len // output_length) ** 0.5)
+            k_squared = k ** 2
+            if k_squared * output_length != input_seq_len:
+                raise ValueError(f"Cannot pool {x.shape} to {output_length}: {k=}^2 mismatch")
+            clamped_positions = position_ids.clamp(min = 0)
+            max_x = clamped_positions[..., 0].max(dim = -1, keepdim = True)[0] + 1
+            kernel_idxs = torch.div(clamped_positions, k, rounding_mode = "floor")
+            kernel_idxs = kernel_idxs[..., 0] + (max_x // k) * kernel_idxs[..., 1]
+            weights = F.one_hot(kernel_idxs.long(), output_length).float() / k_squared
+            x = weights.transpose(1, 2) @ x.float()
+            params["image_pooler_mask"] = torch.logical_not((weights == 0).all(dim = 1))
+        else:
+            x = x.float()
+            params["image_pooler_mask"] = ~padding_positions
+
+        x = x * self.root_hidden_size
+        return to2(x, out_dtype, torch.float)
+
+
+class Gemma4VisionStandardize(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+    ):
+        super().__init__(config, key, None)
+        self.bias_key = f"{key}.std_bias"
+        self.scale_key = f"{key}.std_scale"
+        self.std_bias = None
+        self.std_scale = None
+        self.extra_numel = 0
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.std_bias = self.config.stc.get_tensor(self.bias_key, device, float2half = True, allow_bf16 = True, no_defer = True)
+        self.std_scale = self.config.stc.get_tensor(self.scale_key, device, float2half = True, allow_bf16 = True, no_defer = True)
+        self.extra_numel = self.std_bias.numel() + self.std_scale.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.std_bias = None
+        self.std_scale = None
+        self.extra_numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.std_bias is None or self.std_scale is None:
+            return {}
+        return {
+            self.bias_key: self.std_bias.contiguous(),
+            self.scale_key: self.std_scale.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return self.extra_numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        y = (x.float() - self.std_bias.float()) * self.std_scale.float()
+        return to2(y, out_dtype, torch.float)
+
+
+class Gemma4VisionProjector(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        in_features: int,
+        out_features: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.in_features = in_features
+        self.out_features = out_features
+        self.rms_norm_eps = rms_norm_eps
+        self.weight = None
+        self._numel = 0
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.weight = self.config.stc.get_tensor(
+            f"{self.key}.weight",
+            device,
+            transpose = True,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self._numel = self.weight.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.weight = None
+        self._numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.weight is None:
+            return {}
+        return {
+            f"{self.key}.weight": self.weight.T.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return self._numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        y = torch.matmul(x.float(), self.weight.float())
+        y = y * torch.rsqrt(y.pow(2).mean(dim = -1, keepdim = True) + self.rms_norm_eps)
+        return to2(y, out_dtype, torch.float)

--- a/exllamav3/modules/linear.py
+++ b/exllamav3/modules/linear.py
@@ -24,6 +24,7 @@ class Linear(Module):
         qbits_key: str = "bits",
         fkey : str | None = None,
         frange: tuple[int, int] | None = None,
+        frange_dim: int = 0,
         fidx: int | None = None,
         caps: dict = None,
         softcap: float = 0.0,
@@ -37,6 +38,7 @@ class Linear(Module):
         post_scale: float = 1.0,
         transposed_load: bool = True,
         transpose_fused_weights: bool = True,
+        ftranspose_after_load: bool = True,
         select_hq_bits: int = 0,
         qgroup: str = None
     ):
@@ -55,6 +57,7 @@ class Linear(Module):
         self.qbits_key = qbits_key
         self.fkey = fkey
         self.frange = frange
+        self.frange_dim = frange_dim
         self.fidx = fidx
         self.quant_type = None
         self.softcap = softcap
@@ -63,6 +66,7 @@ class Linear(Module):
         self.post_scale = post_scale
         self.transposed_load = transposed_load
         self.transpose_fused_weights = transpose_fused_weights
+        self.ftranspose_after_load = ftranspose_after_load
         self.select_hq_bits = select_hq_bits
         self.qgroup = qgroup or key
 
@@ -176,12 +180,19 @@ class Linear(Module):
                 fidx = self.fidx
             )
             if self.frange is not None:
-                weight = weight[self.frange[0] : self.frange[1]].contiguous()
+                if self.frange_dim == 0:
+                    weight = weight[self.frange[0] : self.frange[1]].contiguous()
+                elif self.frange_dim == 1:
+                    weight = weight[:, self.frange[0] : self.frange[1]].contiguous()
+                else:
+                    raise ValueError(f"Unsupported frange_dim={self.frange_dim} for {self.key}")
             weight = self.pad_out(weight)
+            if self.ftranspose_after_load:
+                weight = weight.T.contiguous()
             self.inner = LinearFP16(
                 self.in_features,
                 self.out_features,
-                weight.T.contiguous(),
+                weight,
                 None,
                 self.full_in_features,
                 self.full_out_features,
@@ -462,6 +473,11 @@ class Linear(Module):
                 "out_features": self.out_features,
                 "out_dtype": self.out_dtype,
                 "alt_key": self.alt_key,
+                "fkey": self.fkey,
+                "frange": self.frange,
+                "frange_dim": self.frange_dim,
+                "fidx": self.fidx,
+                "ftranspose_after_load": self.ftranspose_after_load,
                 "caps": self.caps,
                 "softcap": self.softcap,
                 "full_in_features": self.full_in_features,

--- a/exllamav3/tokenizer/tokenizer.py
+++ b/exllamav3/tokenizer/tokenizer.py
@@ -627,6 +627,7 @@ class Tokenizer:
         self,
         messages: list,
         add_generation_prompt: bool = True,
+        embeddings: list[MMEmbedding] | None = None,
         **template_kwargs
     ):
         """
@@ -642,6 +643,10 @@ class Tokenizer:
         :param add_generation_prompt:
             bool, add generation prompt
 
+        :param embeddings:
+            Optional list of MMEmbeddings. When present, HF chat template output is first rendered to text and
+            occurrences of the model's image placeholder token are replaced with embedding aliases before tokenizing.
+
         :param template_kwargs:
             Additional kwargs forwarded to `transformers` chat template rendering,
             e.g. `tools`, `chat_template_kwargs`, `enable_thinking`, etc.
@@ -649,6 +654,32 @@ class Tokenizer:
         :return:
             Token IDs tensor, shape (1, num_tokens)
         """
+
+        if embeddings:
+            if self.config.image_token_id is None:
+                raise ValueError("hf_chat_template(..., embeddings=...) requires config.image_token_id")
+            if not (0 <= self.config.image_token_id < len(self.id_to_piece)):
+                raise ValueError("config.image_token_id is out of tokenizer vocabulary range")
+
+            image_placeholder = self.id_to_piece[self.config.image_token_id]
+            rendered = self.hf_render_chat_template(
+                messages,
+                add_generation_prompt = add_generation_prompt,
+                **template_kwargs,
+            )
+            placeholder_count = rendered.count(image_placeholder)
+            if placeholder_count != len(embeddings):
+                raise ValueError(
+                    f"HF chat template rendered {placeholder_count} image placeholders but got "
+                    f"{len(embeddings)} embedding(s)"
+                )
+            for embedding in embeddings:
+                rendered = rendered.replace(image_placeholder, embedding.text_alias, 1)
+            return self.encode(
+                rendered,
+                encode_special_tokens = True,
+                embeddings = embeddings,
+            )
 
         from transformers import AutoTokenizer
         from transformers.tokenization_utils_base import BatchEncoding

--- a/exllamav3/util/rope.py
+++ b/exllamav3/util/rope.py
@@ -112,6 +112,8 @@ class RoPE:
                 self._rope_params_default()
             case "default" | "mrope":
                 self._rope_params_default()
+            case "proportional":
+                self._rope_params_proportional()
             case "llama3":
                 self._rope_params_llama3()
             case "linear":
@@ -158,6 +160,33 @@ class RoPE:
         self._rope_params_default()
         factor = rs.rope_scaling.get("factor", 1.0)
         self.inv_freq /= factor
+
+
+    def _rope_params_proportional(self):
+        rs = self.rope_settings
+        head_dim = rs.head_dim
+        base = rs.rope_theta
+        factor = rs.rope_scaling.get("factor", 1.0) if rs.rope_scaling else 1.0
+        rope_proportion = rs.partial_rotary_factor
+
+        rope_angles = int(rope_proportion * head_dim // 2)
+        inv_freq_rotated = 1.0 / (
+            base ** (
+                torch.arange(0, 2 * rope_angles, 2, dtype = torch.int64, device = self.device).float() / head_dim
+            )
+        )
+        nope_angles = head_dim // 2 - rope_angles
+        if nope_angles > 0:
+            inv_freq = torch.cat(
+                (
+                    inv_freq_rotated,
+                    torch.zeros(nope_angles, dtype = torch.float32, device = self.device),
+                ),
+                dim = 0,
+            )
+        else:
+            inv_freq = inv_freq_rotated
+        self.inv_freq, self.attn_factor = inv_freq / factor, 1.0
 
 
     def _rope_params_yarn(self):

--- a/tests/smoke_gemma4_arch.py
+++ b/tests/smoke_gemma4_arch.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Lightweight smoke checks for Gemma4 text architecture integration.
+
+Checks:
+1) Config/architecture resolution
+2) Text and vision model graph construction
+3) One sliding-attn block forward
+4) One full-attn block forward
+5) One MoE block forward when enabled
+6) One image embedding extraction through the vision tower
+
+Optional:
+7) Attempt full text model load
+"""
+
+import argparse
+import os
+import sys
+import torch
+from PIL import Image
+
+from exllamav3 import Cache, Config, Generator, Job, Model, Tokenizer
+from exllamav3.generator.sampler import GreedySampler
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", required=True)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--full_load", action="store_true")
+    ap.add_argument("--reserve_per_device", default=None, help="e.g. 0.25,0.25")
+    ap.add_argument("--multimodal_generation", action="store_true")
+    ap.add_argument("--multimodal_image", default=None)
+    args = ap.parse_args()
+
+    cfg = Config.from_directory(args.model_dir)
+    print("[INFO] architecture:", cfg.architecture)
+    if cfg.architecture != "Gemma4ForConditionalGeneration":
+        fail(f"Unexpected architecture: {cfg.architecture}")
+
+    model = Model.from_config(cfg)
+    vision_model = Model.from_config(cfg, component = "vision")
+    tokenizer = Tokenizer.from_config(cfg)
+    print("[INFO] model graph ok")
+    print("[INFO] vision graph ok")
+
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this smoke check")
+
+    device = torch.device(args.device)
+    hidden_size = cfg.hidden_size
+
+    idx_sliding = model.first_block_idx + cfg.layer_types.index("sliding_attention")
+    blk_sliding = model.modules[idx_sliding]
+    blk_sliding.load(device)
+    if blk_sliding.attn.v_proj is None:
+        fail("Expected sliding attention to have a v_proj")
+    x = torch.randn((1, 8, hidden_size), device = device, dtype = torch.half)
+    with torch.inference_mode():
+        y = blk_sliding.forward(x, params = {})
+    print("[INFO] sliding block forward:", blk_sliding.key, tuple(y.shape))
+    blk_sliding.unload()
+
+    idx_full = model.first_block_idx + cfg.layer_types.index("full_attention")
+    blk_full = model.modules[idx_full]
+    blk_full.load(device)
+    if blk_full.attn.v_proj is not None:
+        fail("Expected Gemma4 full attention to omit v_proj")
+    x = torch.randn((1, 8, hidden_size), device = device, dtype = torch.half)
+    with torch.inference_mode():
+        y = blk_full.forward(x, params = {})
+    print("[INFO] full block forward:", blk_full.key, tuple(y.shape))
+    blk_full.unload()
+
+    if cfg.enable_moe_block:
+        idx_moe = model.first_block_idx
+        blk_moe = model.modules[idx_moe]
+        blk_moe.load(device)
+        x = torch.randn((1, 8, hidden_size), device = device, dtype = torch.half)
+        with torch.inference_mode():
+            y = blk_moe.forward(x, params = {})
+        print("[INFO] moe block forward:", blk_moe.key, tuple(y.shape))
+        blk_moe.unload()
+
+    vision_model.load(device)
+    image = Image.new("RGB", (640, 480), (255, 0, 0))
+    image_embedding = vision_model.get_image_embeddings(tokenizer, image)
+    print("[INFO] image embeddings:", image_embedding.mm_length)
+    if image_embedding.mm_length <= 0:
+        fail("Vision tower produced no image embeddings")
+    vision_model.unload()
+
+    if args.full_load:
+        reserve = None
+        if args.reserve_per_device:
+            reserve = [float(x) for x in args.reserve_per_device.split(",")]
+        print("[INFO] attempting full model load")
+        try:
+            model.load(reserve_per_device = reserve)
+            print("[INFO] full model load ok")
+            model.unload()
+        except Exception as e:
+            print("[WARN] full model load failed:", repr(e))
+
+    if args.multimodal_generation:
+        image_path = args.multimodal_image
+        if image_path is None:
+            image_path = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                "examples",
+                "media",
+                "cat.png",
+            )
+        if not os.path.exists(image_path):
+            fail(f"Multimodal test image not found: {image_path}")
+
+        reserve = None
+        if args.reserve_per_device:
+            reserve = [float(x) for x in args.reserve_per_device.split(",")]
+
+        cache = Cache(model, max_num_tokens = 4096)
+        vision_model.load(device)
+        image_embedding = vision_model.get_image_embeddings(tokenizer, Image.open(image_path).convert("RGB"))
+        prompt_ids = tokenizer.hf_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": "What animal is shown? Answer with one word."},
+                    ],
+                }
+            ],
+            add_generation_prompt = True,
+            enable_thinking = False,
+            embeddings = [image_embedding],
+        )
+        vision_model.unload()
+
+        model.load(reserve_per_device = reserve)
+        generator = Generator(model, cache, tokenizer)
+        job = Job(
+            input_ids = prompt_ids.cpu(),
+            max_new_tokens = 8,
+            stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+            decode_special_tokens = True,
+            embeddings = [image_embedding],
+            sampler = GreedySampler(),
+        )
+        generator.enqueue(job)
+        output_text = ""
+        while generator.num_remaining_jobs():
+            for result in generator.iterate():
+                if result.get("stage") == "streaming":
+                    output_text += result.get("text", "")
+        print("[INFO] multimodal generation:", repr(output_text))
+        if "cat" not in output_text.lower():
+            fail(f"Unexpected multimodal generation output: {output_text!r}")
+        model.unload()
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    print("[PASS] gemma4 smoke checks complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_gemma4_mm.py
+++ b/tests/smoke_gemma4_mm.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Objective multimodal smoke checks for Gemma4 image understanding.
+
+Checks:
+1) Single-image recognition
+2) Ordered two-image reasoning
+3) Duplicate image consistency
+4) Optional quantized KV-cache path using the model-specific cache layer
+"""
+
+import argparse
+import os
+import sys
+
+import torch
+from PIL import Image
+
+from exllamav3 import Cache, Config, Job, Model, Tokenizer
+from exllamav3.generator import Generator
+from exllamav3.generator.sampler import GreedySampler
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def run_prompt(
+    generator: Generator,
+    tokenizer: Tokenizer,
+    embeddings: list,
+    question: str,
+) -> str:
+    prompt_ids = tokenizer.hf_chat_template(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"} for _ in embeddings
+                ] + [{"type": "text", "text": question}],
+            }
+        ],
+        add_generation_prompt = True,
+        enable_thinking = False,
+        embeddings = embeddings,
+    )
+    job = Job(
+        input_ids = prompt_ids.cpu(),
+        max_new_tokens = 16,
+        stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+        decode_special_tokens = True,
+        embeddings = embeddings,
+        sampler = GreedySampler(),
+    )
+    generator.enqueue(job)
+    output = ""
+    while generator.num_remaining_jobs():
+        for result in generator.iterate():
+            if result.get("stage") == "streaming":
+                output += result.get("text", "")
+    return output
+
+
+def expect_contains(label: str, output: str, expected: list[str]) -> None:
+    n = normalize(output)
+    if not any(e in n for e in expected):
+        fail(f"{label}: expected one of {expected!r}, got {output!r}")
+    print(f"[INFO] {label}: {output!r}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", required=True)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--reserve_per_device", default=None, help="e.g. 0.5,0.5")
+    ap.add_argument("--cache_bits", default=None, help="Either single value or k_bits,v_bits")
+    ap.add_argument("--swa_cache_size", type=int, default=None)
+    ap.add_argument("--cat_image", default=None)
+    ap.add_argument("--fruit_image", default=None)
+    args = ap.parse_args()
+
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this smoke check")
+
+    cat_image = args.cat_image or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "doc",
+        "cat.png",
+    )
+    fruit_image = args.fruit_image or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "examples",
+        "media",
+        "strawberry.png",
+    )
+    for path in [cat_image, fruit_image]:
+        if not os.path.exists(path):
+            fail(f"Required image not found: {path}")
+
+    reserve = None
+    if args.reserve_per_device:
+        reserve = [float(x) for x in args.reserve_per_device.split(",")]
+
+    cfg = Config.from_directory(args.model_dir)
+    model = Model.from_config(cfg)
+    vision_model = Model.from_config(cfg, component="vision")
+    tokenizer = Tokenizer.from_config(cfg)
+
+    cache_kwargs = {}
+    if args.cache_bits is not None:
+        split = [int(bits) for bits in args.cache_bits.split(",")]
+        if len(split) == 1:
+            k_bits = v_bits = split[0]
+        elif len(split) == 2:
+            k_bits, v_bits = split
+        else:
+            fail("--cache_bits must be 'bits' or 'k_bits,v_bits'")
+        cache_kwargs = {
+            "layer_type": model.caps.get("quantized_kv_cache_layer"),
+            "k_bits": k_bits,
+            "v_bits": v_bits,
+        }
+    if args.swa_cache_size is not None:
+        cache_kwargs["swa_max_num_tokens"] = args.swa_cache_size
+    cache = Cache(model, max_num_tokens=1024, **cache_kwargs)
+
+    device = torch.device(args.device)
+    vision_model.load(device)
+    cat = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    cat_dup = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    fruit = vision_model.get_image_embeddings(tokenizer, Image.open(fruit_image).convert("RGB"))
+    vision_model.unload()
+
+    model.load(reserve_per_device=reserve)
+    generator = Generator(model, cache, tokenizer)
+
+    expect_contains(
+        "single cat",
+        run_prompt(generator, tokenizer, [cat], "What animal is shown? Answer with one word."),
+        ["cat"],
+    )
+    expect_contains(
+        "single fruit",
+        run_prompt(generator, tokenizer, [fruit], "What fruit is shown? Answer with one word."),
+        ["strawberry"],
+    )
+
+    pair = [cat, fruit]
+    expect_contains(
+        "animal position",
+        run_prompt(generator, tokenizer, pair, "Which image shows an animal? Answer first or second."),
+        ["first"],
+    )
+    expect_contains(
+        "fruit position",
+        run_prompt(generator, tokenizer, pair, "Which image shows a fruit? Answer first or second."),
+        ["second"],
+    )
+    expect_contains(
+        "first animal yesno",
+        run_prompt(generator, tokenizer, pair, "Does the first image show an animal? Answer yes or no."),
+        ["yes"],
+    )
+    expect_contains(
+        "second fruit yesno",
+        run_prompt(generator, tokenizer, pair, "Does the second image show a fruit? Answer yes or no."),
+        ["yes"],
+    )
+    expect_contains(
+        "same subject no",
+        run_prompt(generator, tokenizer, pair, "Do the two images show the same subject? Answer yes or no."),
+        ["no"],
+    )
+    expect_contains(
+        "duplicate subject yes",
+        run_prompt(
+            generator,
+            tokenizer,
+            [cat, cat_dup],
+            "Do the two images show the same subject? Answer yes or no.",
+        ),
+        ["yes"],
+    )
+
+    model.unload()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    print("[PASS] gemma4 multimodal smoke checks complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add cumulative `Gemma4ForConditionalGeneration` support for Gemma4 text and vision components
- split Gemma4 multimodal and vision-specific logic into the dedicated adapter file `exllamav3/architecture/gemma4_mm.py`
- keep Gemma4 text architecture wiring in `exllamav3/architecture/gemma4.py` and keep vision preprocessing, patch conversion, vision embedding extraction, and vision-group setup isolated in the MM adapter layer
- add Gemma4 multimodal attention handling needed for image-token groups in sliding-attention layers
- keep multimodal prefill atomic across image embedding spans
- allow `hf_chat_template(..., embeddings=[...])` to replace rendered image placeholders with MM embedding aliases automatically
- extend Gemma4 smoke coverage for vision embedding extraction and multimodal generation
- intentionally keep turboquant / reduced-SWA / cache-path work out of this PR so the base support review stays focused

## Why The MM Split Exists
The Gemma4 multimodal path was intentionally moved into a separate file, `exllamav3/architecture/gemma4_mm.py`, instead of leaving it embedded in the main Gemma4 text architecture file.

This split is intentional for reviewability and long-term maintenance:
- it keeps the text architecture adapter focused on Gemma4 text-model wiring and base model capabilities
- it keeps vision preprocessing, image patch conversion, pooled vision embedding generation, and multimodal token-group bookkeeping in one isolated MM-specific module
- it reduces the chance that later cache/runtime work gets mixed into the core model-support PR
- it makes the Gemma4 MM support easier to review independently from the follow-up turboquant/cache optimization work

In short, the split is there to keep the base Gemma4 model-support PR narrow, readable, and maintainable, and the dedicated `gemma4_mm.py` file is part of this PR's actual patch set.

## Validation
- `python tests/smoke_gemma4_arch.py --model_dir <Gemma4 31B checkpoint> --device cuda:0`
- `python tests/smoke_gemma4_arch.py --model_dir <Gemma4 31B quantized output> --device cuda:0`
- `python tests/smoke_gemma4_arch.py --model_dir <Gemma4 31B quantized output> --device cuda:0 --multimodal_generation --reserve_per_device 0`
- `python tests/smoke_gemma4_mm.py --model_dir <Gemma4 31B quantized output> --reserve_per_device 0`
- `python tests/smoke_gemma4_arch.py --model_dir <Gemma4 26B-A4B checkpoint> --device cuda:0`
- `python tests/smoke_gemma4_arch.py --model_dir <Gemma4 26B-A4B quantized output> --device cuda:0`
- `python tests/smoke_gemma4_arch.py --model_dir <Gemma4 26B-A4B quantized output> --device cuda:0 --full_load --reserve_per_device 0.5,0.5`
- `python tests/smoke_gemma4_mm.py --model_dir <Gemma4 26B-A4B quantized output> --reserve_per_device 0`
- support-only 31B sequential text generation sanity check on the current PR head
- EXL3 conversion completed for the Gemma4 31B checkpoint and the Gemma4 26B-A4B checkpoint
- Gemma4 26B-A4B EXL3 conversion was validated with parallel MoE quantization mode (`-pm`)

## Scope
- validated Gemma4 text generation on 31B dense and 26B-A4B MoE checkpoints and EXL3 outputs
- validated Gemma4 multimodal generation on Gemma4 31B IT and Gemma4 26B-A4B IT
- Gemma4 vision inputs are supported through exllamav3 MM embeddings
- this PR is the Gemma4 model-support and multimodal-support layer
- turboquant / reduced-SWA / cache-path work is intentionally being kept in a separate follow-up PR
