### PR TITLE
Gemma4: add turboquant KV cache with reduced SWA and soak validation

### DIFF
--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -9,6 +9,7 @@ from .ernie4_5_moe import Ernie4_5MoEModel
 from .exaone4 import Exaone4Model
 from .gemma2 import Gemma2Model
 from .gemma3 import Gemma3Model, Gemma3TextModel
+from .gemma4 import Gemma4TextModel
 from .glm4 import Glm4Model
 from .glm4_moe import Glm4MoeModel
 from .glm4v import Glm4VModel
@@ -58,6 +59,7 @@ ARCHITECTURES = {
         Gemma2Model,
         Gemma3Model,
         Gemma3TextModel,
+        Gemma4TextModel,
         Glm4Model,
         Glm4MoeModel,
         Glm4VModel,

--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import json
-import math
 import os
 from types import SimpleNamespace
 
-import numpy as np
 import torch
-from PIL import Image
 from typing_extensions import override
 
 from ..model.config import Config
@@ -22,125 +19,74 @@ from ..modules import (
     Gemma4MoEFeedForward,
     Gemma4MoETransformerBlock,
     Gemma4TransformerBlock,
-    Gemma4VisionAttention,
-    Gemma4VisionPatchEmbedder,
-    Gemma4VisionPooler,
-    Gemma4VisionProjector,
-    Gemma4VisionStandardize,
 )
 from ..modules.attn import prepare_for_attn
-from ..tokenizer import MMEmbedding, Tokenizer
 from ..util.file import no_default
 from ..util.rope import RopeStyle
-from ..util.vision import convert_to_rgb
+from .gemma4_mm import Gemma4VisionModel, set_gemma4_vision_groups
 
 
-def _set_gemma4_vision_groups(
+def _detect_gemma4_profile(config: "Gemma4Config") -> str:
+    if (
+        config.num_hidden_layers == 60 and
+        not config.enable_moe_block and
+        config.num_kv_heads == 16 and
+        config.num_global_kv_heads == 4
+    ):
+        return "31b_dense"
+
+    if (
+        config.num_hidden_layers == 30 and
+        config.enable_moe_block and
+        config.num_kv_heads == 8 and
+        config.num_global_kv_heads == 2
+    ):
+        return "26b_a4b_moe"
+
+    return "generic"
+
+
+def _filter_gemma4_indexed_embeddings(
     input_ids: torch.Tensor,
     params: dict,
-    boi_token_id: int | None,
-    eoi_token_id: int | None,
 ) -> None:
     indexed_embeddings = params.get("indexed_embeddings") or []
     if not indexed_embeddings:
-        params.pop("vision_group_ids", None)
+        params.pop("indexed_embeddings", None)
         return
 
-    vision_group_ids = torch.full(input_ids.shape, -1, dtype = torch.int32)
-    group_index = 0
-    for embedding in indexed_embeddings:
-        mask = (input_ids >= embedding.first_index) & (input_ids < embedding.last_index)
-        if not mask.any():
-            continue
+    active_embeddings = [
+        embedding
+        for embedding in indexed_embeddings
+        if ((input_ids >= embedding.first_index) & (input_ids < embedding.last_index)).any().item()
+    ]
 
-        for row in range(input_ids.shape[0]):
-            row_mask = mask[row]
-            if not row_mask.any():
-                continue
-
-            positions = torch.nonzero(row_mask, as_tuple = False).flatten()
-            start = int(positions[0].item())
-            end = int(positions[-1].item())
-
-            vision_group_ids[row, start : end + 1] = group_index
-
-        group_index += 1
-
-    if group_index > 0:
-        params["vision_group_ids"] = vision_group_ids
+    if active_embeddings:
+        params["indexed_embeddings"] = active_embeddings
     else:
-        params.pop("vision_group_ids", None)
+        params.pop("indexed_embeddings", None)
 
 
-def _get_aspect_ratio_preserving_size(
-    height: int,
-    width: int,
-    patch_size: int,
-    max_patches: int,
-    pooling_kernel_size: int,
-) -> tuple[int, int]:
-    total_px = height * width
-    target_px = max_patches * (patch_size ** 2)
-    factor = math.sqrt(target_px / total_px)
-    ideal_height = factor * height
-    ideal_width = factor * width
-    side_mult = pooling_kernel_size * patch_size
+def _update_gemma4_reconstruct_mode(
+    params: dict,
+    profile: str,
+    has_mm_request: bool,
+) -> None:
+    temp_flag = "_gemma4_temp_reconstruct"
 
-    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
-    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
+    if profile != "26b_a4b_moe":
+        if params.pop(temp_flag, False):
+            params.pop("reconstruct", None)
+        return
 
-    if target_height == 0 and target_width == 0:
-        raise ValueError(
-            "Attempting to resize to a 0 x 0 image. "
-            f"Resized height should be divisible by pooling_kernel_size * patch_size = {side_mult}."
-        )
-
-    max_side_length = (max_patches // (pooling_kernel_size ** 2)) * side_mult
-    if target_height == 0:
-        target_height = side_mult
-        target_width = min(int(math.floor(width / height)) * side_mult, max_side_length)
-    elif target_width == 0:
-        target_width = side_mult
-        target_height = min(int(math.floor(height / width)) * side_mult, max_side_length)
-
-    if target_height * target_width > target_px:
-        raise ValueError(
-            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] exceeds patch budget"
-        )
-
-    return target_height, target_width
-
-
-def _convert_image_to_patches(image: np.ndarray, patch_size: int) -> np.ndarray:
-    num_channels, image_height, image_width = image.shape
-    num_patches_height = image_height // patch_size
-    num_patches_width = image_width // patch_size
-    patched_image = image.reshape(num_channels, num_patches_height, patch_size, num_patches_width, patch_size)
-    patched_image = patched_image.transpose(1, 3, 2, 4, 0)
-    patched_image = patched_image.reshape(num_patches_height * num_patches_width, -1)
-    return patched_image
-
-
-def _pad_patches_and_positions(
-    patches: np.ndarray,
-    positions: np.ndarray,
-    target_length: int,
-) -> tuple[np.ndarray, np.ndarray]:
-    current_length = patches.shape[0]
-    if current_length > target_length:
-        raise ValueError(
-            f"Cannot pad Gemma4 patches from {current_length} down to target length {target_length}"
-        )
-
-    padding_length = target_length - current_length
-    if padding_length == 0:
-        return patches, positions
-
-    patch_paddings = [(0, padding_length)] + [(0, 0)] * (patches.ndim - 1)
-    position_paddings = [(0, padding_length), (0, 0)]
-    patches = np.pad(patches, patch_paddings, mode = "constant", constant_values = 0)
-    positions = np.pad(positions, position_paddings, mode = "constant", constant_values = -1)
-    return patches, positions
+    if has_mm_request:
+        if "reconstruct" not in params:
+            params["reconstruct"] = True
+            params[temp_flag] = True
+        else:
+            params.pop(temp_flag, None)
+    elif params.pop(temp_flag, False):
+        params.pop("reconstruct", None)
 
 
 class Gemma4Config(Config):
@@ -278,9 +224,12 @@ class Gemma4TextModel(Model):
         **kwargs
     ):
         super().__init__(config, **kwargs)
+        profile = _detect_gemma4_profile(config)
+        is_31b_dense = profile == "31b_dense"
         self.caps.update({
-            "supports_tp": False,
+            "supports_tp": is_31b_dense,
             "atomic_mm_prefill": True,
+            "gemma4_profile": profile,
         })
 
         self.modules += [
@@ -431,7 +380,14 @@ class Gemma4TextModel(Model):
 
     @override
     def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
-        _set_gemma4_vision_groups(input_ids, params, self.config.boi_token_id, self.config.eoi_token_id)
+        has_mm_request = bool(params.get("indexed_embeddings"))
+        _filter_gemma4_indexed_embeddings(input_ids, params)
+        _update_gemma4_reconstruct_mode(
+            params,
+            self.caps.get("gemma4_profile", "generic"),
+            has_mm_request = has_mm_request,
+        )
+        set_gemma4_vision_groups(input_ids, params, self.config.boi_token_id, self.config.eoi_token_id)
         return prepare_for_attn(input_ids, params)
 
 
@@ -443,242 +399,3 @@ class Gemma4TextModel(Model):
         p += f"<|turn>user\n{prompt}<turn|>\n"
         p += "<|turn>model\n"
         return p
-
-
-class Gemma4VisionModel(Model):
-
-    @staticmethod
-    @override
-    def get_additional_compiled_tensors(config: Gemma4Config) -> dict:
-        return (
-            config.stc.list_tensors(prefix = "model.vision_tower") |
-            config.stc.list_tensors(prefix = "model.embed_vision")
-        )
-
-
-    def __init__(
-        self,
-        config: Gemma4Config,
-        **kwargs,
-    ):
-        super().__init__(config, **kwargs)
-        self.config = config
-        self.caps.update({
-            "image_input": True,
-            "supports_tp": False,
-        })
-        v = self.config.vision
-
-        self.modules += [
-            Gemma4VisionPatchEmbedder(
-                config = config,
-                key = "model.vision_tower.patch_embedder",
-                hidden_size = v.hidden_size,
-                patch_dim = v.patch_dim,
-            )
-        ]
-
-        for idx in range(v.num_hidden_layers):
-            key = f"model.vision_tower.encoder.layers.{idx}"
-            self.modules.append(
-                TransformerBlock(
-                    config = config,
-                    key = key,
-                    layer_idx = idx,
-                    attn_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.input_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                    ),
-                    attn = Gemma4VisionAttention(
-                        config = config,
-                        key = f"{key}.self_attn",
-                        layer_idx = idx,
-                        hidden_size = v.hidden_size,
-                        head_dim = v.head_dim,
-                        num_q_heads = v.num_q_heads,
-                        num_kv_heads = v.num_kv_heads,
-                        rope_theta = v.rope_theta,
-                        rms_norm_eps = v.rms_norm_eps,
-                    ),
-                    attn_post_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.post_attention_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                        out_dtype = torch.float,
-                    ),
-                    mlp_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.pre_feedforward_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                    ),
-                    mlp = GatedMLP(
-                        config = config,
-                        key = f"{key}.mlp",
-                        hidden_size = v.hidden_size,
-                        intermediate_size = v.intermediate_size,
-                        key_up = "up_proj.linear",
-                        key_gate = "gate_proj.linear",
-                        key_down = "down_proj.linear",
-                        activation_fn = "gelu",
-                        qmap = "block.mlp",
-                    ),
-                    mlp_post_norm = RMSNorm(
-                        config = config,
-                        key = f"{key}.post_feedforward_layernorm",
-                        rms_norm_eps = v.rms_norm_eps,
-                        out_dtype = torch.float,
-                    ),
-                )
-            )
-
-        self.modules += [
-            Gemma4VisionPooler(
-                config = config,
-                key = "model.vision_tower.pooler",
-                hidden_size = v.hidden_size,
-            )
-        ]
-
-        if v.standardize:
-            self.modules += [
-                Gemma4VisionStandardize(
-                    config = config,
-                    key = "model.vision_tower",
-                )
-            ]
-
-        self.modules += [
-            Gemma4VisionProjector(
-                config = config,
-                key = "model.embed_vision.embedding_projection",
-                in_features = v.hidden_size,
-                out_features = config.hidden_size,
-                rms_norm_eps = v.rms_norm_eps,
-            ),
-        ]
-
-
-    @override
-    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
-        return input_ids
-
-
-    def default_load_shape_dtype(self, chunk_size):
-        return (
-            1,
-            self.config.vision.max_patches,
-            self.config.vision.patch_dim,
-        ), torch.half
-
-
-    def default_load_params(self, chunk_size):
-        h_patches = 45
-        w_patches = self.config.vision.max_patches // h_patches
-        grid_x, grid_y = np.meshgrid(np.arange(w_patches), np.arange(h_patches), indexing = "xy")
-        position_ids = np.stack([grid_x, grid_y], axis = -1).reshape(self.config.vision.max_patches, 2)
-        return {
-            "input_ids": torch.zeros((1, self.config.vision.max_patches, self.config.vision.patch_dim), dtype = torch.half),
-            "image_position_ids": torch.from_numpy(position_ids).unsqueeze(0).to(torch.long),
-            "image_output_length": self.config.vision_pp.max_soft_tokens,
-            "causal": False,
-        }
-
-
-    def preprocess(
-        self,
-        image: Image.Image,
-    ) -> tuple[torch.Tensor, torch.Tensor, int, tuple[int, int]]:
-        vpp = self.config.vision_pp
-        image = convert_to_rgb(image)
-        old_size = image.size
-        width, height = old_size
-        target_height, target_width = _get_aspect_ratio_preserving_size(
-            height = height,
-            width = width,
-            patch_size = vpp.patch_size,
-            max_patches = self.config.vision.max_patches,
-            pooling_kernel_size = vpp.pooling_kernel_size,
-        )
-
-        if (target_width, target_height) != old_size:
-            image = image.resize((target_width, target_height), resample = Image.Resampling(vpp.resample))
-
-        image_np = np.array(image).astype(np.float32)
-        image_np = image_np.transpose(2, 0, 1)
-
-        if vpp.do_rescale:
-            image_np *= vpp.rescale_factor
-
-        if vpp.do_normalize:
-            image_mean = np.asarray(vpp.image_mean, dtype = np.float32).reshape(-1, 1, 1)
-            image_std = np.asarray(vpp.image_std, dtype = np.float32).reshape(-1, 1, 1)
-            image_np = (image_np - image_mean) / image_std
-
-        patches = _convert_image_to_patches(image_np, vpp.patch_size)
-        num_soft_tokens = patches.shape[0] // (vpp.pooling_kernel_size ** 2)
-
-        patch_height = image_np.shape[-2] // vpp.patch_size
-        patch_width = image_np.shape[-1] // vpp.patch_size
-        grid_x, grid_y = np.meshgrid(np.arange(patch_width), np.arange(patch_height), indexing = "xy")
-        positions = np.stack([grid_x, grid_y], axis = -1).reshape(patches.shape[0], 2)
-
-        patches, positions = _pad_patches_and_positions(
-            patches,
-            positions,
-            self.config.vision.max_patches,
-        )
-
-        pixel_values = torch.from_numpy(patches).half().unsqueeze(0)
-        image_position_ids = torch.from_numpy(positions).to(torch.long).unsqueeze(0)
-        return pixel_values, image_position_ids, num_soft_tokens, (target_width, target_height)
-
-
-    def get_image_embeddings(
-        self,
-        tokenizer: Tokenizer,
-        image: Image.Image | list[Image.Image],
-        text_alias: str | None = None,
-    ):
-        if isinstance(image, list):
-            assert text_alias is None, "Cannot apply a single alias to a list of images"
-            return [self.get_image_embeddings(tokenizer, i) for i in image]
-
-        pixel_values, image_position_ids, _, prep_size = self.preprocess(image)
-        params = {
-            "causal": False,
-            "image_position_ids": image_position_ids,
-            "image_output_length": self.config.vision_pp.max_soft_tokens,
-        }
-        embedding_tensor = self.forward(
-            pixel_values,
-            params = params,
-        ).cpu()
-        pooler_mask = params.get("image_pooler_mask")
-        if pooler_mask is not None:
-            pooler_mask = pooler_mask.cpu()
-            embedding_tensor = embedding_tensor[0][pooler_mask[0]].unsqueeze(0)
-            num_soft_tokens = int(pooler_mask[0].sum().item())
-        else:
-            num_soft_tokens = embedding_tensor.shape[1]
-
-        boi_token_id = tokenizer.single_id("<|image>")
-        image_token_id = tokenizer.single_id("<|image|>")
-        eoi_token_id = tokenizer.single_id("<image|>")
-        token_string = torch.tensor(
-            [[boi_token_id] + [image_token_id] * num_soft_tokens + [eoi_token_id]],
-            dtype = torch.long,
-        )
-        token_string[:, 1:-1] = -1
-
-        mme = MMEmbedding(
-            embeddings = embedding_tensor[0],
-            text_alias = text_alias,
-            token_string = token_string,
-        )
-        mme.metadata.update({
-            "original_size": image.size,
-            "preprocessed_size": prep_size,
-            "model_architecture": self.config.architecture,
-        })
-        return mme

--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -7,15 +7,21 @@ from types import SimpleNamespace
 import torch
 from typing_extensions import override
 
+from ..cache.gemma4 import (
+    Gemma4QuantCacheLayer,
+    Gemma4SingleQuantCacheLayer,
+    select_gemma4_cache_layer,
+)
+from ..generator.gemma4_pagetable import Gemma4PageTable
 from ..model.config import Config
 from ..model.model import Model
 from ..modules import (
     Embedding,
-    GatedMLP,
     Linear,
     RMSNorm,
     TransformerBlock,
     Gemma4Attention,
+    Gemma4GatedMLP,
     Gemma4MoEFeedForward,
     Gemma4MoETransformerBlock,
     Gemma4TransformerBlock,
@@ -80,6 +86,10 @@ def _update_gemma4_reconstruct_mode(
         return
 
     if has_mm_request:
+        # Keep the full 26B MM request on the conservative EXL3 reconstruct
+        # route. The multimodal prompt itself only contains image placeholders
+        # during prefill, but the generated decode tokens belong to the same MM
+        # request and must not fall back to the shared fast path mid-stream.
         if "reconstruct" not in params:
             params["reconstruct"] = True
             params[temp_flag] = True
@@ -226,10 +236,16 @@ class Gemma4TextModel(Model):
         super().__init__(config, **kwargs)
         profile = _detect_gemma4_profile(config)
         is_31b_dense = profile == "31b_dense"
+        is_26b_a4b_moe = profile == "26b_a4b_moe"
+        use_single_quant_kv_cache = is_31b_dense or is_26b_a4b_moe
         self.caps.update({
             "supports_tp": is_31b_dense,
             "atomic_mm_prefill": True,
             "gemma4_profile": profile,
+            "cache_contract": "gemma4_iswa",
+            "cache_layer_selector": self.select_cache_layer,
+            "quantized_kv_cache_layer": Gemma4SingleQuantCacheLayer if use_single_quant_kv_cache else Gemma4QuantCacheLayer,
+            "page_table_cls": Gemma4PageTable,
         })
 
         self.modules += [
@@ -267,6 +283,7 @@ class Gemma4TextModel(Model):
                     rms_norm_eps = config.rms_norm_eps,
                     unweighted = True,
                 ),
+                force_quantized_fallback = is_31b_dense and not layer_is_full,
                 rope_settings = config.rope_settings_full if layer_is_full else config.rope_settings_local,
                 sm_scale = 1.0,
                 sliding_window = config.swa_pattern[idx],
@@ -334,7 +351,7 @@ class Gemma4TextModel(Model):
                 )
             else:
                 block = Gemma4TransformerBlock(
-                    mlp = GatedMLP(
+                    mlp = Gemma4GatedMLP(
                         config = config,
                         key = f"{key}.mlp",
                         hidden_size = config.hidden_size,
@@ -399,3 +416,11 @@ class Gemma4TextModel(Model):
         p += f"<|turn>user\n{prompt}<turn|>\n"
         p += "<|turn>model\n"
         return p
+
+    def select_cache_layer(self, default_layer_type, attention, cache_kwargs):
+        return select_gemma4_cache_layer(
+            default_layer_type,
+            attention,
+            self.config.layer_types,
+            cache_kwargs = cache_kwargs,
+        )

--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -1,0 +1,684 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+from PIL import Image
+from typing_extensions import override
+
+from ..model.config import Config
+from ..model.model import Model
+from ..modules import (
+    Embedding,
+    GatedMLP,
+    Linear,
+    RMSNorm,
+    TransformerBlock,
+    Gemma4Attention,
+    Gemma4MoEFeedForward,
+    Gemma4MoETransformerBlock,
+    Gemma4TransformerBlock,
+    Gemma4VisionAttention,
+    Gemma4VisionPatchEmbedder,
+    Gemma4VisionPooler,
+    Gemma4VisionProjector,
+    Gemma4VisionStandardize,
+)
+from ..modules.attn import prepare_for_attn
+from ..tokenizer import MMEmbedding, Tokenizer
+from ..util.file import no_default
+from ..util.rope import RopeStyle
+from ..util.vision import convert_to_rgb
+
+
+def _set_gemma4_vision_groups(
+    input_ids: torch.Tensor,
+    params: dict,
+    boi_token_id: int | None,
+    eoi_token_id: int | None,
+) -> None:
+    indexed_embeddings = params.get("indexed_embeddings") or []
+    if not indexed_embeddings:
+        params.pop("vision_group_ids", None)
+        return
+
+    vision_group_ids = torch.full(input_ids.shape, -1, dtype = torch.int32)
+    group_index = 0
+    for embedding in indexed_embeddings:
+        mask = (input_ids >= embedding.first_index) & (input_ids < embedding.last_index)
+        if not mask.any():
+            continue
+
+        for row in range(input_ids.shape[0]):
+            row_mask = mask[row]
+            if not row_mask.any():
+                continue
+
+            positions = torch.nonzero(row_mask, as_tuple = False).flatten()
+            start = int(positions[0].item())
+            end = int(positions[-1].item())
+
+            vision_group_ids[row, start : end + 1] = group_index
+
+        group_index += 1
+
+    if group_index > 0:
+        params["vision_group_ids"] = vision_group_ids
+    else:
+        params.pop("vision_group_ids", None)
+
+
+def _get_aspect_ratio_preserving_size(
+    height: int,
+    width: int,
+    patch_size: int,
+    max_patches: int,
+    pooling_kernel_size: int,
+) -> tuple[int, int]:
+    total_px = height * width
+    target_px = max_patches * (patch_size ** 2)
+    factor = math.sqrt(target_px / total_px)
+    ideal_height = factor * height
+    ideal_width = factor * width
+    side_mult = pooling_kernel_size * patch_size
+
+    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
+    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
+
+    if target_height == 0 and target_width == 0:
+        raise ValueError(
+            "Attempting to resize to a 0 x 0 image. "
+            f"Resized height should be divisible by pooling_kernel_size * patch_size = {side_mult}."
+        )
+
+    max_side_length = (max_patches // (pooling_kernel_size ** 2)) * side_mult
+    if target_height == 0:
+        target_height = side_mult
+        target_width = min(int(math.floor(width / height)) * side_mult, max_side_length)
+    elif target_width == 0:
+        target_width = side_mult
+        target_height = min(int(math.floor(height / width)) * side_mult, max_side_length)
+
+    if target_height * target_width > target_px:
+        raise ValueError(
+            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] exceeds patch budget"
+        )
+
+    return target_height, target_width
+
+
+def _convert_image_to_patches(image: np.ndarray, patch_size: int) -> np.ndarray:
+    num_channels, image_height, image_width = image.shape
+    num_patches_height = image_height // patch_size
+    num_patches_width = image_width // patch_size
+    patched_image = image.reshape(num_channels, num_patches_height, patch_size, num_patches_width, patch_size)
+    patched_image = patched_image.transpose(1, 3, 2, 4, 0)
+    patched_image = patched_image.reshape(num_patches_height * num_patches_width, -1)
+    return patched_image
+
+
+def _pad_patches_and_positions(
+    patches: np.ndarray,
+    positions: np.ndarray,
+    target_length: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    current_length = patches.shape[0]
+    if current_length > target_length:
+        raise ValueError(
+            f"Cannot pad Gemma4 patches from {current_length} down to target length {target_length}"
+        )
+
+    padding_length = target_length - current_length
+    if padding_length == 0:
+        return patches, positions
+
+    patch_paddings = [(0, padding_length)] + [(0, 0)] * (patches.ndim - 1)
+    position_paddings = [(0, padding_length), (0, 0)]
+    patches = np.pad(patches, patch_paddings, mode = "constant", constant_values = 0)
+    positions = np.pad(positions, position_paddings, mode = "constant", constant_values = -1)
+    return patches, positions
+
+
+class Gemma4Config(Config):
+    arch_string = "Gemma4ForConditionalGeneration"
+
+    def __init__(
+        self,
+        directory: str,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            {"text": Gemma4TextModel, "vision": Gemma4VisionModel},
+            **kwargs
+        )
+
+        self.image_token_id = self.read_cfg(int, "image_token_id", None)
+        self.boi_token_id = self.read_cfg(int, "boi_token_id", None)
+        self.eoi_token_id = self.read_cfg(int, "eoi_token_id", None)
+        self.vision_soft_tokens_per_image = self.read_cfg(int, "vision_soft_tokens_per_image", no_default)
+
+        self.head_dim = self.read_cfg(int, "text_config->head_dim", no_default)
+        self.global_head_dim = self.read_cfg(int, "text_config->global_head_dim", self.head_dim)
+        self.hidden_size = self.read_cfg(int, "text_config->hidden_size", no_default)
+        self.num_q_heads = self.read_cfg(int, "text_config->num_attention_heads", no_default)
+        self.num_kv_heads = self.read_cfg(int, "text_config->num_key_value_heads", self.num_q_heads)
+        self.num_global_kv_heads = self.read_cfg(
+            int,
+            "text_config->num_global_key_value_heads",
+            self.num_kv_heads
+        )
+        self.num_hidden_layers = self.read_cfg(int, "text_config->num_hidden_layers", no_default)
+        self.tie_word_embeddings = self.read_cfg(bool, "text_config->tie_word_embeddings", False)
+        self.attention_k_eq_v = self.read_cfg(bool, "text_config->attention_k_eq_v", False)
+        self.use_bidirectional_attention = self.read_cfg(str, "text_config->use_bidirectional_attention", None)
+
+        self.layer_types = self.read_cfg(list, "text_config->layer_types", no_default)
+        assert len(self.layer_types) == self.num_hidden_layers, \
+            "Length of text_config->layer_types key doesn't match number of hidden layers"
+
+        self.sliding_window = self.read_cfg(int, "text_config->sliding_window", -1)
+        self.swa_pattern = []
+        for layer_type in self.layer_types:
+            match layer_type:
+                case "sliding_attention":
+                    self.swa_pattern.append(self.sliding_window)
+                case "full_attention":
+                    self.swa_pattern.append(-1)
+                case _:
+                    raise ValueError(f"Unknown layer type in layer_types: {layer_type}")
+
+        self.assert_cfg(str, "text_config->hidden_activation", "gelu_pytorch_tanh", True)
+        self.intermediate_size = self.read_cfg(int, "text_config->intermediate_size", no_default)
+
+        self.rms_norm_eps = self.read_cfg(float, "text_config->rms_norm_eps", no_default)
+        self.attn_logit_softcapping = self.read_cfg(float, "text_config->attn_logit_softcapping", 0.0)
+        self.final_logit_softcapping = self.read_cfg(float, "text_config->final_logit_softcapping", 0.0)
+
+        self.hidden_size_per_layer_input = self.read_cfg(int, "text_config->hidden_size_per_layer_input", 0)
+        if self.hidden_size_per_layer_input:
+            raise NotImplementedError("Gemma4 per-layer inputs are not implemented yet")
+
+        self.enable_moe_block = self.read_cfg(bool, "text_config->enable_moe_block", False)
+        self.num_experts = self.read_cfg(int, "text_config->num_experts", 0)
+        self.num_experts_per_tok = self.read_cfg(int, "text_config->top_k_experts", 0)
+        self.moe_intermediate_size = self.read_cfg(int, "text_config->moe_intermediate_size", 0)
+        if self.enable_moe_block:
+            assert self.num_experts > 0, "Gemma4 MoE requires text_config->num_experts"
+            assert self.num_experts_per_tok > 0, "Gemma4 MoE requires text_config->top_k_experts"
+            assert self.moe_intermediate_size > 0, "Gemma4 MoE requires text_config->moe_intermediate_size"
+
+        self.rope_settings_local = self.read_rope_settings_default(
+            RopeStyle.NEOX,
+            default_rope_theta = 10000.0,
+            config_dict = self.read_cfg(dict, "text_config->rope_parameters->sliding_attention", {}),
+            override_type = self.read_cfg(
+                str,
+                "text_config->rope_parameters->sliding_attention->rope_type",
+                None,
+            )
+        )
+        self.rope_settings_full = self.read_rope_settings_default(
+            RopeStyle.NEOX,
+            default_rope_theta = 1000000.0,
+            config_dict = self.read_cfg(dict, "text_config->rope_parameters->full_attention", {}),
+            override_type = self.read_cfg(
+                str,
+                "text_config->rope_parameters->full_attention->rope_type",
+                None,
+            )
+        )
+        self.rope_settings_full.head_dim = self.global_head_dim
+
+        self.vision = SimpleNamespace()
+        self.vision.hidden_size = self.read_cfg(int, "vision_config->hidden_size", no_default)
+        self.vision.intermediate_size = self.read_cfg(int, "vision_config->intermediate_size", no_default)
+        self.vision.num_hidden_layers = self.read_cfg(int, "vision_config->num_hidden_layers", no_default)
+        self.vision.num_q_heads = self.read_cfg(int, "vision_config->num_attention_heads", no_default)
+        self.vision.num_kv_heads = self.read_cfg(int, "vision_config->num_key_value_heads", self.vision.num_q_heads)
+        self.vision.head_dim = self.read_cfg(int, "vision_config->head_dim", no_default)
+        self.vision.patch_size = self.read_cfg(int, "vision_config->patch_size", no_default)
+        self.vision.pooling_kernel_size = self.read_cfg(int, "vision_config->pooling_kernel_size", no_default)
+        self.vision.position_embedding_size = self.read_cfg(int, "vision_config->position_embedding_size", no_default)
+        self.vision.rms_norm_eps = self.read_cfg(float, "vision_config->rms_norm_eps", no_default)
+        self.vision.standardize = self.read_cfg(bool, "vision_config->standardize", False)
+        self.vision.rope_theta = self.read_cfg(float, "vision_config->rope_parameters->rope_theta", 100.0)
+        self.vision.num_channels = 3
+        self.vision.patch_dim = self.vision.num_channels * self.vision.patch_size ** 2
+
+        processor_path = os.path.join(self.directory, "processor_config.json")
+        with open(processor_path, encoding = "utf8") as f:
+            processor_config = json.load(f)
+        image_processor = processor_config["image_processor"]
+
+        self.vision_pp = SimpleNamespace()
+        self.vision_pp.do_convert_rgb = image_processor["do_convert_rgb"]
+        self.vision_pp.do_rescale = image_processor["do_rescale"]
+        self.vision_pp.do_normalize = image_processor["do_normalize"]
+        self.vision_pp.image_mean = image_processor["image_mean"]
+        self.vision_pp.image_std = image_processor["image_std"]
+        self.vision_pp.resample = image_processor["resample"]
+        self.vision_pp.rescale_factor = image_processor["rescale_factor"]
+        self.vision_pp.max_soft_tokens = image_processor["max_soft_tokens"]
+        self.vision_pp.patch_size = image_processor["patch_size"]
+        self.vision_pp.pooling_kernel_size = image_processor["pooling_kernel_size"]
+        self.vision.max_patches = self.vision_pp.max_soft_tokens * (self.vision_pp.pooling_kernel_size ** 2)
+
+
+class Gemma4TextModel(Model):
+    config_class = Gemma4Config
+
+    def __init__(
+        self,
+        config: Gemma4Config,
+        **kwargs
+    ):
+        super().__init__(config, **kwargs)
+        self.caps.update({
+            "supports_tp": False,
+            "atomic_mm_prefill": True,
+        })
+
+        self.modules += [
+            Embedding(
+                config = config,
+                key = "model.language_model.embed_tokens",
+                vocab_size = config.vocab_size,
+                hidden_size = config.hidden_size,
+                multiplier = config.hidden_size ** 0.5,
+            )
+        ]
+
+        self.first_block_idx = len(self.modules)
+
+        for idx in range(config.num_hidden_layers):
+            key = f"model.language_model.layers.{idx}"
+            layer_is_full = config.layer_types[idx] == "full_attention"
+
+            attn = Gemma4Attention(
+                config = config,
+                key = f"{key}.self_attn",
+                layer_idx = idx,
+                hidden_size = config.hidden_size,
+                head_dim = config.global_head_dim if layer_is_full else config.head_dim,
+                num_q_heads = config.num_q_heads,
+                num_kv_heads = (
+                    config.num_global_kv_heads
+                    if layer_is_full and config.attention_k_eq_v
+                    else config.num_kv_heads
+                ),
+                use_k_as_v = layer_is_full and config.attention_k_eq_v,
+                v_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.self_attn.v_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    unweighted = True,
+                ),
+                rope_settings = config.rope_settings_full if layer_is_full else config.rope_settings_local,
+                sm_scale = 1.0,
+                sliding_window = config.swa_pattern[idx],
+                key_q = "q_proj",
+                key_k = "k_proj",
+                key_v = "v_proj",
+                key_o = "o_proj",
+                qmap = "block.attn",
+                logit_softcapping = config.attn_logit_softcapping,
+                q_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.self_attn.q_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                k_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.self_attn.k_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+            )
+
+            common_kwargs = dict(
+                config = config,
+                key = key,
+                layer_idx = idx,
+                attn_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.input_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                attn = attn,
+                attn_post_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.post_attention_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    out_dtype = torch.float,
+                ),
+                mlp_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.pre_feedforward_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                mlp_post_norm = RMSNorm(
+                    config = config,
+                    key = f"{key}.post_feedforward_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    out_dtype = torch.float,
+                ),
+            )
+
+            if config.enable_moe_block:
+                mlp = Gemma4MoEFeedForward(
+                    config = config,
+                    key = key,
+                    hidden_size = config.hidden_size,
+                    intermediate_size = config.intermediate_size,
+                    moe_intermediate_size = config.moe_intermediate_size,
+                    num_experts = config.num_experts,
+                    num_experts_per_tok = config.num_experts_per_tok,
+                    rms_norm_eps = config.rms_norm_eps,
+                )
+                block = Gemma4MoETransformerBlock(
+                    mlp = mlp,
+                    **common_kwargs,
+                )
+            else:
+                block = Gemma4TransformerBlock(
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"{key}.mlp",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.intermediate_size,
+                        key_up = "up_proj",
+                        key_gate = "gate_proj",
+                        key_down = "down_proj",
+                        qmap = "block.mlp",
+                        activation_fn = "gelu",
+                    ),
+                    **common_kwargs,
+                )
+
+            self.modules.append(block)
+
+        self.last_kv_module_idx = len(self.modules) - 1
+
+        self.modules += [
+            RMSNorm(
+                config = config,
+                key = "model.language_model.norm",
+                rms_norm_eps = config.rms_norm_eps,
+                out_dtype = torch.half,
+            ),
+            Linear(
+                config = config,
+                key = "lm_head",
+                qbits_key = "head_bits",
+                alt_key = "model.language_model.embed_tokens" if config.tie_word_embeddings else None,
+                in_features = config.hidden_size,
+                out_features = config.vocab_size,
+                qmap = "block",
+                softcap = config.final_logit_softcapping,
+                caps = {"logits_output": True},
+            )
+        ]
+
+        self.logit_layer_idx = len(self.modules) - 1
+
+        if config.enable_moe_block:
+            self.calibration_all_experts = True
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        _set_gemma4_vision_groups(input_ids, params, self.config.boi_token_id, self.config.eoi_token_id)
+        return prepare_for_attn(input_ids, params)
+
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        p = "<bos>"
+        if system_prompt:
+            p += f"<|turn>system\n{system_prompt}<turn|>\n"
+        p += f"<|turn>user\n{prompt}<turn|>\n"
+        p += "<|turn>model\n"
+        return p
+
+
+class Gemma4VisionModel(Model):
+
+    @staticmethod
+    @override
+    def get_additional_compiled_tensors(config: Gemma4Config) -> dict:
+        return (
+            config.stc.list_tensors(prefix = "model.vision_tower") |
+            config.stc.list_tensors(prefix = "model.embed_vision")
+        )
+
+
+    def __init__(
+        self,
+        config: Gemma4Config,
+        **kwargs,
+    ):
+        super().__init__(config, **kwargs)
+        self.config = config
+        self.caps.update({
+            "image_input": True,
+            "supports_tp": False,
+        })
+        v = self.config.vision
+
+        self.modules += [
+            Gemma4VisionPatchEmbedder(
+                config = config,
+                key = "model.vision_tower.patch_embedder",
+                hidden_size = v.hidden_size,
+                patch_dim = v.patch_dim,
+            )
+        ]
+
+        for idx in range(v.num_hidden_layers):
+            key = f"model.vision_tower.encoder.layers.{idx}"
+            self.modules.append(
+                TransformerBlock(
+                    config = config,
+                    key = key,
+                    layer_idx = idx,
+                    attn_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.input_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn = Gemma4VisionAttention(
+                        config = config,
+                        key = f"{key}.self_attn",
+                        layer_idx = idx,
+                        hidden_size = v.hidden_size,
+                        head_dim = v.head_dim,
+                        num_q_heads = v.num_q_heads,
+                        num_kv_heads = v.num_kv_heads,
+                        rope_theta = v.rope_theta,
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_attention_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                    mlp_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.pre_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"{key}.mlp",
+                        hidden_size = v.hidden_size,
+                        intermediate_size = v.intermediate_size,
+                        key_up = "up_proj.linear",
+                        key_gate = "gate_proj.linear",
+                        key_down = "down_proj.linear",
+                        activation_fn = "gelu",
+                        qmap = "block.mlp",
+                    ),
+                    mlp_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                )
+            )
+
+        self.modules += [
+            Gemma4VisionPooler(
+                config = config,
+                key = "model.vision_tower.pooler",
+                hidden_size = v.hidden_size,
+            )
+        ]
+
+        if v.standardize:
+            self.modules += [
+                Gemma4VisionStandardize(
+                    config = config,
+                    key = "model.vision_tower",
+                )
+            ]
+
+        self.modules += [
+            Gemma4VisionProjector(
+                config = config,
+                key = "model.embed_vision.embedding_projection",
+                in_features = v.hidden_size,
+                out_features = config.hidden_size,
+                rms_norm_eps = v.rms_norm_eps,
+            ),
+        ]
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        return input_ids
+
+
+    def default_load_shape_dtype(self, chunk_size):
+        return (
+            1,
+            self.config.vision.max_patches,
+            self.config.vision.patch_dim,
+        ), torch.half
+
+
+    def default_load_params(self, chunk_size):
+        h_patches = 45
+        w_patches = self.config.vision.max_patches // h_patches
+        grid_x, grid_y = np.meshgrid(np.arange(w_patches), np.arange(h_patches), indexing = "xy")
+        position_ids = np.stack([grid_x, grid_y], axis = -1).reshape(self.config.vision.max_patches, 2)
+        return {
+            "input_ids": torch.zeros((1, self.config.vision.max_patches, self.config.vision.patch_dim), dtype = torch.half),
+            "image_position_ids": torch.from_numpy(position_ids).unsqueeze(0).to(torch.long),
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+            "causal": False,
+        }
+
+
+    def preprocess(
+        self,
+        image: Image.Image,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, tuple[int, int]]:
+        vpp = self.config.vision_pp
+        image = convert_to_rgb(image)
+        old_size = image.size
+        width, height = old_size
+        target_height, target_width = _get_aspect_ratio_preserving_size(
+            height = height,
+            width = width,
+            patch_size = vpp.patch_size,
+            max_patches = self.config.vision.max_patches,
+            pooling_kernel_size = vpp.pooling_kernel_size,
+        )
+
+        if (target_width, target_height) != old_size:
+            image = image.resize((target_width, target_height), resample = Image.Resampling(vpp.resample))
+
+        image_np = np.array(image).astype(np.float32)
+        image_np = image_np.transpose(2, 0, 1)
+
+        if vpp.do_rescale:
+            image_np *= vpp.rescale_factor
+
+        if vpp.do_normalize:
+            image_mean = np.asarray(vpp.image_mean, dtype = np.float32).reshape(-1, 1, 1)
+            image_std = np.asarray(vpp.image_std, dtype = np.float32).reshape(-1, 1, 1)
+            image_np = (image_np - image_mean) / image_std
+
+        patches = _convert_image_to_patches(image_np, vpp.patch_size)
+        num_soft_tokens = patches.shape[0] // (vpp.pooling_kernel_size ** 2)
+
+        patch_height = image_np.shape[-2] // vpp.patch_size
+        patch_width = image_np.shape[-1] // vpp.patch_size
+        grid_x, grid_y = np.meshgrid(np.arange(patch_width), np.arange(patch_height), indexing = "xy")
+        positions = np.stack([grid_x, grid_y], axis = -1).reshape(patches.shape[0], 2)
+
+        patches, positions = _pad_patches_and_positions(
+            patches,
+            positions,
+            self.config.vision.max_patches,
+        )
+
+        pixel_values = torch.from_numpy(patches).half().unsqueeze(0)
+        image_position_ids = torch.from_numpy(positions).to(torch.long).unsqueeze(0)
+        return pixel_values, image_position_ids, num_soft_tokens, (target_width, target_height)
+
+
+    def get_image_embeddings(
+        self,
+        tokenizer: Tokenizer,
+        image: Image.Image | list[Image.Image],
+        text_alias: str | None = None,
+    ):
+        if isinstance(image, list):
+            assert text_alias is None, "Cannot apply a single alias to a list of images"
+            return [self.get_image_embeddings(tokenizer, i) for i in image]
+
+        pixel_values, image_position_ids, _, prep_size = self.preprocess(image)
+        params = {
+            "causal": False,
+            "image_position_ids": image_position_ids,
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+        }
+        embedding_tensor = self.forward(
+            pixel_values,
+            params = params,
+        ).cpu()
+        pooler_mask = params.get("image_pooler_mask")
+        if pooler_mask is not None:
+            pooler_mask = pooler_mask.cpu()
+            embedding_tensor = embedding_tensor[0][pooler_mask[0]].unsqueeze(0)
+            num_soft_tokens = int(pooler_mask[0].sum().item())
+        else:
+            num_soft_tokens = embedding_tensor.shape[1]
+
+        boi_token_id = tokenizer.single_id("<|image>")
+        image_token_id = tokenizer.single_id("<|image|>")
+        eoi_token_id = tokenizer.single_id("<image|>")
+        token_string = torch.tensor(
+            [[boi_token_id] + [image_token_id] * num_soft_tokens + [eoi_token_id]],
+            dtype = torch.long,
+        )
+        token_string[:, 1:-1] = -1
+
+        mme = MMEmbedding(
+            embeddings = embedding_tensor[0],
+            text_alias = text_alias,
+            token_string = token_string,
+        )
+        mme.metadata.update({
+            "original_size": image.size,
+            "preprocessed_size": prep_size,
+            "model_architecture": self.config.architecture,
+        })
+        return mme

--- a/exllamav3/architecture/gemma4_mm.py
+++ b/exllamav3/architecture/gemma4_mm.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+from PIL import Image
+from typing_extensions import override
+
+from ..model.model import Model
+from ..modules import (
+    GatedMLP,
+    RMSNorm,
+    TransformerBlock,
+    Gemma4VisionAttention,
+    Gemma4VisionPatchEmbedder,
+    Gemma4VisionPooler,
+    Gemma4VisionProjector,
+    Gemma4VisionStandardize,
+)
+from ..tokenizer import MMEmbedding, Tokenizer
+from ..util.vision import convert_to_rgb
+
+if TYPE_CHECKING:
+    from .gemma4 import Gemma4Config
+
+
+def set_gemma4_vision_groups(
+    input_ids: torch.Tensor,
+    params: dict,
+    boi_token_id: int | None,
+    eoi_token_id: int | None,
+) -> None:
+    indexed_embeddings = params.get("indexed_embeddings") or []
+    if not indexed_embeddings:
+        params.pop("vision_group_ids", None)
+        return
+
+    vision_group_ids = torch.full(input_ids.shape, -1, dtype = torch.int32)
+    group_index = 0
+    for embedding in indexed_embeddings:
+        mask = (input_ids >= embedding.first_index) & (input_ids < embedding.last_index)
+        if not mask.any():
+            continue
+
+        for row in range(input_ids.shape[0]):
+            row_mask = mask[row]
+            if not row_mask.any():
+                continue
+
+            positions = torch.nonzero(row_mask, as_tuple = False).flatten()
+            start = int(positions[0].item())
+            end = int(positions[-1].item())
+            # Gemma4's multimodal bidirectional mask groups only the soft image
+            # tokens. BOI/EOI remain text tokens in HF/vLLM and should not be
+            # merged into the vision group span.
+            vision_group_ids[row, start : end + 1] = group_index
+
+        group_index += 1
+
+    if group_index > 0:
+        params["vision_group_ids"] = vision_group_ids
+    else:
+        params.pop("vision_group_ids", None)
+
+
+def _get_aspect_ratio_preserving_size(
+    height: int,
+    width: int,
+    patch_size: int,
+    max_patches: int,
+    pooling_kernel_size: int,
+) -> tuple[int, int]:
+    total_px = height * width
+    target_px = max_patches * (patch_size ** 2)
+    factor = math.sqrt(target_px / total_px)
+    ideal_height = factor * height
+    ideal_width = factor * width
+    side_mult = pooling_kernel_size * patch_size
+
+    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
+    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
+
+    if target_height == 0 and target_width == 0:
+        raise ValueError(
+            "Attempting to resize to a 0 x 0 image. "
+            f"Resized height should be divisible by pooling_kernel_size * patch_size = {side_mult}."
+        )
+
+    max_side_length = (max_patches // (pooling_kernel_size ** 2)) * side_mult
+    if target_height == 0:
+        target_height = side_mult
+        target_width = min(int(math.floor(width / height)) * side_mult, max_side_length)
+    elif target_width == 0:
+        target_width = side_mult
+        target_height = min(int(math.floor(height / width)) * side_mult, max_side_length)
+
+    if target_height * target_width > target_px:
+        raise ValueError(
+            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] exceeds patch budget"
+        )
+
+    return target_height, target_width
+
+
+def _convert_image_to_patches(image: np.ndarray, patch_size: int) -> np.ndarray:
+    num_channels, image_height, image_width = image.shape
+    num_patches_height = image_height // patch_size
+    num_patches_width = image_width // patch_size
+    patched_image = image.reshape(num_channels, num_patches_height, patch_size, num_patches_width, patch_size)
+    patched_image = patched_image.transpose(1, 3, 2, 4, 0)
+    patched_image = patched_image.reshape(num_patches_height * num_patches_width, -1)
+    return patched_image
+
+
+def _pad_patches_and_positions(
+    patches: np.ndarray,
+    positions: np.ndarray,
+    target_length: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    current_length = patches.shape[0]
+    if current_length > target_length:
+        raise ValueError(
+            f"Cannot pad Gemma4 patches from {current_length} down to target length {target_length}"
+        )
+
+    padding_length = target_length - current_length
+    if padding_length == 0:
+        return patches, positions
+
+    patch_paddings = [(0, padding_length)] + [(0, 0)] * (patches.ndim - 1)
+    position_paddings = [(0, padding_length), (0, 0)]
+    patches = np.pad(patches, patch_paddings, mode = "constant", constant_values = 0)
+    positions = np.pad(positions, position_paddings, mode = "constant", constant_values = -1)
+    return patches, positions
+
+
+class Gemma4VisionModel(Model):
+
+    @staticmethod
+    @override
+    def get_additional_compiled_tensors(config: "Gemma4Config") -> dict:
+        return (
+            config.stc.list_tensors(prefix = "model.vision_tower") |
+            config.stc.list_tensors(prefix = "model.embed_vision")
+        )
+
+
+    def __init__(
+        self,
+        config: "Gemma4Config",
+        **kwargs,
+    ):
+        super().__init__(config, **kwargs)
+        self.config = config
+        self.caps.update({
+            "image_input": True,
+            "supports_tp": False,
+        })
+        v = self.config.vision
+
+        self.modules += [
+            Gemma4VisionPatchEmbedder(
+                config = config,
+                key = "model.vision_tower.patch_embedder",
+                hidden_size = v.hidden_size,
+                patch_dim = v.patch_dim,
+            )
+        ]
+
+        for idx in range(v.num_hidden_layers):
+            key = f"model.vision_tower.encoder.layers.{idx}"
+            self.modules.append(
+                TransformerBlock(
+                    config = config,
+                    key = key,
+                    layer_idx = idx,
+                    attn_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.input_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn = Gemma4VisionAttention(
+                        config = config,
+                        key = f"{key}.self_attn",
+                        layer_idx = idx,
+                        hidden_size = v.hidden_size,
+                        head_dim = v.head_dim,
+                        num_q_heads = v.num_q_heads,
+                        num_kv_heads = v.num_kv_heads,
+                        rope_theta = v.rope_theta,
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    attn_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_attention_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                    mlp_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.pre_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                    ),
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"{key}.mlp",
+                        hidden_size = v.hidden_size,
+                        intermediate_size = v.intermediate_size,
+                        key_up = "up_proj.linear",
+                        key_gate = "gate_proj.linear",
+                        key_down = "down_proj.linear",
+                        activation_fn = "gelu",
+                        qmap = "block.mlp",
+                    ),
+                    mlp_post_norm = RMSNorm(
+                        config = config,
+                        key = f"{key}.post_feedforward_layernorm",
+                        rms_norm_eps = v.rms_norm_eps,
+                        out_dtype = torch.float,
+                    ),
+                )
+            )
+
+        self.modules += [
+            Gemma4VisionPooler(
+                config = config,
+                key = "model.vision_tower.pooler",
+                hidden_size = v.hidden_size,
+            )
+        ]
+
+        if v.standardize:
+            self.modules += [
+                Gemma4VisionStandardize(
+                    config = config,
+                    key = "model.vision_tower",
+                )
+            ]
+
+        self.modules += [
+            Gemma4VisionProjector(
+                config = config,
+                key = "model.embed_vision.embedding_projection",
+                in_features = v.hidden_size,
+                out_features = config.hidden_size,
+                rms_norm_eps = v.rms_norm_eps,
+            ),
+        ]
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        return input_ids
+
+
+    def default_load_shape_dtype(self, chunk_size):
+        return (
+            1,
+            self.config.vision.max_patches,
+            self.config.vision.patch_dim,
+        ), torch.half
+
+
+    def default_load_params(self, chunk_size):
+        h_patches = 45
+        w_patches = self.config.vision.max_patches // h_patches
+        grid_x, grid_y = np.meshgrid(np.arange(w_patches), np.arange(h_patches), indexing = "xy")
+        position_ids = np.stack([grid_x, grid_y], axis = -1).reshape(self.config.vision.max_patches, 2)
+        return {
+            "input_ids": torch.zeros((1, self.config.vision.max_patches, self.config.vision.patch_dim), dtype = torch.half),
+            "image_position_ids": torch.from_numpy(position_ids).unsqueeze(0).to(torch.long),
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+            "causal": False,
+        }
+
+
+    def preprocess(
+        self,
+        image: Image.Image,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, tuple[int, int]]:
+        vpp = self.config.vision_pp
+        image = convert_to_rgb(image)
+        old_size = image.size
+        width, height = old_size
+        target_height, target_width = _get_aspect_ratio_preserving_size(
+            height = height,
+            width = width,
+            patch_size = vpp.patch_size,
+            max_patches = self.config.vision.max_patches,
+            pooling_kernel_size = vpp.pooling_kernel_size,
+        )
+
+        if (target_width, target_height) != old_size:
+            image = image.resize((target_width, target_height), resample = Image.Resampling(vpp.resample))
+
+        image_np = np.array(image).astype(np.float32)
+        image_np = image_np.transpose(2, 0, 1)
+
+        if vpp.do_rescale:
+            image_np *= vpp.rescale_factor
+
+        if vpp.do_normalize:
+            image_mean = np.asarray(vpp.image_mean, dtype = np.float32).reshape(-1, 1, 1)
+            image_std = np.asarray(vpp.image_std, dtype = np.float32).reshape(-1, 1, 1)
+            image_np = (image_np - image_mean) / image_std
+
+        patches = _convert_image_to_patches(image_np, vpp.patch_size)
+        num_soft_tokens = patches.shape[0] // (vpp.pooling_kernel_size ** 2)
+
+        patch_height = image_np.shape[-2] // vpp.patch_size
+        patch_width = image_np.shape[-1] // vpp.patch_size
+        grid_x, grid_y = np.meshgrid(np.arange(patch_width), np.arange(patch_height), indexing = "xy")
+        positions = np.stack([grid_x, grid_y], axis = -1).reshape(patches.shape[0], 2)
+
+        patches, positions = _pad_patches_and_positions(
+            patches,
+            positions,
+            self.config.vision.max_patches,
+        )
+
+        pixel_values = torch.from_numpy(patches).half().unsqueeze(0)
+        image_position_ids = torch.from_numpy(positions).to(torch.long).unsqueeze(0)
+        return pixel_values, image_position_ids, num_soft_tokens, (target_width, target_height)
+
+
+    def get_image_embeddings(
+        self,
+        tokenizer: Tokenizer,
+        image: Image.Image | list[Image.Image],
+        text_alias: str | None = None,
+    ):
+        if isinstance(image, list):
+            assert text_alias is None, "Cannot apply a single alias to a list of images"
+            return [self.get_image_embeddings(tokenizer, i) for i in image]
+
+        pixel_values, image_position_ids, _, prep_size = self.preprocess(image)
+        params = {
+            "causal": False,
+            "image_position_ids": image_position_ids,
+            "image_output_length": self.config.vision_pp.max_soft_tokens,
+        }
+        embedding_tensor = self.forward(
+            pixel_values,
+            params = params,
+        ).cpu()
+        pooler_mask = params.get("image_pooler_mask")
+        if pooler_mask is not None:
+            pooler_mask = pooler_mask.cpu()
+            embedding_tensor = embedding_tensor[0][pooler_mask[0]].unsqueeze(0)
+            num_soft_tokens = int(pooler_mask[0].sum().item())
+        else:
+            num_soft_tokens = embedding_tensor.shape[1]
+
+        boi_token_id = tokenizer.single_id("<|image>")
+        image_token_id = tokenizer.single_id("<|image|>")
+        eoi_token_id = tokenizer.single_id("<image|>")
+        token_string = torch.tensor(
+            [[boi_token_id] + [image_token_id] * num_soft_tokens + [eoi_token_id]],
+            dtype = torch.long,
+        )
+        token_string[:, 1:-1] = -1
+
+        mme = MMEmbedding(
+            embeddings = embedding_tensor[0],
+            text_alias = text_alias,
+            token_string = token_string,
+        )
+        mme.metadata.update({
+            "original_size": image.size,
+            "preprocessed_size": prep_size,
+            "model_architecture": self.config.architecture,
+        })
+        return mme

--- a/exllamav3/cache/cache.py
+++ b/exllamav3/cache/cache.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 
 class CacheLayer(ABC):
 
+    cache_role = "default"
+
     def __init__(
         self,
         config: Config | None,
@@ -110,14 +112,55 @@ class Cache:
 
         from .fp16 import CacheLayer_fp16
         self.layer_type = layer_type or CacheLayer_fp16
+        # Default models keep the original one-layer-class-per-cache contract.
+        # Architectures such as Gemma4 can opt into a selector at construction
+        # time to choose a different cache layer class or token budget per
+        # attention layer without changing the runtime path for other models.
+        self.layer_selector = self.model.caps.get("cache_layer_selector")
+        if self.layer_selector is None:
+            # Gemma4 uses swa_max_num_tokens via its per-layer selector. Models that
+            # stay on the original single-layer cache path should ignore this knob
+            # so their cache-layer constructors continue to see the same kwargs.
+            kwargs.pop("swa_max_num_tokens", None)
         # self.recurrent_layer_type = recurrent_layer_type or RecurrentLayer_fp16
 
         cl = self.model.get_cache_layers()
         self.num_layers = len(cl)
-        self.layers = {
-            attn.layer_idx: self.layer_type(self.config, attn, id(self), self.max_num_tokens, **kwargs)
-            for attn in cl
-        }
+        if self.layer_selector is None:
+            self.layers = {
+                attn.layer_idx: self.layer_type(self.config, attn, id(self), self.max_num_tokens, **kwargs)
+                for attn in cl
+            }
+        else:
+            # Models that opt into a selector can override the cache layer class and
+            # per-layer token budget without changing the default single-layer path.
+            self.layers = {}
+            for attn in cl:
+                layer_cls = self.layer_type
+                layer_max_num_tokens = self.max_num_tokens
+                layer_kwargs = dict(kwargs)
+                selector_kwargs = dict(kwargs)
+                selector_kwargs["max_num_tokens"] = layer_max_num_tokens
+                selected = self.layer_selector(
+                    default_layer_type = self.layer_type,
+                    attention = attn,
+                    cache_kwargs = selector_kwargs,
+                )
+                if isinstance(selected, dict):
+                    layer_cls = selected.get("layer_type", layer_cls)
+                    layer_max_num_tokens = selected.get("max_num_tokens", layer_max_num_tokens)
+                    layer_kwargs = dict(selected.get("cache_kwargs", layer_kwargs))
+                    extra_kwargs = selected.get("kwargs", {})
+                    layer_kwargs.update(extra_kwargs)
+                elif selected is not None:
+                    layer_cls = selected
+                self.layers[attn.layer_idx] = layer_cls(
+                    self.config,
+                    attn,
+                    id(self),
+                    layer_max_num_tokens,
+                    **layer_kwargs,
+                )
 
         self.attach_to_model()
 
@@ -173,6 +216,7 @@ class Cache:
         from_page: int,
         to_page: int,
         num_tokens: int,
+        page_plan: dict[str, tuple[int, int]] | None = None,
     ):
         assert target == self or (not target.model.loaded_tp and not self.model.loaded_tp), \
             "Cannot copy pages between TP and non-TP caches, or between distinct TP caches."
@@ -181,7 +225,21 @@ class Cache:
             for idx, src in self.layers.items():
                 dst = target.layers[idx]
                 assert type(src) is type(dst)
-                dst.copy_page(src, from_page, to_page, num_tokens)
+                if page_plan is None:
+                    dst.copy_page(src, from_page, to_page, num_tokens)
+                else:
+                    # Role-aware copy plans are only used by custom page tables such
+                    # as Gemma4. Non-Gemma models never pass page_plan here, so they
+                    # keep the original single-source/single-target page copy path.
+                    src_page = from_page
+                    dst_page = to_page
+                    role = getattr(src, "cache_role", "default")
+                    role_plan = page_plan.get(role)
+                    if role_plan is None:
+                        role_plan = page_plan.get("default")
+                    if role_plan is not None:
+                        src_page, dst_page = role_plan
+                    dst.copy_page(src, src_page, dst_page, num_tokens)
         else:
             self.model.tp_cache_page_copy(id(self), from_page, to_page, num_tokens)
 

--- a/exllamav3/cache/gemma4.py
+++ b/exllamav3/cache/gemma4.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Type
+
+import torch
+from typing_extensions import override
+
+from ..constants import PAGE_SIZE
+from ..ext import exllamav3_ext as ext
+from ..model import Config
+from .fp16 import CacheLayer_fp16
+from .quant import CacheLayer_quant
+
+if TYPE_CHECKING:
+    from ..modules import Attention
+
+
+def _normalize_role_max_tokens(role_max_tokens: int | None, default_max_tokens: int | None) -> int | None:
+    if role_max_tokens is None:
+        return default_max_tokens
+    if default_max_tokens is None:
+        return role_max_tokens
+    role_max_tokens = min(role_max_tokens, default_max_tokens)
+    role_max_tokens = max(PAGE_SIZE, role_max_tokens)
+    role_max_tokens = (role_max_tokens // PAGE_SIZE) * PAGE_SIZE
+    return role_max_tokens
+
+
+def _default_swa_max_tokens(attention: "Attention", default_max_tokens: int | None) -> int | None:
+    if default_max_tokens is None:
+        return None
+    sliding_window = getattr(attention, "sliding_window", -1)
+    if sliding_window is None or sliding_window < 0:
+        return default_max_tokens
+    # Mirror llama.cpp's intent: keep SWA sized to the sliding window plus a
+    # modest runtime headroom instead of inheriting the full cache budget.
+    return _normalize_role_max_tokens(sliding_window + PAGE_SIZE, default_max_tokens)
+
+
+class Gemma4QuantCacheLayer(CacheLayer_quant):
+
+    def __init__(
+        self,
+        config: Config | None,
+        attention: Attention,
+        cache_id: int,
+        max_num_tokens: int,
+        k_bits: int,
+        v_bits: int,
+    ):
+        super().__init__(config, attention, cache_id, max_num_tokens, k_bits, v_bits)
+        self.shadow_k_pages: dict[int, torch.Tensor] | None = None
+        self.shadow_v_pages: dict[int, torch.Tensor] | None = None
+
+    @override
+    def alloc(self, device: torch.device):
+        super().alloc(device)
+        self.shadow_k_pages = {}
+        self.shadow_v_pages = {}
+
+    @override
+    def free(self):
+        super().free()
+        self.shadow_k_pages = None
+        self.shadow_v_pages = None
+
+    def _ensure_shadow_page(self, page_idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self.device is not None
+        assert self.shadow_k_pages is not None and self.shadow_v_pages is not None
+        sk = self.shadow_k_pages.get(page_idx)
+        sv = self.shadow_v_pages.get(page_idx)
+        if sk is None or sv is None:
+            shape = self.shape[1:]
+            sk = torch.zeros(shape, dtype = torch.half, device = self.device)
+            sv = torch.zeros(shape, dtype = torch.half, device = self.device)
+            self.shadow_k_pages[page_idx] = sk
+            self.shadow_v_pages[page_idx] = sv
+        return sk, sv
+
+    def write_shadow_pages(
+        self,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> None:
+        bsz, seqlen, _, _ = k.shape
+        positions = (
+            cache_seqlens.to(dtype = torch.long).unsqueeze(1) +
+            torch.arange(seqlen, device = block_table.device, dtype = torch.long).unsqueeze(0)
+        )
+        page_idx = block_table.gather(1, torch.div(positions, PAGE_SIZE, rounding_mode = "floor")).reshape(-1)
+        page_pos = positions.remainder(PAGE_SIZE).reshape(-1)
+        flat_k = k.reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+        flat_v = v.reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+
+        unique_pages, inverse = torch.unique(page_idx, sorted = False, return_inverse = True)
+        for local_idx, page in enumerate(unique_pages.tolist()):
+            mask = inverse == local_idx
+            sk, sv = self._ensure_shadow_page(int(page))
+            local_pos = page_pos[mask].to(dtype = torch.long)
+            sk[local_pos] = flat_k[mask]
+            sv[local_pos] = flat_v[mask]
+
+    def gather_shadow_pages(
+        self,
+        block_table: torch.Tensor,
+        total_lens: torch.Tensor,
+        gathered_k: torch.Tensor | None = None,
+        gathered_v: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self.device is not None
+        assert self.shadow_k_pages is not None and self.shadow_v_pages is not None
+        bsz = block_table.shape[0]
+        max_total = int(total_lens.max())
+        target_shape = (bsz, max_total, self.attention.num_kv_heads, self.attention.head_dim)
+        target_shape_heads = (bsz, self.attention.num_kv_heads, max_total, self.attention.head_dim)
+        heads_first = gathered_k is not None and gathered_k.shape == target_shape_heads
+        if gathered_k is None:
+            gathered_k = torch.empty(target_shape, dtype = torch.half, device = self.device)
+        elif gathered_k.shape not in (target_shape, target_shape_heads):
+            gathered_k = torch.empty(target_shape, dtype = torch.half, device = self.device)
+            heads_first = False
+        if gathered_v is None:
+            gathered_v = torch.empty(target_shape, dtype = torch.half, device = self.device)
+        elif gathered_v.shape not in (target_shape, target_shape_heads):
+            gathered_v = torch.empty(target_shape, dtype = torch.half, device = self.device)
+            heads_first = False
+        for b in range(bsz):
+            total = int(total_lens[b])
+            if total == 0:
+                continue
+            num_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+            pages = block_table[b, :num_pages].to(dtype = torch.long).tolist()
+            shadow_k = torch.stack([self._ensure_shadow_page(page_idx)[0] for page_idx in pages], dim = 0)
+            shadow_v = torch.stack([self._ensure_shadow_page(page_idx)[1] for page_idx in pages], dim = 0)
+            flat_k = shadow_k.reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+            flat_v = shadow_v.reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+            if heads_first:
+                gathered_k[b, :, :total].copy_(flat_k[:total].transpose(0, 1), non_blocking = True)
+                gathered_v[b, :, :total].copy_(flat_v[:total].transpose(0, 1), non_blocking = True)
+            else:
+                gathered_k[b, :total].copy_(flat_k[:total], non_blocking = True)
+                gathered_v[b, :total].copy_(flat_v[:total], non_blocking = True)
+        return gathered_k, gathered_v
+
+    @override
+    def copy_page(self, source: "Gemma4QuantCacheLayer", from_page: int, to_page: int, num_tokens: int):
+        super().copy_page(source, from_page, to_page, num_tokens)
+        if (
+            source.shadow_k_pages is None or
+            source.shadow_v_pages is None or
+            self.shadow_k_pages is None or
+            self.shadow_v_pages is None
+        ):
+            return
+        src_k = source.shadow_k_pages.get(from_page)
+        src_v = source.shadow_v_pages.get(from_page)
+        if src_k is None or src_v is None:
+            return
+        dst_k, dst_v = self._ensure_shadow_page(to_page)
+        dst_k[:num_tokens].copy_(src_k[:num_tokens], non_blocking = True)
+        dst_v[:num_tokens].copy_(src_v[:num_tokens], non_blocking = True)
+
+    @override
+    def tp_export(self, plan):
+        return {
+            "cls": self.__class__,
+            "args": {
+                "cache_id": self.cache_id,
+                "max_num_tokens": self.max_num_tokens,
+                "k_bits": self.k_bits,
+                "v_bits": self.v_bits,
+            }
+        }
+
+
+class Gemma4SingleQuantCacheLayer(Gemma4QuantCacheLayer):
+
+    def _build_compact_update_index_map(
+        self,
+        cache_seqlens: torch.Tensor,
+        block_table: torch.Tensor,
+        length: int,
+        local_block_table: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        bsz, blocks_per_seq = block_table.shape
+        positions = (
+            cache_seqlens.to(dtype = torch.long).unsqueeze(1) +
+            torch.arange(length, device = block_table.device, dtype = torch.long).unsqueeze(0)
+        )
+        page_idx = torch.div(positions, PAGE_SIZE, rounding_mode = "floor")
+        page_pos = positions.remainder(PAGE_SIZE)
+
+        if local_block_table is None:
+            local_pages = bsz * blocks_per_seq
+            local_block_table = torch.arange(
+                local_pages,
+                dtype = block_table.dtype,
+                device = block_table.device,
+            ).view(bsz, blocks_per_seq)
+
+        local_page = local_block_table.gather(1, page_idx)
+        target_page = block_table.gather(1, page_idx)
+        return local_block_table, local_page, target_page, page_pos
+
+    def _stage_compact_update_inputs(
+        self,
+        cache_seqlens: torch.Tensor,
+        block_table: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        length: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert self.device is not None
+
+        bsz, blocks_per_seq = block_table.shape
+        local_pages = bsz * blocks_per_seq
+        local_block_table, local_page, _, page_pos = self._build_compact_update_index_map(
+            cache_seqlens,
+            block_table,
+            length,
+        )
+
+        staged_k = torch.empty(
+            (local_pages, PAGE_SIZE, self.attention.num_kv_heads, self.attention.head_dim),
+            dtype = torch.half,
+            device = self.device,
+        )
+        staged_v = torch.empty_like(staged_k)
+
+        flat_local_page = local_page.reshape(-1).to(dtype = torch.long)
+        flat_page_pos = page_pos.reshape(-1).to(dtype = torch.long)
+        staged_k[flat_local_page, flat_page_pos] = k.reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+        staged_v[flat_local_page, flat_page_pos] = v.reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+
+        return local_block_table, staged_k, staged_v
+
+    def _scatter_compact_quantized_updates(
+        self,
+        cache_seqlens: torch.Tensor,
+        block_table: torch.Tensor,
+        local_block_table: torch.Tensor,
+        local_qk: torch.Tensor,
+        local_qv: torch.Tensor,
+        local_sk: torch.Tensor,
+        local_sv: torch.Tensor,
+        length: int,
+    ) -> None:
+        _, local_page, target_page, page_pos = self._build_compact_update_index_map(
+            cache_seqlens,
+            block_table,
+            length,
+            local_block_table = local_block_table,
+        )
+
+        flat_local_page = local_page.reshape(-1).to(dtype = torch.long)
+        flat_target_page = target_page.reshape(-1).to(dtype = torch.long)
+        flat_page_pos = page_pos.reshape(-1).to(dtype = torch.long)
+
+        self.qk[flat_target_page, flat_page_pos] = local_qk[flat_local_page, flat_page_pos]
+        self.qv[flat_target_page, flat_page_pos] = local_qv[flat_local_page, flat_page_pos]
+        self.sk[flat_target_page, flat_page_pos] = local_sk[flat_local_page, flat_page_pos]
+        self.sv[flat_target_page, flat_page_pos] = local_sv[flat_local_page, flat_page_pos]
+
+    def get_kv_compact(
+        self,
+        total_lens: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        block_table: torch.Tensor,
+        k_delta: torch.Tensor | None = None,
+        v_delta: torch.Tensor | None = None,
+        delta_len: int = 0,
+        gathered_k: torch.Tensor | None = None,
+        gathered_v: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        bsz = block_table.shape[0]
+        max_total = int(total_lens.max())
+        target_shape = (bsz, max_total, self.attention.num_kv_heads, self.attention.head_dim)
+        target_shape_heads = (bsz, self.attention.num_kv_heads, max_total, self.attention.head_dim)
+        heads_first = gathered_k is not None and gathered_k.shape == target_shape_heads
+        if gathered_k is None:
+            gathered_k = torch.empty(target_shape, dtype = torch.half, device = self.device)
+        elif gathered_k.shape not in (target_shape, target_shape_heads):
+            gathered_k = torch.empty(target_shape, dtype = torch.half, device = self.device)
+            heads_first = False
+        if gathered_v is None:
+            gathered_v = torch.empty(target_shape, dtype = torch.half, device = self.device)
+        elif gathered_v.shape not in (target_shape, target_shape_heads):
+            gathered_v = torch.empty(target_shape, dtype = torch.half, device = self.device)
+            heads_first = False
+        if (
+            k_delta is not None and
+            v_delta is not None and
+            delta_len > 0
+        ):
+            if heads_first and hasattr(ext, "dequant_cache_paged_gather_delta_heads"):
+                ext.dequant_cache_paged_gather_delta_heads(
+                    self.qk, self.sk, k_delta.contiguous(), gathered_k,
+                    self.qv, self.sv, v_delta.contiguous(), gathered_v,
+                    cache_seqlens, block_table,
+                    PAGE_SIZE,
+                    max_total,
+                    delta_len,
+                )
+                return gathered_k, gathered_v
+            if hasattr(ext, "dequant_cache_paged_gather_delta"):
+                ext.dequant_cache_paged_gather_delta(
+                    self.qk, self.sk, k_delta.contiguous(), gathered_k,
+                    self.qv, self.sv, v_delta.contiguous(), gathered_v,
+                    cache_seqlens, block_table,
+                    PAGE_SIZE,
+                    max_total,
+                    delta_len,
+                )
+                return gathered_k, gathered_v
+
+        if heads_first and hasattr(ext, "dequant_cache_paged_gather_heads"):
+            ext.dequant_cache_paged_gather_heads(
+                self.qk, self.sk, gathered_k,
+                self.qv, self.sv, gathered_v,
+                cache_seqlens, block_table,
+                PAGE_SIZE,
+                max_total,
+            )
+        elif hasattr(ext, "dequant_cache_paged_gather"):
+            ext.dequant_cache_paged_gather(
+                self.qk, self.sk, gathered_k,
+                self.qv, self.sv, gathered_v,
+                cache_seqlens, block_table,
+                PAGE_SIZE,
+                max_total,
+            )
+        else:
+            cache_k, cache_v = self.get_kv(cache_seqlens, block_table)
+            if heads_first:
+                temp_k = torch.empty(target_shape, dtype = torch.half, device = self.device)
+                temp_v = torch.empty(target_shape, dtype = torch.half, device = self.device)
+                for b in range(bsz):
+                    total = int(cache_seqlens[b])
+                    if total == 0:
+                        continue
+                    num_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+                    pages = block_table[b, :num_pages].to(dtype = torch.long)
+                    flat_k = cache_k.index_select(0, pages).reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+                    flat_v = cache_v.index_select(0, pages).reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+                    temp_k[b, :total].copy_(flat_k[:total], non_blocking = True)
+                    temp_v[b, :total].copy_(flat_v[:total], non_blocking = True)
+                gathered_k.copy_(temp_k.transpose(1, 2), non_blocking = True)
+                gathered_v.copy_(temp_v.transpose(1, 2), non_blocking = True)
+            else:
+                for b in range(bsz):
+                    total = int(cache_seqlens[b])
+                    if total == 0:
+                        continue
+                    num_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+                    pages = block_table[b, :num_pages].to(dtype = torch.long)
+                    flat_k = cache_k.index_select(0, pages).reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+                    flat_v = cache_v.index_select(0, pages).reshape(-1, self.attention.num_kv_heads, self.attention.head_dim)
+                    gathered_k[b, :total].copy_(flat_k[:total], non_blocking = True)
+                    gathered_v[b, :total].copy_(flat_v[:total], non_blocking = True)
+
+        if k_delta is not None and v_delta is not None and delta_len > 0:
+            for b in range(bsz):
+                start = int(cache_seqlens[b])
+                if heads_first:
+                    gathered_k[b, :, start : start + delta_len].copy_(k_delta[b].transpose(0, 1), non_blocking = True)
+                    gathered_v[b, :, start : start + delta_len].copy_(v_delta[b].transpose(0, 1), non_blocking = True)
+                else:
+                    gathered_k[b, start : start + delta_len].copy_(k_delta[b], non_blocking = True)
+                    gathered_v[b, start : start + delta_len].copy_(v_delta[b], non_blocking = True)
+        return gathered_k, gathered_v
+
+    def update_kv_compact(
+        self,
+        cache_seqlens: torch.Tensor,
+        block_table: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        length: int,
+    ) -> None:
+        if k.dim() == 3:
+            bsz = k.shape[0]
+            k = k.contiguous().view(bsz, length, self.attention.num_kv_heads, self.attention.head_dim)
+            v = v.contiguous().view(bsz, length, self.attention.num_kv_heads, self.attention.head_dim)
+
+        if hasattr(ext, "quant_cache_paged_delta"):
+            ext.quant_cache_paged_delta(
+                k.contiguous(), self.qk, self.sk,
+                v.contiguous(), self.qv, self.sv,
+                cache_seqlens, block_table,
+                PAGE_SIZE,
+                length,
+            )
+            return
+
+        # quant_cache_paged expects inputs addressed in cache/page space, like the generic
+        # flash-attn path. The compact Gemma4 path only has the new delta K/V span, so stage
+        # it into a temporary local page layout, quantize there, then scatter the updated token
+        # slots back into the real cache pages.
+        local_block_table, staged_k, staged_v = self._stage_compact_update_inputs(
+            cache_seqlens,
+            block_table,
+            k,
+            v,
+            length,
+        )
+
+        local_pages = staged_k.shape[0]
+        local_qk = torch.empty(
+            (local_pages, PAGE_SIZE, self.token_dim // 32 * self.k_bits),
+            dtype = torch.int,
+            device = self.device,
+        )
+        local_qv = torch.empty(
+            (local_pages, PAGE_SIZE, self.token_dim // 32 * self.v_bits),
+            dtype = torch.int,
+            device = self.device,
+        )
+        local_sk = torch.empty(
+            (local_pages, PAGE_SIZE, self.token_dim // 32),
+            dtype = torch.half,
+            device = self.device,
+        )
+        local_sv = torch.empty_like(local_sk)
+
+        ext.quant_cache_paged(
+            staged_k, local_qk, local_sk,
+            staged_v, local_qv, local_sv,
+            cache_seqlens, local_block_table,
+            PAGE_SIZE,
+            length,
+        )
+
+        self._scatter_compact_quantized_updates(
+            cache_seqlens,
+            block_table,
+            local_block_table,
+            local_qk,
+            local_qv,
+            local_sk,
+            local_sv,
+            length,
+        )
+
+
+class Gemma4FullQuantCacheLayer(Gemma4SingleQuantCacheLayer):
+    cache_role = "full"
+
+
+class Gemma4SWAQuantCacheLayer(Gemma4SingleQuantCacheLayer):
+    cache_role = "swa"
+
+
+class Gemma4FullCacheLayer(CacheLayer_fp16):
+    cache_role = "full"
+
+    @override
+    def tp_export(self, plan):
+        return {
+            "cls": self.__class__,
+            "args": {
+                "cache_id": self.cache_id,
+                "max_num_tokens": self.max_num_tokens,
+            }
+        }
+
+
+class Gemma4SWACacheLayer(CacheLayer_fp16):
+    cache_role = "swa"
+
+    @override
+    def tp_export(self, plan):
+        return {
+            "cls": self.__class__,
+            "args": {
+                "cache_id": self.cache_id,
+                "max_num_tokens": self.max_num_tokens,
+            }
+        }
+
+
+def select_gemma4_cache_layer(
+    default_layer_type: Type[CacheLayer_fp16 | CacheLayer_quant],
+    attention: Attention,
+    layer_types: list[str],
+    cache_kwargs: dict | None = None,
+):
+    layer_type = layer_types[attention.layer_idx]
+    cache_kwargs = cache_kwargs or {}
+    layer_cache_kwargs = dict(cache_kwargs)
+    layer_max_num_tokens = cache_kwargs.get("max_num_tokens")
+    selected = None
+
+    if layer_type == "full_attention":
+        full_max_num_tokens = cache_kwargs.get("full_max_num_tokens")
+        layer_max_num_tokens = _normalize_role_max_tokens(full_max_num_tokens, layer_max_num_tokens)
+    else:
+        swa_max_num_tokens = cache_kwargs.get("swa_max_num_tokens")
+        if swa_max_num_tokens is None:
+            swa_max_num_tokens = _default_swa_max_tokens(attention, layer_max_num_tokens)
+        layer_max_num_tokens = _normalize_role_max_tokens(swa_max_num_tokens, layer_max_num_tokens)
+
+    layer_cache_kwargs.pop("swa_max_num_tokens", None)
+    layer_cache_kwargs.pop("full_max_num_tokens", None)
+    layer_cache_kwargs.pop("max_num_tokens", None)
+
+    if issubclass(default_layer_type, CacheLayer_quant):
+        selected = Gemma4FullQuantCacheLayer if layer_type == "full_attention" else Gemma4SWAQuantCacheLayer
+
+    elif issubclass(default_layer_type, CacheLayer_fp16):
+        selected = Gemma4FullCacheLayer if layer_type == "full_attention" else Gemma4SWACacheLayer
+
+    if selected is None:
+        return default_layer_type
+
+    if layer_max_num_tokens is None and layer_cache_kwargs == cache_kwargs:
+        return selected
+
+    result = {
+        "layer_type": selected,
+        "cache_kwargs": layer_cache_kwargs,
+    }
+    if layer_max_num_tokens is not None:
+        result["max_num_tokens"] = layer_max_num_tokens
+    return result

--- a/exllamav3/exllamav3_ext/bindings.cpp
+++ b/exllamav3/exllamav3_ext/bindings.cpp
@@ -128,7 +128,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("quant_cache_cont", &quant_cache_cont, "quant_cache_cont");
     m.def("dequant_cache_cont", &dequant_cache_cont, "dequant_cache_cont");
     m.def("quant_cache_paged", &quant_cache_paged, "quant_cache_paged");
+    m.def("quant_cache_paged_delta", &quant_cache_paged_delta, "quant_cache_paged_delta");
     m.def("dequant_cache_paged", &dequant_cache_paged, "dequant_cache_paged");
+    m.def("dequant_cache_paged_gather", &dequant_cache_paged_gather, "dequant_cache_paged_gather");
+    m.def("dequant_cache_paged_gather_heads", &dequant_cache_paged_gather_heads, "dequant_cache_paged_gather_heads");
+    m.def("dequant_cache_paged_gather_delta", &dequant_cache_paged_gather_delta, "dequant_cache_paged_gather_delta");
+    m.def("dequant_cache_paged_gather_delta_heads", &dequant_cache_paged_gather_delta_heads, "dequant_cache_paged_gather_delta_heads");
+    m.def("dequant_cache_paged_select_delta_heads", &dequant_cache_paged_select_delta_heads, "dequant_cache_paged_select_delta_heads");
 
     m.def("count_inf_nan", &count_inf_nan, "count_inf_nan");
     m.def("histogram", &histogram, "histogram");

--- a/exllamav3/exllamav3_ext/cache/q_cache.cu
+++ b/exllamav3/exllamav3_ext/cache/q_cache.cu
@@ -169,6 +169,75 @@ void quant_cache_paged
     cuda_check(cudaPeekAtLastError());
 }
 
+void quant_cache_paged_delta
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_out,
+    const at::Tensor& k_out_scales,
+    const at::Tensor& v_in,
+    const at::Tensor& v_out,
+    const at::Tensor& v_out_scales,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(k_in.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK_DTYPE(k_in, kHalf);
+    TORCH_CHECK_DTYPE(k_out, kInt);
+    TORCH_CHECK_DTYPE(k_out_scales, kHalf);
+    TORCH_CHECK_DTYPE(v_in, kHalf);
+    TORCH_CHECK_DTYPE(v_out, kInt);
+    TORCH_CHECK_DTYPE(v_out_scales, kHalf);
+    TORCH_CHECK_SHAPES_FULL(k_in, v_in);
+    TORCH_CHECK_SHAPES_FULL(k_out_scales, v_out_scales);
+    TORCH_CHECK(page_size == CQ_PAGE_SIZE, "Page size mismatch");
+
+    int dim;
+    if (k_in.dim() == 4)
+        dim = k_in.size(2) * k_in.size(3);
+    else if (k_in.dim() == 3)
+        dim = k_in.size(2);
+    else
+        TORCH_CHECK(false, "paged cache must be 3D or 4D");
+
+    int warps_per_token = dim / 32;
+    TORCH_CHECK(dim == 32 * warps_per_token, "dim must be a multiple of 32");
+    int tb_per_token = CEIL_DIVIDE(warps_per_token, MAX_WARPS);
+    int tb_usage = CEIL_DIVIDE(warps_per_token, tb_per_token);
+
+    TORCH_CHECK(k_out.dim() == 3 && v_out.dim() == 3, "paged q.cache must have shape (num_pages, page_size, dim // 32 * bitrate)");
+    int k_bits = k_out.size(2) / warps_per_token;
+    int v_bits = v_out.size(2) / warps_per_token;
+
+    int bsz = block_table.size(0);
+    int blocks_per_seq = block_table.size(1);
+
+    dim3 blocks(tb_per_token, seq_len, bsz);
+    dim3 threads(32 * tb_usage);
+
+    TORCH_CHECK(2 <= k_bits && k_bits <= 8 && 2 <= v_bits && v_bits <= 8, "no kernel for K/V bitrate");
+
+    quant_cache_paged_delta_kernel_instances[k_bits - 2][v_bits - 2]<<<blocks, threads, 0, stream>>>
+    (
+        (const half*) k_in.data_ptr(),
+        (uint32_t*) k_out.data_ptr(),
+        (half*) k_out_scales.data_ptr(),
+        (const half*) v_in.data_ptr(),
+        (uint32_t*) v_out.data_ptr(),
+        (half*) v_out_scales.data_ptr(),
+        (const uint32_t*) cache_seqlens.data_ptr(),
+        (const uint32_t*) block_table.data_ptr(),
+        blocks_per_seq,
+        dim,
+        seq_len
+    );
+    cuda_check(cudaPeekAtLastError());
+}
+
 /*
 Dequantize paged tensor
 
@@ -248,6 +317,427 @@ void dequant_cache_paged
         pages_per_seq,
         warps_per_token,
         num_blocks
+    );
+    cuda_check(cudaPeekAtLastError());
+}
+
+void dequant_cache_paged_gather
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(k_in.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK_DTYPE(k_in, kInt);
+    TORCH_CHECK_DTYPE(k_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(k_out, kHalf);
+    TORCH_CHECK_DTYPE(v_in, kInt);
+    TORCH_CHECK_DTYPE(v_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(v_out, kHalf);
+    TORCH_CHECK_SHAPES_FULL(k_in_scales, v_in_scales);
+    TORCH_CHECK_SHAPES_FULL(k_out, v_out);
+    TORCH_CHECK(page_size == CQ_PAGE_SIZE, "Page size mismatch");
+
+    int dim;
+    if (k_out.dim() == 4)
+        dim = k_out.size(2) * k_out.size(3);
+    else if (k_out.dim() == 3)
+        dim = k_out.size(2);
+    else
+        TORCH_CHECK(false, "paged cache output must be 3D or 4D");
+
+    int warps_per_token = dim / 32;
+    TORCH_CHECK(dim == 32 * warps_per_token, "dim must be a multiple of 32");
+    int tb_per_token = CEIL_DIVIDE(warps_per_token, MAX_WARPS);
+    int tb_usage = CEIL_DIVIDE(warps_per_token, tb_per_token);
+
+    TORCH_CHECK(k_in.dim() == 3 && v_in.dim() == 3, "paged q.cache must have shape (num_pages, page_size, dim // 32 * bitrate)");
+    int k_bits = k_in.size(2) / warps_per_token;
+    int v_bits = v_in.size(2) / warps_per_token;
+
+    int bsz = block_table.size(0);
+    int blocks_per_seq = block_table.size(1);
+
+    dim3 blocks(tb_per_token, seq_len, bsz);
+    dim3 threads(32 * tb_usage);
+
+    TORCH_CHECK(2 <= k_bits && k_bits <= 8 && 2 <= v_bits && v_bits <= 8, "no kernel for K/V bitrate");
+
+    dequant_cache_paged_gather_kernel_instances[k_bits - 2][v_bits - 2]<<<blocks, threads, 0, stream>>>
+    (
+        (const uint32_t*) k_in.data_ptr(),
+        (const half*) k_in_scales.data_ptr(),
+        (half*) k_out.data_ptr(),
+        (const uint32_t*) v_in.data_ptr(),
+        (const half*) v_in_scales.data_ptr(),
+        (half*) v_out.data_ptr(),
+        (const uint32_t*) cache_seqlens.data_ptr(),
+        (const uint32_t*) block_table.data_ptr(),
+        blocks_per_seq,
+        dim,
+        seq_len
+    );
+    cuda_check(cudaPeekAtLastError());
+}
+
+void dequant_cache_paged_gather_heads
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(k_in.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK_DTYPE(k_in, kInt);
+    TORCH_CHECK_DTYPE(k_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(k_out, kHalf);
+    TORCH_CHECK_DTYPE(v_in, kInt);
+    TORCH_CHECK_DTYPE(v_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(v_out, kHalf);
+    TORCH_CHECK_SHAPES_FULL(k_in_scales, v_in_scales);
+    TORCH_CHECK_SHAPES_FULL(k_out, v_out);
+    TORCH_CHECK(page_size == CQ_PAGE_SIZE, "Page size mismatch");
+
+    TORCH_CHECK(k_out.dim() == 4, "heads-first paged cache output must be 4D");
+    TORCH_CHECK(k_out.size(2) == seq_len, "heads-first output seq_len mismatch");
+
+    int num_kv_heads = k_out.size(1);
+    int head_dim = k_out.size(3);
+    int dim = num_kv_heads * head_dim;
+    int warps_per_token = dim / 32;
+    TORCH_CHECK(dim == 32 * warps_per_token, "dim must be a multiple of 32");
+    TORCH_CHECK(head_dim % 32 == 0, "head_dim must be a multiple of 32");
+    int tb_per_token = CEIL_DIVIDE(warps_per_token, MAX_WARPS);
+    int tb_usage = CEIL_DIVIDE(warps_per_token, tb_per_token);
+
+    TORCH_CHECK(k_in.dim() == 3 && v_in.dim() == 3, "paged q.cache must have shape (num_pages, page_size, dim // 32 * bitrate)");
+    int k_bits = k_in.size(2) / warps_per_token;
+    int v_bits = v_in.size(2) / warps_per_token;
+
+    int bsz = block_table.size(0);
+    int blocks_per_seq = block_table.size(1);
+
+    dim3 blocks(tb_per_token, seq_len, bsz);
+    dim3 threads(32 * tb_usage);
+
+    TORCH_CHECK(2 <= k_bits && k_bits <= 8 && 2 <= v_bits && v_bits <= 8, "no kernel for K/V bitrate");
+
+    dequant_cache_paged_gather_heads_kernel_instances[k_bits - 2][v_bits - 2]<<<blocks, threads, 0, stream>>>
+    (
+        (const uint32_t*) k_in.data_ptr(),
+        (const half*) k_in_scales.data_ptr(),
+        (half*) k_out.data_ptr(),
+        (const uint32_t*) v_in.data_ptr(),
+        (const half*) v_in_scales.data_ptr(),
+        (half*) v_out.data_ptr(),
+        (const uint32_t*) cache_seqlens.data_ptr(),
+        (const uint32_t*) block_table.data_ptr(),
+        blocks_per_seq,
+        dim,
+        seq_len,
+        num_kv_heads,
+        head_dim
+    );
+    cuda_check(cudaPeekAtLastError());
+}
+
+void dequant_cache_paged_gather_delta
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_delta,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_delta,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len,
+    int delta_len
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(k_in.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK_DTYPE(k_in, kInt);
+    TORCH_CHECK_DTYPE(k_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(k_delta, kHalf);
+    TORCH_CHECK_DTYPE(k_out, kHalf);
+    TORCH_CHECK_DTYPE(v_in, kInt);
+    TORCH_CHECK_DTYPE(v_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(v_delta, kHalf);
+    TORCH_CHECK_DTYPE(v_out, kHalf);
+    TORCH_CHECK_SHAPES_FULL(k_in_scales, v_in_scales);
+    TORCH_CHECK_SHAPES_FULL(k_delta, v_delta);
+    TORCH_CHECK_SHAPES_FULL(k_out, v_out);
+    TORCH_CHECK(page_size == CQ_PAGE_SIZE, "Page size mismatch");
+
+    int dim;
+    if (k_out.dim() == 4)
+        dim = k_out.size(2) * k_out.size(3);
+    else if (k_out.dim() == 3)
+        dim = k_out.size(2);
+    else
+        TORCH_CHECK(false, "paged cache output must be 3D or 4D");
+
+    int delta_dim;
+    if (k_delta.dim() == 4)
+        delta_dim = k_delta.size(2) * k_delta.size(3);
+    else if (k_delta.dim() == 3)
+        delta_dim = k_delta.size(2);
+    else
+        TORCH_CHECK(false, "delta cache input must be 3D or 4D");
+
+    TORCH_CHECK(delta_dim == dim, "delta dim must match output dim");
+
+    int warps_per_token = dim / 32;
+    TORCH_CHECK(dim == 32 * warps_per_token, "dim must be a multiple of 32");
+    int tb_per_token = CEIL_DIVIDE(warps_per_token, MAX_WARPS);
+    int tb_usage = CEIL_DIVIDE(warps_per_token, tb_per_token);
+
+    TORCH_CHECK(k_in.dim() == 3 && v_in.dim() == 3, "paged q.cache must have shape (num_pages, page_size, dim // 32 * bitrate)");
+    int k_bits = k_in.size(2) / warps_per_token;
+    int v_bits = v_in.size(2) / warps_per_token;
+
+    int bsz = block_table.size(0);
+    int blocks_per_seq = block_table.size(1);
+
+    dim3 blocks(tb_per_token, seq_len, bsz);
+    dim3 threads(32 * tb_usage);
+
+    TORCH_CHECK(2 <= k_bits && k_bits <= 8 && 2 <= v_bits && v_bits <= 8, "no kernel for K/V bitrate");
+
+    dequant_cache_paged_gather_delta_kernel_instances[k_bits - 2][v_bits - 2]<<<blocks, threads, 0, stream>>>
+    (
+        (const uint32_t*) k_in.data_ptr(),
+        (const half*) k_in_scales.data_ptr(),
+        (const half*) k_delta.data_ptr(),
+        (half*) k_out.data_ptr(),
+        (const uint32_t*) v_in.data_ptr(),
+        (const half*) v_in_scales.data_ptr(),
+        (const half*) v_delta.data_ptr(),
+        (half*) v_out.data_ptr(),
+        (const uint32_t*) cache_seqlens.data_ptr(),
+        (const uint32_t*) block_table.data_ptr(),
+        blocks_per_seq,
+        dim,
+        seq_len,
+        delta_len
+    );
+    cuda_check(cudaPeekAtLastError());
+}
+
+void dequant_cache_paged_gather_delta_heads
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_delta,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_delta,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len,
+    int delta_len
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(k_in.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK_DTYPE(k_in, kInt);
+    TORCH_CHECK_DTYPE(k_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(k_delta, kHalf);
+    TORCH_CHECK_DTYPE(k_out, kHalf);
+    TORCH_CHECK_DTYPE(v_in, kInt);
+    TORCH_CHECK_DTYPE(v_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(v_delta, kHalf);
+    TORCH_CHECK_DTYPE(v_out, kHalf);
+    TORCH_CHECK_SHAPES_FULL(k_in_scales, v_in_scales);
+    TORCH_CHECK_SHAPES_FULL(k_delta, v_delta);
+    TORCH_CHECK_SHAPES_FULL(k_out, v_out);
+    TORCH_CHECK(page_size == CQ_PAGE_SIZE, "Page size mismatch");
+
+    TORCH_CHECK(k_out.dim() == 4, "heads-first paged cache output must be 4D");
+    TORCH_CHECK(k_out.size(2) == seq_len, "heads-first output seq_len mismatch");
+
+    int num_kv_heads = k_out.size(1);
+    int head_dim = k_out.size(3);
+    int dim = num_kv_heads * head_dim;
+    int delta_dim;
+    if (k_delta.dim() == 4)
+        delta_dim = k_delta.size(2) * k_delta.size(3);
+    else if (k_delta.dim() == 3)
+        delta_dim = k_delta.size(2);
+    else
+        TORCH_CHECK(false, "delta cache input must be 3D or 4D");
+
+    TORCH_CHECK(delta_dim == dim, "delta dim must match output dim");
+    TORCH_CHECK(head_dim % 32 == 0, "head_dim must be a multiple of 32");
+
+    int warps_per_token = dim / 32;
+    TORCH_CHECK(dim == 32 * warps_per_token, "dim must be a multiple of 32");
+    int tb_per_token = CEIL_DIVIDE(warps_per_token, MAX_WARPS);
+    int tb_usage = CEIL_DIVIDE(warps_per_token, tb_per_token);
+
+    TORCH_CHECK(k_in.dim() == 3 && v_in.dim() == 3, "paged q.cache must have shape (num_pages, page_size, dim // 32 * bitrate)");
+    int k_bits = k_in.size(2) / warps_per_token;
+    int v_bits = v_in.size(2) / warps_per_token;
+
+    int bsz = block_table.size(0);
+    int blocks_per_seq = block_table.size(1);
+
+    dim3 blocks(tb_per_token, seq_len, bsz);
+    dim3 threads(32 * tb_usage);
+
+    TORCH_CHECK(2 <= k_bits && k_bits <= 8 && 2 <= v_bits && v_bits <= 8, "no kernel for K/V bitrate");
+
+    dequant_cache_paged_gather_delta_heads_kernel_instances[k_bits - 2][v_bits - 2]<<<blocks, threads, 0, stream>>>
+    (
+        (const uint32_t*) k_in.data_ptr(),
+        (const half*) k_in_scales.data_ptr(),
+        (const half*) k_delta.data_ptr(),
+        (half*) k_out.data_ptr(),
+        (const uint32_t*) v_in.data_ptr(),
+        (const half*) v_in_scales.data_ptr(),
+        (const half*) v_delta.data_ptr(),
+        (half*) v_out.data_ptr(),
+        (const uint32_t*) cache_seqlens.data_ptr(),
+        (const uint32_t*) block_table.data_ptr(),
+        blocks_per_seq,
+        dim,
+        seq_len,
+        delta_len,
+        num_kv_heads,
+        head_dim
+    );
+    cuda_check(cudaPeekAtLastError());
+}
+
+void dequant_cache_paged_select_delta_heads
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_delta,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_delta,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    const at::Tensor& selected_positions,
+    const at::Tensor& selected_counts,
+    int page_size,
+    int seq_len,
+    int delta_len
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(k_in.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK_DTYPE(k_in, kInt);
+    TORCH_CHECK_DTYPE(k_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(k_delta, kHalf);
+    TORCH_CHECK_DTYPE(k_out, kHalf);
+    TORCH_CHECK_DTYPE(v_in, kInt);
+    TORCH_CHECK_DTYPE(v_in_scales, kHalf);
+    TORCH_CHECK_DTYPE(v_delta, kHalf);
+    TORCH_CHECK_DTYPE(v_out, kHalf);
+    TORCH_CHECK_DTYPE(cache_seqlens, kInt);
+    TORCH_CHECK_DTYPE(block_table, kInt);
+    TORCH_CHECK_DTYPE(selected_positions, kInt);
+    TORCH_CHECK_DTYPE(selected_counts, kInt);
+    TORCH_CHECK_SHAPES_FULL(k_in_scales, v_in_scales);
+    TORCH_CHECK_SHAPES_FULL(k_delta, v_delta);
+    TORCH_CHECK_SHAPES_FULL(k_out, v_out);
+    TORCH_CHECK(page_size == CQ_PAGE_SIZE, "Page size mismatch");
+
+    TORCH_CHECK(k_out.dim() == 4, "heads-first paged cache output must be 4D");
+    TORCH_CHECK(k_out.size(2) == seq_len, "heads-first output seq_len mismatch");
+    TORCH_CHECK(selected_positions.dim() == 2, "selected_positions must have shape (bsz, max_selected)");
+    TORCH_CHECK(selected_counts.dim() == 1, "selected_counts must have shape (bsz)");
+
+    int bsz = block_table.size(0);
+    TORCH_CHECK(selected_positions.size(0) == bsz, "selected_positions batch mismatch");
+    TORCH_CHECK(selected_counts.size(0) == bsz, "selected_counts batch mismatch");
+
+    int max_selected = selected_positions.size(1);
+    TORCH_CHECK(seq_len == max_selected, "selected gather seq_len mismatch");
+
+    int num_kv_heads = k_out.size(1);
+    int head_dim = k_out.size(3);
+    int dim = num_kv_heads * head_dim;
+    int delta_dim;
+    if (k_delta.dim() == 4)
+        delta_dim = k_delta.size(2) * k_delta.size(3);
+    else if (k_delta.dim() == 3)
+        delta_dim = k_delta.size(2);
+    else
+        TORCH_CHECK(false, "delta cache input must be 3D or 4D");
+
+    TORCH_CHECK(delta_dim == dim, "delta dim must match output dim");
+    TORCH_CHECK(head_dim % 32 == 0, "head_dim must be a multiple of 32");
+
+    int warps_per_token = dim / 32;
+    TORCH_CHECK(dim == 32 * warps_per_token, "dim must be a multiple of 32");
+    int tb_per_token = CEIL_DIVIDE(warps_per_token, MAX_WARPS);
+    int tb_usage = CEIL_DIVIDE(warps_per_token, tb_per_token);
+
+    TORCH_CHECK(k_in.dim() == 3 && v_in.dim() == 3, "paged q.cache must have shape (num_pages, page_size, dim // 32 * bitrate)");
+    int k_bits = k_in.size(2) / warps_per_token;
+    int v_bits = v_in.size(2) / warps_per_token;
+    int blocks_per_seq = block_table.size(1);
+
+    dim3 blocks(tb_per_token, max_selected, bsz);
+    dim3 threads(32 * tb_usage);
+
+    TORCH_CHECK(2 <= k_bits && k_bits <= 8 && 2 <= v_bits && v_bits <= 8, "no kernel for K/V bitrate");
+
+    dequant_cache_paged_select_delta_heads_kernel_instances[k_bits - 2][v_bits - 2]<<<blocks, threads, 0, stream>>>
+    (
+        (const uint32_t*) k_in.data_ptr(),
+        (const half*) k_in_scales.data_ptr(),
+        (const half*) k_delta.data_ptr(),
+        (half*) k_out.data_ptr(),
+        (const uint32_t*) v_in.data_ptr(),
+        (const half*) v_in_scales.data_ptr(),
+        (const half*) v_delta.data_ptr(),
+        (half*) v_out.data_ptr(),
+        (const uint32_t*) cache_seqlens.data_ptr(),
+        (const uint32_t*) block_table.data_ptr(),
+        (const uint32_t*) selected_positions.data_ptr(),
+        (const uint32_t*) selected_counts.data_ptr(),
+        blocks_per_seq,
+        dim,
+        seq_len,
+        delta_len,
+        max_selected,
+        num_kv_heads,
+        head_dim
     );
     cuda_check(cudaPeekAtLastError());
 }

--- a/exllamav3/exllamav3_ext/cache/q_cache.cuh
+++ b/exllamav3/exllamav3_ext/cache/q_cache.cuh
@@ -30,6 +30,20 @@ void quant_cache_paged
     int seq_len
 );
 
+void quant_cache_paged_delta
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_out,
+    const at::Tensor& k_out_scales,
+    const at::Tensor& v_in,
+    const at::Tensor& v_out,
+    const at::Tensor& v_out_scales,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len
+);
+
 void dequant_cache_paged
 (
     const at::Tensor& k_in,
@@ -41,4 +55,85 @@ void dequant_cache_paged
     const at::Tensor& cache_seqlens,
     const at::Tensor& block_table,
     int page_size
+);
+
+void dequant_cache_paged_gather
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len
+);
+
+void dequant_cache_paged_gather_heads
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len
+);
+
+void dequant_cache_paged_gather_delta
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_delta,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_delta,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len,
+    int delta_len
+);
+
+void dequant_cache_paged_gather_delta_heads
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_delta,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_delta,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    int page_size,
+    int seq_len,
+    int delta_len
+);
+
+void dequant_cache_paged_select_delta_heads
+(
+    const at::Tensor& k_in,
+    const at::Tensor& k_in_scales,
+    const at::Tensor& k_delta,
+    const at::Tensor& k_out,
+    const at::Tensor& v_in,
+    const at::Tensor& v_in_scales,
+    const at::Tensor& v_delta,
+    const at::Tensor& v_out,
+    const at::Tensor& cache_seqlens,
+    const at::Tensor& block_table,
+    const at::Tensor& selected_positions,
+    const at::Tensor& selected_counts,
+    int page_size,
+    int seq_len,
+    int delta_len
 );

--- a/exllamav3/exllamav3_ext/cache/q_cache_kernels.cuh
+++ b/exllamav3/exllamav3_ext/cache/q_cache_kernels.cuh
@@ -199,6 +199,51 @@ constexpr auto quant_cache_paged_kernel_instances = std::array
 
 template <int k_bits, int v_bits>
 __global__ __launch_bounds__(MAX_WARPS * 32)
+void quant_cache_paged_delta_kernel
+(
+    const half* __restrict__ k_in,
+    uint32_t* __restrict__ k_out,
+    half* __restrict__ k_out_scales,
+    const half* __restrict__ v_in,
+    uint32_t* __restrict__ v_out,
+    half* __restrict__ v_out_scales,
+    const uint32_t* __restrict__ cache_seqlens,
+    const uint32_t* __restrict__ block_table,
+    const int blocks_per_seq,
+    const int token_dim,
+    const int seq_len
+)
+{
+    int batch_idx = blockIdx.z;
+    int delta_token_idx = blockIdx.y;
+    int token_idx = delta_token_idx + cache_seqlens[batch_idx];
+    int page_idx = token_idx / CQ_PAGE_SIZE;
+    int token_pos = block_table[blocks_per_seq * batch_idx + page_idx] * CQ_PAGE_SIZE + (token_idx % CQ_PAGE_SIZE);
+    int input_pos = (batch_idx * seq_len + delta_token_idx) * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+    int output_pos = token_pos * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+    int sub_pos_in = input_pos / 32;
+    int sub_pos_out = output_pos / 32;
+
+    quant_block<k_bits>(k_in + sub_pos_in * 32, k_out + sub_pos_out * k_bits, k_out_scales + sub_pos_out);
+    quant_block<v_bits>(v_in + sub_pos_in * 32, v_out + sub_pos_out * v_bits, v_out_scales + sub_pos_out);
+}
+
+#define __(i, j) quant_cache_paged_delta_kernel<i, j>
+constexpr auto quant_cache_paged_delta_kernel_instances = std::array
+{
+    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
+    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
+    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
+    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
+    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
+    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
+    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
+};
+#undef __
+
+
+template <int k_bits, int v_bits>
+__global__ __launch_bounds__(MAX_WARPS * 32)
 void dequant_cache_paged_kernel
 (
     const uint32_t* __restrict__ k_in,
@@ -241,6 +286,301 @@ void dequant_cache_paged_kernel
 
 #define __(i, j) dequant_cache_paged_kernel<i, j>
 constexpr auto dequant_cache_paged_kernel_instances = std::array
+{
+    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
+    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
+    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
+    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
+    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
+    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
+    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
+};
+#undef __
+
+
+template <int k_bits, int v_bits>
+__global__ __launch_bounds__(MAX_WARPS * 32)
+void dequant_cache_paged_gather_kernel
+(
+    const uint32_t* __restrict__ k_in,
+    const half* __restrict__ k_in_scales,
+    half* __restrict__ k_out,
+    const uint32_t* __restrict__ v_in,
+    const half* __restrict__ v_in_scales,
+    half* __restrict__ v_out,
+    const uint32_t* __restrict__ cache_seqlens,
+    const uint32_t* __restrict__ block_table,
+    const int blocks_per_seq,
+    const int token_dim,
+    const int seq_len
+)
+{
+    int batch_idx = blockIdx.z;
+    int token_idx = blockIdx.y;
+    int max_token_idx = cache_seqlens[batch_idx];
+    if (token_idx >= max_token_idx) return;
+
+    int page_idx = token_idx / CQ_PAGE_SIZE;
+    int token_pos = block_table[blocks_per_seq * batch_idx + page_idx] * CQ_PAGE_SIZE + (token_idx % CQ_PAGE_SIZE);
+    int input_pos = token_pos * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+    int output_pos = (batch_idx * seq_len + token_idx) * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+    int sub_pos_in = input_pos / 32;
+    int sub_pos_out = output_pos / 32;
+
+    dequant_block<k_bits>(k_in + sub_pos_in * k_bits, k_in_scales + sub_pos_in, k_out + sub_pos_out * 32);
+    dequant_block<v_bits>(v_in + sub_pos_in * v_bits, v_in_scales + sub_pos_in, v_out + sub_pos_out * 32);
+}
+
+#define __(i, j) dequant_cache_paged_gather_kernel<i, j>
+constexpr auto dequant_cache_paged_gather_kernel_instances = std::array
+{
+    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
+    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
+    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
+    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
+    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
+    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
+    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
+};
+#undef __
+
+template <int k_bits, int v_bits>
+__global__ __launch_bounds__(MAX_WARPS * 32)
+void dequant_cache_paged_gather_heads_kernel
+(
+    const uint32_t* __restrict__ k_in,
+    const half* __restrict__ k_in_scales,
+    half* __restrict__ k_out,
+    const uint32_t* __restrict__ v_in,
+    const half* __restrict__ v_in_scales,
+    half* __restrict__ v_out,
+    const uint32_t* __restrict__ cache_seqlens,
+    const uint32_t* __restrict__ block_table,
+    const int blocks_per_seq,
+    const int token_dim,
+    const int seq_len,
+    const int num_kv_heads,
+    const int head_dim
+)
+{
+    int batch_idx = blockIdx.z;
+    int token_idx = blockIdx.y;
+    int max_token_idx = cache_seqlens[batch_idx];
+    if (token_idx >= max_token_idx) return;
+
+    int page_idx = token_idx / CQ_PAGE_SIZE;
+    int token_pos = block_table[blocks_per_seq * batch_idx + page_idx] * CQ_PAGE_SIZE + (token_idx % CQ_PAGE_SIZE);
+    int channel = blockDim.x * blockIdx.x + threadIdx.x;
+    int input_pos = token_pos * token_dim + channel;
+    int head_idx = channel / head_dim;
+    int head_offset = channel - head_idx * head_dim;
+    int output_pos = ((batch_idx * num_kv_heads + head_idx) * seq_len + token_idx) * head_dim + head_offset;
+    int sub_pos_in = input_pos / 32;
+    int sub_pos_out = output_pos / 32;
+
+    dequant_block<k_bits>(k_in + sub_pos_in * k_bits, k_in_scales + sub_pos_in, k_out + sub_pos_out * 32);
+    dequant_block<v_bits>(v_in + sub_pos_in * v_bits, v_in_scales + sub_pos_in, v_out + sub_pos_out * 32);
+}
+
+#define __(i, j) dequant_cache_paged_gather_heads_kernel<i, j>
+constexpr auto dequant_cache_paged_gather_heads_kernel_instances = std::array
+{
+    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
+    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
+    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
+    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
+    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
+    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
+    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
+};
+#undef __
+
+
+template <int k_bits, int v_bits>
+__global__ __launch_bounds__(MAX_WARPS * 32)
+void dequant_cache_paged_gather_delta_kernel
+(
+    const uint32_t* __restrict__ k_in,
+    const half* __restrict__ k_in_scales,
+    const half* __restrict__ k_delta,
+    half* __restrict__ k_out,
+    const uint32_t* __restrict__ v_in,
+    const half* __restrict__ v_in_scales,
+    const half* __restrict__ v_delta,
+    half* __restrict__ v_out,
+    const uint32_t* __restrict__ cache_seqlens,
+    const uint32_t* __restrict__ block_table,
+    const int blocks_per_seq,
+    const int token_dim,
+    const int seq_len,
+    const int delta_len
+)
+{
+    int batch_idx = blockIdx.z;
+    int token_idx = blockIdx.y;
+    int cache_len = cache_seqlens[batch_idx];
+    int total_len = cache_len + delta_len;
+    if (token_idx >= total_len) return;
+
+    if (token_idx < cache_len)
+    {
+        int page_idx = token_idx / CQ_PAGE_SIZE;
+        int token_pos = block_table[blocks_per_seq * batch_idx + page_idx] * CQ_PAGE_SIZE + (token_idx % CQ_PAGE_SIZE);
+        int input_pos = token_pos * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+        int output_pos = (batch_idx * seq_len + token_idx) * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+        int sub_pos_in = input_pos / 32;
+        int sub_pos_out = output_pos / 32;
+
+        dequant_block<k_bits>(k_in + sub_pos_in * k_bits, k_in_scales + sub_pos_in, k_out + sub_pos_out * 32);
+        dequant_block<v_bits>(v_in + sub_pos_in * v_bits, v_in_scales + sub_pos_in, v_out + sub_pos_out * 32);
+        return;
+    }
+
+    int delta_token_idx = token_idx - cache_len;
+    int input_pos = (batch_idx * delta_len + delta_token_idx) * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+    int output_pos = (batch_idx * seq_len + token_idx) * token_dim + blockDim.x * blockIdx.x + threadIdx.x;
+    k_out[output_pos] = k_delta[input_pos];
+    v_out[output_pos] = v_delta[input_pos];
+}
+
+#define __(i, j) dequant_cache_paged_gather_delta_kernel<i, j>
+constexpr auto dequant_cache_paged_gather_delta_kernel_instances = std::array
+{
+    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
+    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
+    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
+    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
+    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
+    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
+    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
+};
+#undef __
+
+template <int k_bits, int v_bits>
+__global__ __launch_bounds__(MAX_WARPS * 32)
+void dequant_cache_paged_gather_delta_heads_kernel
+(
+    const uint32_t* __restrict__ k_in,
+    const half* __restrict__ k_in_scales,
+    const half* __restrict__ k_delta,
+    half* __restrict__ k_out,
+    const uint32_t* __restrict__ v_in,
+    const half* __restrict__ v_in_scales,
+    const half* __restrict__ v_delta,
+    half* __restrict__ v_out,
+    const uint32_t* __restrict__ cache_seqlens,
+    const uint32_t* __restrict__ block_table,
+    const int blocks_per_seq,
+    const int token_dim,
+    const int seq_len,
+    const int delta_len,
+    const int num_kv_heads,
+    const int head_dim
+)
+{
+    int batch_idx = blockIdx.z;
+    int token_idx = blockIdx.y;
+    int cache_len = cache_seqlens[batch_idx];
+    int total_len = cache_len + delta_len;
+    if (token_idx >= total_len) return;
+
+    int channel = blockDim.x * blockIdx.x + threadIdx.x;
+    int head_idx = channel / head_dim;
+    int head_offset = channel - head_idx * head_dim;
+    int output_pos = ((batch_idx * num_kv_heads + head_idx) * seq_len + token_idx) * head_dim + head_offset;
+
+    if (token_idx < cache_len)
+    {
+        int page_idx = token_idx / CQ_PAGE_SIZE;
+        int token_pos = block_table[blocks_per_seq * batch_idx + page_idx] * CQ_PAGE_SIZE + (token_idx % CQ_PAGE_SIZE);
+        int input_pos = token_pos * token_dim + channel;
+        int sub_pos_in = input_pos / 32;
+        int sub_pos_out = output_pos / 32;
+
+        dequant_block<k_bits>(k_in + sub_pos_in * k_bits, k_in_scales + sub_pos_in, k_out + sub_pos_out * 32);
+        dequant_block<v_bits>(v_in + sub_pos_in * v_bits, v_in_scales + sub_pos_in, v_out + sub_pos_out * 32);
+        return;
+    }
+
+    int delta_token_idx = token_idx - cache_len;
+    int input_pos = (batch_idx * delta_len + delta_token_idx) * token_dim + channel;
+    k_out[output_pos] = k_delta[input_pos];
+    v_out[output_pos] = v_delta[input_pos];
+}
+
+#define __(i, j) dequant_cache_paged_gather_delta_heads_kernel<i, j>
+constexpr auto dequant_cache_paged_gather_delta_heads_kernel_instances = std::array
+{
+    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
+    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
+    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
+    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
+    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
+    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
+    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
+};
+#undef __
+
+
+template <int k_bits, int v_bits>
+__global__ __launch_bounds__(MAX_WARPS * 32)
+void dequant_cache_paged_select_delta_heads_kernel
+(
+    const uint32_t* __restrict__ k_in,
+    const half* __restrict__ k_in_scales,
+    const half* __restrict__ k_delta,
+    half* __restrict__ k_out,
+    const uint32_t* __restrict__ v_in,
+    const half* __restrict__ v_in_scales,
+    const half* __restrict__ v_delta,
+    half* __restrict__ v_out,
+    const uint32_t* __restrict__ cache_seqlens,
+    const uint32_t* __restrict__ block_table,
+    const uint32_t* __restrict__ selected_positions,
+    const uint32_t* __restrict__ selected_counts,
+    const int blocks_per_seq,
+    const int token_dim,
+    const int seq_len,
+    const int delta_len,
+    const int max_selected,
+    const int num_kv_heads,
+    const int head_dim
+)
+{
+    int batch_idx = blockIdx.z;
+    int selected_idx = blockIdx.y;
+    int selected_total = selected_counts[batch_idx];
+    if (selected_idx >= selected_total) return;
+
+    int token_idx = selected_positions[batch_idx * max_selected + selected_idx];
+    int cache_len = cache_seqlens[batch_idx];
+    int channel = blockDim.x * blockIdx.x + threadIdx.x;
+    int head_idx = channel / head_dim;
+    int head_offset = channel - head_idx * head_dim;
+    int output_pos = ((batch_idx * num_kv_heads + head_idx) * seq_len + selected_idx) * head_dim + head_offset;
+
+    if (token_idx < cache_len)
+    {
+        int page_idx = token_idx / CQ_PAGE_SIZE;
+        int token_pos = block_table[blocks_per_seq * batch_idx + page_idx] * CQ_PAGE_SIZE + (token_idx % CQ_PAGE_SIZE);
+        int input_pos = token_pos * token_dim + channel;
+        int sub_pos_in = input_pos / 32;
+        int sub_pos_out = output_pos / 32;
+
+        dequant_block<k_bits>(k_in + sub_pos_in * k_bits, k_in_scales + sub_pos_in, k_out + sub_pos_out * 32);
+        dequant_block<v_bits>(v_in + sub_pos_in * v_bits, v_in_scales + sub_pos_in, v_out + sub_pos_out * 32);
+        return;
+    }
+
+    int delta_token_idx = token_idx - cache_len;
+    if (delta_token_idx >= delta_len) return;
+    int input_pos = (batch_idx * delta_len + delta_token_idx) * token_dim + channel;
+    k_out[output_pos] = k_delta[input_pos];
+    v_out[output_pos] = v_delta[input_pos];
+}
+
+#define __(i, j) dequant_cache_paged_select_delta_heads_kernel<i, j>
+constexpr auto dequant_cache_paged_select_delta_heads_kernel_instances = std::array
 {
     std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
     std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },

--- a/exllamav3/generator/gemma4_pagetable.py
+++ b/exllamav3/generator/gemma4_pagetable.py
@@ -844,6 +844,11 @@ class Gemma4PageTable(PageTable):
         )
         return params
 
+    def advance_draft_decode_params(self, params: dict, step: int = 1) -> None:
+        super().advance_draft_decode_params(params, step = step)
+        params["cache_seqlens_full"] += step
+        params["cache_seqlens_swa"] += step
+
     def build_decode_params(self, active_jobs: list, max_seq_len: int, use_offsets: bool = False) -> dict:
         params = super().build_decode_params(active_jobs, max_seq_len, use_offsets = use_offsets)
         for job in active_jobs:

--- a/exllamav3/generator/gemma4_pagetable.py
+++ b/exllamav3/generator/gemma4_pagetable.py
@@ -1,0 +1,875 @@
+from __future__ import annotations
+
+from collections import OrderedDict, deque
+
+import torch
+
+from ..constants import PAGE_SIZE
+from ..tokenizer.mm_embedding import FIRST_MM_EMBEDDING_INDEX
+from .pagetable import CachePage, PageArena, PageTable, tensor_hash_checksum
+
+
+class Gemma4PageTable(PageTable):
+
+    def __init__(self, generator, cache):
+        super().__init__(generator, cache)
+        self.sliding_window = generator.model.config.sliding_window
+        self.full_arena = self.default_arena
+        self.swa_arena = PageArena(self, self._get_role_max_pages("swa"), role = "swa")
+        self._allocate_has_mm_tokens = False
+        self._prefer_low_index_swa = False
+        self.active_full_to_swa_pages: dict[int, CachePage] = {}
+        self.cached_full_to_swa_pages: OrderedDict[tuple[bytes, bool], CachePage] = OrderedDict()
+        self.cached_partial_to_swa_pages: OrderedDict[tuple[bytes, bool], CachePage] = OrderedDict()
+        sliding_window_pages = 0 if self.sliding_window < 0 else (self.sliding_window + PAGE_SIZE - 1) // PAGE_SIZE
+        self.max_cached_copy_sources = max(1, sliding_window_pages + 1)
+
+    @staticmethod
+    def _ensure_seq_role_state(seq) -> dict[str, dict]:
+        state = getattr(seq, "_gemma4_role_state", None)
+        if state is None:
+            state = {
+                "pages": {},
+                "backing_pages": {},
+                "block_index_tensors": {},
+                "kv_positions": {},
+                "page_maps": {},
+            }
+            setattr(seq, "_gemma4_role_state", state)
+        return state
+
+    def _get_seq_allocated_pages(self, seq, role: str = "default"):
+        if role == "default":
+            return seq.allocated_pages
+        return self._ensure_seq_role_state(seq)["pages"].get(role)
+
+    def _set_seq_allocated_pages(self, seq, pages, role: str = "default"):
+        if role == "default":
+            seq.allocated_pages = pages
+            return
+        self._ensure_seq_role_state(seq)["pages"][role] = pages
+
+    def _get_seq_backing_pages(self, seq, role: str = "default"):
+        if role == "default":
+            return seq.allocated_pages
+        return self._ensure_seq_role_state(seq)["backing_pages"].get(role)
+
+    def _set_seq_backing_pages(self, seq, pages, role: str = "default"):
+        if role == "default":
+            seq.allocated_pages = pages
+            return
+        state = self._ensure_seq_role_state(seq)["backing_pages"]
+        if pages is None:
+            state.pop(role, None)
+        else:
+            state[role] = pages
+
+    def _get_seq_block_index_tensor(self, seq, role: str = "default"):
+        if role == "default":
+            return seq.block_index_tensor
+        return self._ensure_seq_role_state(seq)["block_index_tensors"].get(role)
+
+    def _get_seq_kv_position(self, seq, role: str = "default"):
+        if role == "default":
+            return seq.kv_position
+        return self._ensure_seq_role_state(seq)["kv_positions"].get(role, seq.kv_position)
+
+    def _set_seq_kv_position(self, seq, kv_position: int, role: str = "default"):
+        if role == "default":
+            seq.kv_position = kv_position
+            return
+        self._ensure_seq_role_state(seq)["kv_positions"][role] = kv_position
+
+    def _clear_seq_role_views(self, seq):
+        if hasattr(seq, "_gemma4_role_state"):
+            delattr(seq, "_gemma4_role_state")
+
+    def _get_seq_page_map(self, seq, role: str = "default"):
+        if role == "default":
+            return {}
+        return self._ensure_seq_role_state(seq)["page_maps"].get(role, {})
+
+    def _set_seq_page_map(self, seq, page_map: dict[int, CachePage], role: str = "default"):
+        if role == "default":
+            return
+        self._ensure_seq_role_state(seq)["page_maps"][role] = page_map
+
+    def _build_seq_block_index_tensor(self, seq, role: str = "default"):
+        if role == "default":
+            return seq.build_block_index_tensor()
+        pages = self._get_seq_allocated_pages(seq, role = role)
+        tensor = None if pages is None else torch.tensor(
+            [[page.page_index for page in pages]],
+            dtype = torch.int32,
+        )
+        self._ensure_seq_role_state(seq)["block_index_tensors"][role] = tensor
+        return tensor
+
+    def build_batch_block_index(
+        self,
+        active_jobs: list,
+        max_seq_len: int,
+        role: str = "default",
+        single_sequence_per_job: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size = 0
+        for job in active_jobs:
+            if not job.is_prefill_done():
+                continue
+            batch_size += 1 if single_sequence_per_job else len(job.sequences)
+
+        max_pages_batch = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+        block_index = torch.zeros((batch_size, max_pages_batch), dtype = torch.int32)
+        cache_seqlens = torch.zeros((batch_size,), dtype = torch.int32)
+
+        batch = 0
+        for job in active_jobs:
+            if not job.is_prefill_done():
+                continue
+            for seq in job.sequences:
+                seq_block_index = self._get_seq_block_index_tensor(seq, role = role)
+                if seq_block_index is None:
+                    continue
+                seq_block_index = seq_block_index[:, :max_pages_batch]
+                block_index[batch : batch + 1, :seq_block_index.shape[-1]].copy_(seq_block_index)
+                cache_seqlens[batch] = self._get_seq_kv_position(seq, role = role)
+                batch += 1
+                if single_sequence_per_job:
+                    break
+
+        return block_index, cache_seqlens
+
+    @staticmethod
+    def _sequence_has_mm_tokens(seq) -> bool:
+        cached = getattr(seq, "_gemma4_has_mm_tokens", None)
+        if cached is None:
+            cached = bool((seq.input_ids.torch() >= FIRST_MM_EMBEDDING_INDEX).any().item())
+            setattr(seq, "_gemma4_has_mm_tokens", cached)
+        return cached
+
+    @staticmethod
+    def _cached_full_page_key(full_page: CachePage, has_mm_tokens: bool = False) -> tuple[bytes, bool]:
+        return full_page.phash, has_mm_tokens
+
+    @staticmethod
+    def _cached_partial_page_key(
+        prev_hash: bytes | None,
+        partial_ids: torch.Tensor,
+        has_mm_tokens: bool = False,
+    ) -> tuple[bytes, bool]:
+        return tensor_hash_checksum(partial_ids, prev_hash), has_mm_tokens
+
+    def _get_prompt_window_start_page(self, prompt_cached_tokens: int) -> int:
+        if prompt_cached_tokens <= 0 or self.sliding_window < 0:
+            return 0
+        window_start = max(0, prompt_cached_tokens - self.sliding_window)
+        return window_start // PAGE_SIZE
+
+    def _has_matching_partial_copy_source(self, seq) -> bool:
+        prompt_cached_tokens = len(seq.input_ids) - 1
+        prompt_tail_tokens = prompt_cached_tokens % PAGE_SIZE
+        if prompt_tail_tokens <= 0:
+            return True
+
+        page_idx = prompt_cached_tokens // PAGE_SIZE
+        prefill_ids = seq.sequence_ids.torch_slice(page_idx * PAGE_SIZE, prompt_cached_tokens)
+        prev_hash = None if page_idx == 0 else seq.page_hashes[page_idx - 1]
+        partial_key = self._cached_partial_page_key(prev_hash, prefill_ids, self._sequence_has_mm_tokens(seq))
+        return self.cached_partial_to_swa_pages.get(partial_key) is not None
+
+    def _has_reusable_full_prefix(self, seq) -> bool:
+        prompt_cached_tokens = len(seq.input_ids) - 1
+        prompt_full_pages = prompt_cached_tokens // PAGE_SIZE
+        if prompt_full_pages <= 0:
+            return False
+
+        has_mm_tokens = self._sequence_has_mm_tokens(seq)
+        for page_hash in seq.page_hashes[:prompt_full_pages]:
+            if self.cached_full_to_swa_pages.get((page_hash, has_mm_tokens)) is None:
+                return False
+            if (
+                self.find_referenced_page(page_hash, role = "full") is not None or
+                self.find_unreferenced_page(page_hash, role = "full") is not None
+            ):
+                return True
+            return False
+        return False
+
+    def _iter_prompt_window_full_pages(self, seq, full_pages: list[CachePage]) -> list[tuple[CachePage, CachePage]]:
+        old_swa_map = self._get_seq_page_map(seq, role = "swa")
+        prompt_cached_tokens = len(seq.input_ids) - 1
+        prompt_full_pages = prompt_cached_tokens // PAGE_SIZE
+        if prompt_full_pages <= 0:
+            return []
+        start_page = self._get_prompt_window_start_page(prompt_cached_tokens)
+        cached_pairs = []
+        for page_idx in range(start_page, min(prompt_full_pages, len(full_pages))):
+            full_page = full_pages[page_idx]
+            swa_page = old_swa_map.get(id(full_page))
+            if swa_page is not None:
+                cached_pairs.append((full_page, swa_page))
+        return cached_pairs
+
+    def _copy_cached_swa_page(self, source_page: CachePage, target_page: CachePage, num_tokens: int) -> None:
+        if num_tokens <= 0:
+            return
+        for layer in self.cache.layers.values():
+            if getattr(layer, "cache_role", "default") != "swa":
+                continue
+            layer.copy_page(layer, source_page.page_index, target_page.page_index, num_tokens)
+        target_page.kv_position = num_tokens
+        target_page.prev_hash = source_page.prev_hash
+        target_page.can_revert = False
+
+    def _restore_cached_swa_prefix(self, seq, swa_pages: list[CachePage]) -> None:
+        full_pages = self._get_seq_allocated_pages(seq, role = "full") or seq.allocated_pages or []
+        if not full_pages or not swa_pages:
+            return
+
+        cached_full_pages = seq.kv_position // PAGE_SIZE
+        if cached_full_pages <= 0:
+            return
+
+        has_mm_tokens = self._sequence_has_mm_tokens(seq)
+        start_page = self._get_prompt_window_start_page(seq.kv_position)
+        local_cached_pages = max(0, cached_full_pages - start_page)
+        for local_idx in range(min(local_cached_pages, len(swa_pages))):
+            full_page = full_pages[start_page + local_idx]
+            full_page_key = self._cached_full_page_key(full_page, has_mm_tokens)
+            cached_source = self.cached_full_to_swa_pages.get(full_page_key)
+            if cached_source is None:
+                continue
+            self.cached_full_to_swa_pages.move_to_end(full_page_key)
+            self._copy_cached_swa_page(cached_source, swa_pages[local_idx], PAGE_SIZE)
+
+    def _snapshot_prompt_window_sources(self, seq, full_pages: list[CachePage]) -> None:
+        has_mm_tokens = self._sequence_has_mm_tokens(seq)
+        prompt_window_pairs = [
+            (full_page, active_swa)
+            for full_page, active_swa in self._iter_prompt_window_full_pages(seq, full_pages)
+            if self.cached_full_to_swa_pages.get(self._cached_full_page_key(full_page, has_mm_tokens)) is None
+        ]
+        if not prompt_window_pairs:
+            return
+
+        self._evict_cached_swa_for_admission(len(prompt_window_pairs))
+        if not self.swa_arena.unreferenced_pages:
+            return
+
+        snapshot_count = min(len(prompt_window_pairs), len(self.swa_arena.unreferenced_pages))
+        snapshot_pages, _, _, _ = self.allocate_pages([], snapshot_count, None, role = "swa")
+        for (full_page, active_swa), snapshot_page in zip(prompt_window_pairs[:snapshot_count], snapshot_pages):
+            self._copy_cached_swa_page(active_swa, snapshot_page, PAGE_SIZE)
+            self._cache_copy_candidate(full_page, snapshot_page, has_mm_tokens)
+
+    def _get_role_max_pages(self, role: str) -> int:
+        role_max_tokens = [
+            layer.max_num_tokens
+            for layer in self.cache.layers.values()
+            if getattr(layer, "cache_role", "default") == role
+        ]
+        if not role_max_tokens:
+            return self.default_arena.max_pages
+        return min(role_max_tokens) // PAGE_SIZE
+
+    def _get_swa_capacity_pages(self, seq) -> int:
+        total_pages = len(seq.page_hashes or []) + seq.new_unique_pages
+        if total_pages <= 0:
+            return 0
+        if self.sliding_window < 0:
+            return min(total_pages, self.swa_arena.max_pages)
+        capacity_pages = self.get_min_swa_capacity_pages()
+        return min(total_pages, capacity_pages, self.swa_arena.max_pages)
+
+    def get_min_swa_capacity_tokens(self) -> int:
+        if self.sliding_window < 0:
+            return self.full_arena.max_pages * PAGE_SIZE
+        max_write_tokens = max(self.generator.max_chunk_size, self.generator.num_draft_tokens + 1)
+        return self.sliding_window + PAGE_SIZE + max_write_tokens
+
+    def get_min_swa_capacity_pages(self) -> int:
+        capacity_tokens = self.get_min_swa_capacity_tokens()
+        return (capacity_tokens + PAGE_SIZE - 1) // PAGE_SIZE
+
+    def prepare_sequence(
+        self,
+        seq,
+        has_prefix_token: bool,
+        max_new_tokens: int,
+        allow_page_reuse: bool = True,
+    ):
+        unique_hashes, unique_pages = super().prepare_sequence(
+            seq,
+            has_prefix_token,
+            max_new_tokens,
+            allow_page_reuse = allow_page_reuse,
+        )
+        if not allow_page_reuse:
+            return unique_hashes, unique_pages
+        if not self._has_reusable_full_prefix(seq):
+            return unique_hashes, unique_pages
+        if self._has_matching_partial_copy_source(seq):
+            return unique_hashes, unique_pages
+        return super().prepare_sequence(
+            seq,
+            has_prefix_token,
+            max_new_tokens,
+            allow_page_reuse = False,
+        )
+
+    def get_arena(self, role: str = "default") -> PageArena:
+        if role == "swa":
+            return self.swa_arena
+        if role in ("default", "full"):
+            return self.full_arena
+        raise KeyError(f"Unknown page arena role: {role}")
+
+    def num_unreferenced_pages_by_role(self) -> dict[str, int]:
+        full_available = len(self.full_arena.unreferenced_pages)
+        return {
+            "default": full_available,
+            "full": full_available,
+            "swa": len(self.swa_arena.unreferenced_pages),
+        }
+
+    def current_new_pages_required_by_role(self, job) -> dict[str, int]:
+        full_required = self.current_new_pages_required(job)
+        swa_required = sum(self._get_swa_capacity_pages(seq) for seq in job.sequences)
+        return {
+            "default": full_required,
+            "full": full_required,
+            "swa": swa_required,
+        }
+
+    def _evict_cached_swa_for_admission(self, required_pages: int) -> None:
+        if required_pages <= len(self.swa_arena.unreferenced_pages):
+            return
+        while self.cached_partial_to_swa_pages and required_pages > len(self.swa_arena.unreferenced_pages):
+            self._evict_oldest_cached_partial_swa_page()
+        while self.cached_full_to_swa_pages and required_pages > len(self.swa_arena.unreferenced_pages):
+            self._evict_oldest_cached_swa_page()
+
+    def can_admit_job(self, job, current_batch_size: int, max_batch_size: int) -> bool:
+        if len(job.sequences) + current_batch_size > max_batch_size:
+            return False
+        required = self.current_new_pages_required_by_role(job)
+        swa_required = required.get("swa", 0)
+        if swa_required:
+            self._evict_cached_swa_for_admission(swa_required)
+        available = self.num_unreferenced_pages_by_role()
+        for role, pages in required.items():
+            if pages > available.get(role, 0):
+                return False
+        return True
+
+    def _release_cached_swa_page(self, full_page: CachePage) -> None:
+        for has_mm_tokens in (False, True):
+            cached_swa = self.cached_full_to_swa_pages.pop(
+                self._cached_full_page_key(full_page, has_mm_tokens),
+                None,
+            )
+            if cached_swa is not None and cached_swa.ref_count > 0:
+                self.deallocate_pages([cached_swa])
+
+    @staticmethod
+    def _clear_page_sequence(page: CachePage) -> None:
+        # Gemma4 reuses physical cache pages across heterogeneous text/MM requests.
+        # Clear the token bookkeeping buffer whenever a page is freshly assigned to a
+        # new logical sequence so stale ids cannot influence later partial-page logic.
+        page.sequence.zero_()
+
+    def _evict_oldest_cached_swa_page(self) -> None:
+        if not self.cached_full_to_swa_pages:
+            return
+        _, cached_swa = self.cached_full_to_swa_pages.popitem(last = False)
+        if cached_swa.ref_count > 0:
+            self.deallocate_pages([cached_swa])
+
+    def _evict_oldest_cached_partial_swa_page(self) -> None:
+        if not self.cached_partial_to_swa_pages:
+            return
+        _, cached_swa = self.cached_partial_to_swa_pages.popitem(last = False)
+        if cached_swa.ref_count > 0:
+            self.deallocate_pages([cached_swa])
+
+    def _cache_copy_candidate(self, full_page: CachePage, swa_page: CachePage, has_mm_tokens: bool) -> None:
+        full_page_key = self._cached_full_page_key(full_page, has_mm_tokens)
+        existing = self.cached_full_to_swa_pages.get(full_page_key)
+        if existing is swa_page:
+            self.cached_full_to_swa_pages.move_to_end(full_page_key)
+            return
+        if existing is not None and existing.ref_count > 0:
+            self.deallocate_pages([existing])
+        self.cached_full_to_swa_pages[full_page_key] = swa_page
+        self.cached_full_to_swa_pages.move_to_end(full_page_key)
+        while len(self.cached_full_to_swa_pages) > self.max_cached_copy_sources:
+            self._evict_oldest_cached_swa_page()
+
+    def _cache_partial_copy_candidate(self, partial_key: tuple[bytes, bool], swa_page: CachePage) -> None:
+        existing = self.cached_partial_to_swa_pages.get(partial_key)
+        if existing is swa_page:
+            self.cached_partial_to_swa_pages.move_to_end(partial_key)
+            return
+        if existing is not None and existing.ref_count > 0:
+            self.deallocate_pages([existing])
+        self.cached_partial_to_swa_pages[partial_key] = swa_page
+        self.cached_partial_to_swa_pages.move_to_end(partial_key)
+        while len(self.cached_partial_to_swa_pages) > self.max_cached_copy_sources:
+            self._evict_oldest_cached_partial_swa_page()
+
+    def cache_prefill_copy_source(self, seq) -> None:
+        # In TP mode the cache tensors live on split worker-local cache layers, so the
+        # main-process cache objects do not own backing qk/qv/sk/sv tensors. This
+        # snapshot is an optimization only, so skip it and keep the deallocate-time pin
+        # path as the correctness-preserving fallback.
+        if self.cache.model.loaded_tp:
+            return
+
+        full_pages = self._get_seq_allocated_pages(seq, role = "full") or seq.allocated_pages or []
+        has_mm_tokens = self._sequence_has_mm_tokens(seq)
+        if full_pages:
+            self._snapshot_prompt_window_sources(seq, full_pages)
+
+        prompt_cached_tokens = len(seq.input_ids) - 1
+        prompt_tail_tokens = prompt_cached_tokens % PAGE_SIZE
+        if prompt_tail_tokens <= 0:
+            return
+
+        prompt_terminal_page_idx = len(seq.page_hashes or [])
+        if not (0 <= prompt_terminal_page_idx < len(full_pages)):
+            return
+
+        prompt_terminal_page = full_pages[prompt_terminal_page_idx]
+        active_swa = self._get_seq_page_map(seq, role = "swa").get(id(prompt_terminal_page))
+        if active_swa is None:
+            return
+
+        prev_hash = None if prompt_terminal_page_idx == 0 else seq.page_hashes[prompt_terminal_page_idx - 1]
+        partial_ids = seq.sequence_ids.torch_slice(prompt_terminal_page_idx * PAGE_SIZE, prompt_cached_tokens)
+        partial_key = self._cached_partial_page_key(prev_hash, partial_ids, has_mm_tokens)
+        if self.cached_partial_to_swa_pages.get(partial_key) is not None:
+            return
+
+        # Snapshotting the prompt-terminal local page is an optimization, not a correctness
+        # requirement. If the SWA arena is currently full, fall back to the existing
+        # deallocate-time pinning path instead of overcommitting local pages.
+        if not self.swa_arena.unreferenced_pages:
+            return
+
+        snapshot_pages, _, _, _ = self.allocate_pages([], 1, None, role = "swa")
+        if not snapshot_pages:
+            return
+        snapshot_page = snapshot_pages[0]
+
+        for layer in self.cache.layers.values():
+            if getattr(layer, "cache_role", "default") != "swa":
+                continue
+            layer.copy_page(layer, active_swa.page_index, snapshot_page.page_index, prompt_tail_tokens)
+
+        snapshot_page.kv_position = prompt_tail_tokens
+        snapshot_page.prev_hash = active_swa.prev_hash
+        snapshot_page.can_revert = False
+        self._cache_partial_copy_candidate(partial_key, snapshot_page)
+
+    def _sync_role_views(self, seq) -> None:
+        old_swa_map = self._get_seq_page_map(seq, role = "swa")
+        for full_page_id, swa_page in old_swa_map.items():
+            if self.active_full_to_swa_pages.get(full_page_id) is swa_page:
+                del self.active_full_to_swa_pages[full_page_id]
+
+        old_full_kv = self._get_seq_kv_position(seq, role = "full")
+        old_swa_kv = self._get_seq_kv_position(seq, role = "swa")
+        full_pages = self._get_seq_backing_pages(seq, role = "full") or seq.allocated_pages
+        full_kv = seq.kv_position
+        base_page = 0
+
+        self._set_seq_allocated_pages(seq, full_pages, role = "full")
+        self._set_seq_kv_position(seq, full_kv, role = "full")
+        self._build_seq_block_index_tensor(seq, role = "full")
+
+        swa_backing = self._get_seq_backing_pages(seq, role = "swa")
+        if swa_backing is not None:
+            swa_pages = list(self._get_seq_allocated_pages(seq, role = "swa") or swa_backing)
+            if len(swa_pages) != len(swa_backing):
+                swa_pages = list(swa_backing)
+
+            if self.sliding_window < 0:
+                old_base_page = 0
+                new_base_page = 0
+            else:
+                old_window_start = max(0, old_full_kv - self.sliding_window)
+                new_window_start = max(0, full_kv - self.sliding_window)
+                old_base_page = old_window_start // PAGE_SIZE
+                new_base_page = new_window_start // PAGE_SIZE
+            base_page = new_base_page
+
+            old_valid_pages = min(len(swa_pages), (old_swa_kv + PAGE_SIZE - 1) // PAGE_SIZE) if old_swa_kv else 0
+            pages_to_drop = max(0, new_base_page - old_base_page)
+            if full_kv >= old_full_kv and old_valid_pages and pages_to_drop:
+                drop = min(pages_to_drop, old_valid_pages)
+                swa_pages = (
+                    swa_pages[drop:old_valid_pages] +
+                    swa_pages[:drop] +
+                    swa_pages[old_valid_pages:]
+                )
+
+            swa_kv = min(full_kv - new_base_page * PAGE_SIZE, len(swa_pages) * PAGE_SIZE)
+        elif full_pages is None:
+            swa_pages = None
+            swa_kv = 0
+        elif self.sliding_window < 0:
+            swa_pages = full_pages
+            swa_kv = full_kv
+        else:
+            window_start = max(0, full_kv - self.sliding_window)
+            base_page = window_start // PAGE_SIZE
+            swa_pages = full_pages[base_page:]
+            swa_kv = full_kv - base_page * PAGE_SIZE
+
+        self._set_seq_allocated_pages(seq, swa_pages, role = "swa")
+        self._set_seq_kv_position(seq, swa_kv, role = "swa")
+        self._build_seq_block_index_tensor(seq, role = "swa")
+        swa_page_map = {}
+        if full_pages is not None and swa_pages is not None:
+            max_local_pages = min(len(swa_pages), max(len(full_pages) - base_page, 0))
+            for local_idx in range(max_local_pages):
+                full_page = full_pages[base_page + local_idx]
+                swa_page = swa_pages[local_idx]
+                swa_page_map[id(full_page)] = swa_page
+                self.active_full_to_swa_pages[id(full_page)] = swa_page
+        self._set_seq_page_map(seq, swa_page_map, role = "swa")
+
+    def clear_page(self, page: CachePage, role: str = "default"):
+        if role == "default":
+            self._release_cached_swa_page(page)
+        super().clear_page(page, role = role)
+
+    def reset_page_table(self):
+        self.active_full_to_swa_pages.clear()
+        self.cached_full_to_swa_pages.clear()
+        self.cached_partial_to_swa_pages.clear()
+        super().reset_page_table()
+        self.swa_arena.reset()
+
+    def allocate_pages(
+        self,
+        page_hashes: list,
+        new_unique_pages: int,
+        recurrent_pages: list[int] | None,
+        role: str = "default",
+    ):
+        if role != "default":
+            if (
+                role == "swa" and
+                self._prefer_low_index_swa and
+                not page_hashes and
+                recurrent_pages is None
+            ):
+                arena = self.get_arena(role)
+                allocated_pages = []
+                available_pages = list(arena.unreferenced_pages.values())
+                available_pages.sort(key = lambda page: page.page_index)
+                available_pages = deque(available_pages)
+
+                for _ in range(new_unique_pages):
+                    arena.access_serial += 1
+                    while available_pages[0].ref_count:
+                        available_pages.popleft()
+                    page = available_pages.popleft()
+                    page.add_ref_unique(arena.access_serial)
+                    self._clear_page_sequence(page)
+                    allocated_pages.append(page)
+
+                cached_pages = 0
+                kv_position = 0
+                non_sequential_pages = 0
+                for page_a, page_b in zip(allocated_pages, allocated_pages[1:]):
+                    if page_b.page_index != page_a.page_index + 1:
+                        non_sequential_pages += 1
+
+                return allocated_pages, kv_position, cached_pages, non_sequential_pages
+
+            allocated_pages, kv_position, cached_pages, non_sequential_pages = super().allocate_pages(
+                page_hashes,
+                new_unique_pages,
+                recurrent_pages,
+                role = role,
+            )
+            for page in allocated_pages:
+                if page.kv_position == 0:
+                    self._clear_page_sequence(page)
+            return allocated_pages, kv_position, cached_pages, non_sequential_pages
+
+        arena = self.get_arena(role)
+        allocated_pages = []
+        available_pages = None
+        reuse_prefix_valid = True
+        profile = getattr(getattr(self.generator, "model", None), "caps", {}).get("gemma4_profile", "generic")
+        prefer_low_index_pages = (
+            len(page_hashes) == 0 or
+            (
+                profile == "26b_a4b_moe" and
+                not self._allocate_has_mm_tokens
+            )
+        )
+
+        def get_available_pages() -> deque[CachePage]:
+            pages = list(arena.unreferenced_pages.values())
+            # Gemma4 26B text requests are sensitive to full-page placement after multimodal
+            # churn, including the "reuse one full page, append one new tail page" case.
+            # Keep the generic LRU path for every other model/request type, but make 26B
+            # non-MM text full-page allocation deterministic by preferring the lowest page
+            # indices across the whole request, not only for a completely fresh prefix.
+            pages.sort(key = (lambda page: page.page_index) if prefer_low_index_pages else (lambda page: page.access_serial))
+            return deque(pages)
+
+        for h in page_hashes:
+            arena.access_serial += 1
+
+            cached_swa = (
+                self.cached_full_to_swa_pages.get((h, self._allocate_has_mm_tokens))
+                if reuse_prefix_valid else None
+            )
+
+            rp = arena.referenced_pages.get(h)
+            if rp and cached_swa is not None:
+                rp.add_ref(arena.access_serial)
+                allocated_pages.append(rp)
+                continue
+
+            up = arena.unreferenced_pages.get(h)
+            if up and cached_swa is not None:
+                up.add_ref(arena.access_serial)
+                allocated_pages.append(up)
+                continue
+
+            reuse_prefix_valid = False
+            if not allocated_pages:
+                prefer_low_index_pages = True
+
+            if available_pages is None:
+                available_pages = get_available_pages()
+            else:
+                while available_pages[0].ref_count:
+                    available_pages.popleft()
+
+            op = available_pages.popleft()
+            self._release_cached_swa_page(op)
+            if (
+                not cached_swa and
+                (h in arena.referenced_pages or h in arena.unreferenced_pages)
+            ):
+                op.add_ref_unique(arena.access_serial)
+                self._clear_page_sequence(op)
+            else:
+                op.add_ref_clear(arena.access_serial, h)
+                self._clear_page_sequence(op)
+            allocated_pages.append(op)
+
+        for _ in range(new_unique_pages):
+            arena.access_serial += 1
+
+            if available_pages is None:
+                available_pages = get_available_pages()
+            else:
+                while available_pages[0].ref_count:
+                    available_pages.popleft()
+
+            op = available_pages.popleft()
+            self._release_cached_swa_page(op)
+            op.add_ref_unique(arena.access_serial)
+            self._clear_page_sequence(op)
+            allocated_pages.append(op)
+
+        cached_pages = 0
+        for page in allocated_pages:
+            if page.kv_position == PAGE_SIZE:
+                cached_pages += 1
+            else:
+                break
+
+        if recurrent_pages is not None:
+            max_recur = 0
+            for rp in recurrent_pages:
+                if rp < cached_pages:
+                    max_recur = rp + 1
+            cached_pages = max_recur
+
+        kv_position = cached_pages * PAGE_SIZE
+
+        non_sequential_pages = 0
+        for page_a, page_b in zip(allocated_pages, allocated_pages[1:]):
+            if page_b.page_index != page_a.page_index + 1:
+                non_sequential_pages += 1
+
+        return allocated_pages, kv_position, cached_pages, non_sequential_pages
+
+    def allocate_sequence(self, seq, recurrent_cache):
+        self._allocate_has_mm_tokens = self._sequence_has_mm_tokens(seq)
+        try:
+            result = super().allocate_sequence(seq, recurrent_cache)
+        finally:
+            self._allocate_has_mm_tokens = False
+        swa_capacity_pages = self._get_swa_capacity_pages(seq)
+        if swa_capacity_pages:
+            self._evict_cached_swa_for_admission(swa_capacity_pages)
+            profile = getattr(getattr(self.generator, "model", None), "caps", {}).get("gemma4_profile", "generic")
+            # 26B text requests can start from a completely fresh local SWA view after
+            # multimodal churn. In that case, keep the local window on the lowest SWA
+            # page indices so the initial block-table mapping is deterministic instead
+            # of depending on prior SWA eviction order.
+            self._prefer_low_index_swa = (
+                profile == "26b_a4b_moe" and
+                not self._sequence_has_mm_tokens(seq) and
+                seq.kv_position == 0
+            )
+            try:
+                swa_pages, _, _, _ = self.allocate_pages([], swa_capacity_pages, None, role = "swa")
+            finally:
+                self._prefer_low_index_swa = False
+            self._set_seq_backing_pages(seq, swa_pages, role = "swa")
+            self._restore_cached_swa_prefix(seq, swa_pages)
+        self.sync_sequence_views(seq)
+        return result
+
+    def deallocate_sequence(self, seq):
+        old_swa_map = self._get_seq_page_map(seq, role = "swa")
+        for full_page_id, swa_page in old_swa_map.items():
+            if self.active_full_to_swa_pages.get(full_page_id) is swa_page:
+                del self.active_full_to_swa_pages[full_page_id]
+
+        swa_backing = self._get_seq_backing_pages(seq, role = "swa")
+        if swa_backing:
+            self.deallocate_pages(swa_backing)
+            self._set_seq_backing_pages(seq, None, role = "swa")
+        super().deallocate_sequence(seq)
+
+    def sync_sequence_views(self, seq):
+        self._sync_role_views(seq)
+
+    def clamp_prefill_end(
+        self,
+        seq,
+        prefill_start: int,
+        prefill_end: int,
+        embeddings = None,
+        atomic_mm_prefill: bool = False,
+    ) -> int:
+        swa_pages = self._get_seq_allocated_pages(seq, role = "swa")
+        if not swa_pages:
+            return prefill_end
+
+        local_capacity = len(swa_pages) * PAGE_SIZE
+        local_past = self._get_seq_kv_position(seq, role = "swa")
+        local_headroom = local_capacity - local_past
+        if local_headroom <= 0:
+            raise ValueError(
+                "Gemma4 sliding-window cache has no local headroom left for prefill "
+                f"(capacity {local_capacity}, local past {local_past}). "
+                "Increase swa_cache_size or reduce the effective local write span."
+            )
+
+        max_prefill_end = min(prefill_end, prefill_start + local_headroom)
+        if max_prefill_end >= prefill_end or not atomic_mm_prefill or not embeddings:
+            return max_prefill_end
+
+        seq_tokens = seq.sequence_ids.torch().view(-1)
+        for embedding in embeddings:
+            mask = (seq_tokens >= embedding.first_index) & (seq_tokens < embedding.last_index)
+            if not mask.any():
+                continue
+            mm_positions = torch.nonzero(mask, as_tuple = False).flatten()
+            mm_start = int(mm_positions[0])
+            mm_end = int(mm_positions[-1]) + 1
+            if prefill_start < mm_end and mm_start < max_prefill_end < mm_end:
+                required_tokens = mm_end - prefill_start
+                recommended_tokens = ((required_tokens + PAGE_SIZE - 1) // PAGE_SIZE) * PAGE_SIZE
+                raise ValueError(
+                    "Gemma4 atomic MM prefill span exceeds the current local SWA cache view "
+                    f"(need {required_tokens} local tokens, but only {local_headroom} are available; "
+                    f"capacity {local_capacity}, local past {local_past}; "
+                    f"next page-aligned safe size {recommended_tokens}). "
+                    "Increase swa_cache_size or reduce max_chunk_size."
+                )
+
+        return max_prefill_end
+
+    def build_cache_copy_plan(self, source_page, target_page, num_tokens, seq = None):
+        has_mm_tokens = self._sequence_has_mm_tokens(seq) if seq is not None else False
+        source_partial = None
+        if source_page.kv_position < PAGE_SIZE and source_page.prev_hash is not None and num_tokens > 0:
+            partial_ids = source_page.sequence[:, :num_tokens]
+            partial_key = self._cached_partial_page_key(source_page.prev_hash, partial_ids, has_mm_tokens)
+            source_partial = self.cached_partial_to_swa_pages.get(partial_key)
+        source_swa = (
+            self.active_full_to_swa_pages.get(id(source_page)) or
+            self.cached_full_to_swa_pages.get(self._cached_full_page_key(source_page, has_mm_tokens)) or
+            source_partial
+        )
+        target_swa = (
+            self.active_full_to_swa_pages.get(id(target_page)) or
+            self.cached_full_to_swa_pages.get(self._cached_full_page_key(target_page, has_mm_tokens))
+        )
+        if source_swa is None or target_swa is None:
+            return None
+        source_page_key = self._cached_full_page_key(source_page, has_mm_tokens)
+        if source_page_key in self.cached_full_to_swa_pages:
+            self.cached_full_to_swa_pages.move_to_end(source_page_key)
+        if source_partial is not None:
+            self.cached_partial_to_swa_pages.move_to_end(partial_key)
+        return {
+            "full": (source_page.page_index, target_page.page_index),
+            "swa": (source_swa.page_index, target_swa.page_index),
+        }
+
+    def build_draft_decode_params(self, active_jobs: list, max_seq_len: int) -> dict:
+        params = super().build_draft_decode_params(active_jobs, max_seq_len)
+        for job in active_jobs:
+            if not job.is_prefill_done():
+                continue
+            for seq in job.sequences:
+                self.sync_sequence_views(seq)
+                break
+        params["block_table_full"], params["cache_seqlens_full"] = self.build_batch_block_index(
+            active_jobs,
+            max_seq_len,
+            role = "full",
+            single_sequence_per_job = True,
+        )
+        params["block_table_swa"], params["cache_seqlens_swa"] = self.build_batch_block_index(
+            active_jobs,
+            max_seq_len,
+            role = "swa",
+            single_sequence_per_job = True,
+        )
+        return params
+
+    def build_decode_params(self, active_jobs: list, max_seq_len: int, use_offsets: bool = False) -> dict:
+        params = super().build_decode_params(active_jobs, max_seq_len, use_offsets = use_offsets)
+        for job in active_jobs:
+            if not job.is_prefill_done():
+                continue
+            for seq in job.sequences:
+                self.sync_sequence_views(seq)
+        params["block_table_full"], params["cache_seqlens_full"] = self.build_batch_block_index(
+            active_jobs,
+            max_seq_len,
+            role = "full",
+            single_sequence_per_job = False,
+        )
+        params["block_table_swa"], params["cache_seqlens_swa"] = self.build_batch_block_index(
+            active_jobs,
+            max_seq_len,
+            role = "swa",
+            single_sequence_per_job = False,
+        )
+        return params
+
+    def build_prefill_params(self, seq, prefill_start: int) -> dict:
+        params = super().build_prefill_params(seq, prefill_start)
+        self.sync_sequence_views(seq)
+        params["block_table_full"] = self._get_seq_block_index_tensor(seq, role = "full")
+        params["block_table_swa"] = self._get_seq_block_index_tensor(seq, role = "swa")
+        params["cache_seqlens_full"] = torch.tensor([self._get_seq_kv_position(seq, role = "full")], dtype = torch.int32)
+        params["cache_seqlens_swa"] = torch.tensor([self._get_seq_kv_position(seq, role = "swa")], dtype = torch.int32)
+        return params

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -379,7 +379,7 @@ class Generator:
             new_ids = torch.argmax(batch_logits, dim = -1)
             self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
             batch_ids.copy_(new_ids)
-            cache_params["cache_seqlens"] += 1
+            self.pagetable.advance_draft_decode_params(cache_params)
 
         self.draft_model.prefill(
             input_ids = batch_ids,
@@ -529,12 +529,12 @@ class Generator:
                         job.rejected_draft_tokens += rejected
                         for seq in job.sequences:
                             r = rejected
-                        while r:
-                            pos = seq.kv_position + r
-                            page = seq.allocated_pages[(pos - 1) // PAGE_SIZE]
-                            rp = min(page.kv_position, r)
-                            page.kv_position -= rp
-                            r -= rp
+                            while r:
+                                pos = seq.kv_position + r
+                                page = seq.allocated_pages[(pos - 1) // PAGE_SIZE]
+                                rp = min(page.kv_position, r)
+                                page.kv_position -= rp
+                                r -= rp
                             self.pagetable.sync_sequence_views(seq)
                         break
                     else:

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -14,7 +14,6 @@ from .sampler import Sampler
 from .visualizer import CacheVisualizer
 import time
 import threading
-from ..tokenizer import MMEmbedding
 from ..util import profile_opt
 
 class Generator:
@@ -93,10 +92,6 @@ class Generator:
         cfg = self.model.config
         self.padded_vocab_size = ((cfg.vocab_size + 31) // 32) * 32
 
-        # Paging
-        self.pagetable = PageTable(self, cache)
-        self.max_total_tokens = PAGE_SIZE * self.pagetable.max_pages
-
         # Draft model
         self.draft_model = draft_model
         self.draft_cache = draft_cache
@@ -116,6 +111,14 @@ class Generator:
         # Chunking/partitioning
         self.max_batch_size = max_batch_size
         self.max_chunk_size = max_chunk_size
+
+        # Paging
+        # Most models keep the default PageTable. Architectures such as Gemma4 can
+        # opt into a custom pagetable class through model caps without changing the
+        # public Generator API for existing models.
+        pagetable_cls = self.model.caps.get("page_table_cls", PageTable)
+        self.pagetable = pagetable_cls(self, cache)
+        self.max_total_tokens = PAGE_SIZE * self.pagetable.max_pages
 
         # Job queues
         self.job_serial = 0
@@ -141,7 +144,7 @@ class Generator:
 
         # Visualizer
         if show_visualizer:
-            self.visualizer = CacheVisualizer(self.pagetable.max_pages)
+            self.visualizer = CacheVisualizer(self.pagetable.get_visualizer_num_pages())
         else:
             self.visualizer = None
 
@@ -325,15 +328,7 @@ class Generator:
 
 
     def update_visualizer(self):
-        chains = []
-        for job in self.active_jobs:
-            for seq in job.sequences:
-                idx = job.serial_number
-                chain = [page.page_index for page in seq.allocated_pages]
-                chains.append((idx, chain))
-        usage = [0] * self.pagetable.max_pages
-        for page in self.pagetable.all_pages:
-            usage[page.page_index] = page.kv_position / PAGE_SIZE
+        chains, usage = self.pagetable.get_visualizer_state(self.active_jobs)
         self.visualizer.update(chains, usage)
 
 
@@ -349,18 +344,9 @@ class Generator:
         if batch_size == 0:
             return None
 
-        # Create block index table for batch
-        max_pages_batch = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
-        block_index = torch.zeros((batch_size, max_pages_batch), dtype = torch.int32)
-        cache_seqlens = torch.zeros((batch_size,), dtype = torch.int32)
-        batch = 0
-        for job in self.active_jobs:
-            if not job.is_prefill_done(): continue
-            for seq in job.sequences:
-                seq_block_index = seq.block_index_tensor[:, :max_pages_batch]
-                block_index[batch:batch+1, :seq_block_index.shape[-1]].copy_(seq_block_index)
-                cache_seqlens[batch] = seq.kv_position
-                batch += 1
+        # Default PageTable returns the original single-cache draft metadata.
+        # Custom pagetables can extend this without changing non-Gemma callers.
+        cache_params = self.pagetable.build_draft_decode_params(self.active_jobs, max_seq_len)
 
         # Indexed embeddings not supported when drafting
         # TODO: Allow multimodal draft model, perhaps with dummy embeddings?
@@ -386,23 +372,21 @@ class Generator:
                 input_ids = batch_ids,
                 params = {
                     "attn_mode": "flash_attn",
-                    "block_table": block_index,
                     "cache": self.draft_cache,
-                    "cache_seqlens": cache_seqlens,
+                    **cache_params,
                 }
             )
             new_ids = torch.argmax(batch_logits, dim = -1)
             self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
             batch_ids.copy_(new_ids)
-            cache_seqlens += 1
+            cache_params["cache_seqlens"] += 1
 
         self.draft_model.prefill(
             input_ids = batch_ids,
             params = {
                 "attn_mode": "flash_attn",
-                "block_table": block_index,
                 "cache": self.draft_cache,
-                "cache_seqlens": cache_seqlens
+                **cache_params,
             }
         )
 
@@ -423,22 +407,11 @@ class Generator:
         if draft_tokens is not None:
             max_seq_len += draft_tokens.shape[-1]
 
-        # Create block index table for batch
-        max_pages_batch = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
-        block_index = torch.zeros((batch_size, max_pages_batch), dtype = torch.int32)
-        cache_seqlens = torch.zeros((batch_size,), dtype = torch.int32)
-        batch = 0
         use_offsets = "mrope" in self.model.caps
-        positions = torch.zeros_like(cache_seqlens) if use_offsets else None
-        for job in self.active_jobs:
-            if not job.is_prefill_done(): continue
-            for seq in job.sequences:
-                seq_block_index = seq.block_index_tensor[:, :max_pages_batch]
-                block_index[batch:batch+1, :seq_block_index.shape[-1]].copy_(seq_block_index)
-                cache_seqlens[batch] = seq.kv_position
-                if use_offsets:
-                    positions[batch] = seq.kv_position + job.alt_rope_offset
-                batch += 1
+        # Non-Gemma models keep the original one-block-table decode contract
+        # through the default PageTable implementation. Custom pagetables can
+        # add role-aware tables while preserving that contract for other models.
+        cache_params = self.pagetable.build_decode_params(self.active_jobs, max_seq_len, use_offsets = use_offsets)
 
         # Collect input IDs and indexed embeddings
         input_ids_list = []
@@ -484,12 +457,10 @@ class Generator:
             input_ids = batch_ids,
             params = {
                 "attn_mode": "flash_attn",
-                "block_table": block_index,
                 "cache": self.cache,
-                "cache_seqlens": cache_seqlens,
                 "recurrent_states": batch_states,
-                "indexed_embeddings": active_embeddings,
-                "positions": positions,
+                **({"indexed_embeddings": active_embeddings} if active_embeddings else {}),
+                **cache_params,
             }
         )
 
@@ -558,12 +529,13 @@ class Generator:
                         job.rejected_draft_tokens += rejected
                         for seq in job.sequences:
                             r = rejected
-                            while r:
-                                pos = seq.kv_position + r
-                                page = seq.allocated_pages[(pos - 1) // PAGE_SIZE]
-                                rp = min(page.kv_position, r)
-                                page.kv_position -= rp
-                                r -= rp
+                        while r:
+                            pos = seq.kv_position + r
+                            page = seq.allocated_pages[(pos - 1) // PAGE_SIZE]
+                            rp = min(page.kv_position, r)
+                            page.kv_position -= rp
+                            r -= rp
+                            self.pagetable.sync_sequence_views(seq)
                         break
                     else:
                         job.accepted_draft_tokens += 1
@@ -594,15 +566,12 @@ class Generator:
             current_max_batch += len(job.sequences)
 
         # Start new jobs if possible
-        if (self.pagetable.num_unreferenced_pages() and
-            len(self.pending_jobs) and
-            current_max_batch < self.max_batch_size):
+        if len(self.pending_jobs) and current_max_batch < self.max_batch_size:
 
             skipped_jobs = []
             for job in self.pending_jobs.copy():
 
-                if (len(job.sequences) + current_max_batch > self.max_batch_size or
-                        job.current_new_pages_required() > self.pagetable.num_unreferenced_pages()):
+                if not self.pagetable.can_admit_job(job, current_max_batch, self.max_batch_size):
                     skipped_jobs.append(job)
                     continue
 

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -333,6 +333,7 @@ class Job:
                     ids = ids[:, tokens_page:]
                     tokens_to_add -= tokens_page
                     page.can_revert = False
+                self.pagetable.sync_sequence_views(seq)
         return input_ids_list
 
 
@@ -483,33 +484,40 @@ class Job:
                 else:
                     last_hash = None
 
-                page_ids = seq.sequence_ids.torch_slice(page_before * PAGE_SIZE, page_after * PAGE_SIZE)
-                new_hash = tensor_hash_checksum(page_ids, last_hash)
-
-                # If another referenced page has the same hash, switch to referencing that instead
-                if new_hash in self.pagetable.referenced_pages:
-                    new_serial = page.access_serial
-                    page.sub_ref()
-                    page = self.pagetable.referenced_pages[new_hash]
-                    assert page.kv_position == PAGE_SIZE
-                    seq.allocated_pages[page_before] = page
-                    seq.build_block_index_tensor()
-                    page.add_ref(new_serial)
-
-                else:
-                    # If an unreferenced page has the same hash, clear that page
-                    if new_hash in self.pagetable.unreferenced_pages:
-                        up = self.pagetable.unreferenced_pages[new_hash]
-                        up.clear()
-
-                    # Update the hash
+                if self.embeddings:
+                    new_hash = random_hash()
                     page.update_hash(new_hash)
+                else:
+                    page_ids = seq.sequence_ids.torch_slice(page_before * PAGE_SIZE, page_after * PAGE_SIZE)
+                    new_hash = tensor_hash_checksum(page_ids, last_hash)
+
+                    # If another referenced page has the same hash, switch to referencing that instead
+                    referenced_page = self.pagetable.find_referenced_page(new_hash)
+                    if referenced_page is not None:
+                        new_serial = page.access_serial
+                        page.sub_ref()
+                        page = referenced_page
+                        assert page.kv_position == PAGE_SIZE
+                        seq.allocated_pages[page_before] = page
+                        seq.build_block_index_tensor()
+                        page.add_ref(new_serial)
+                        self.pagetable.sync_sequence_views(seq)
+
+                    else:
+                        # If an unreferenced page has the same hash, clear that page
+                        up = self.pagetable.find_unreferenced_page(new_hash)
+                        if up is not None:
+                            self.pagetable.clear_page(up)
+
+                        # Update the hash
+                        page.update_hash(new_hash)
 
                 # Allow completing the final page without starting a new one (for requeue)
                 if page_after < len(seq.allocated_pages):
                     page = seq.allocated_pages[page_after]
                     page.prev_hash = new_hash
                     page.can_revert = False
+            self.pagetable.sync_sequence_views(seq)
 
         # Stream output
 
@@ -707,6 +715,7 @@ class Job:
                         page.kv_position = seq.kv_position - pi * PAGE_SIZE
                     else:
                         page.kv_position = 0
+                self.pagetable.sync_sequence_views(seq)
             off_tokens = self.held_tokens.slice(len(self.checkpoint["held_tokens"]), None)
             off_text = self.held_text[len(self.checkpoint["held_text"]):]
             self.held_text = self.checkpoint["held_text"]
@@ -850,15 +859,24 @@ class Job:
         # Hash full pages of input IDs
         all_unique_hashes = set()
         all_unique_pages = 0
+        allow_page_reuse = not bool(self.embeddings)
         for seq in self.sequences:
-            unique_hashes, unique_pages = seq.prepare(self.prefix_token is not None, self.max_rq_tokens)
+            # Default PageTable forwards to the original Sequence.prepare()
+            # behavior. Custom pagetables can tighten reuse rules without
+            # changing how non-Gemma jobs are hashed and queued.
+            unique_hashes, unique_pages = self.pagetable.prepare_sequence(
+                seq,
+                self.prefix_token is not None,
+                self.max_rq_tokens,
+                allow_page_reuse = allow_page_reuse,
+            )
             all_unique_hashes |= unique_hashes
             all_unique_pages += unique_pages
         self.all_unique_hashes = list(all_unique_hashes)
 
         # Make sure the request can potentially fit
         total_pages = len(self.all_unique_hashes) + seq.new_unique_pages
-        max_pages = self.pagetable.max_pages
+        max_pages = self.pagetable.get_max_pages_for_job(self)
         assert total_pages <= max_pages, \
             f"Job requires {total_pages} pages (only {max_pages} available) and cannot " + \
             f"be enqueued. Total cache allocated is {max_pages} * {PAGE_SIZE} = " + \
@@ -895,13 +913,7 @@ class Job:
 
 
     def current_new_pages_required(self):
-        new_pages = 0
-        for h in self.all_unique_hashes:
-            if h not in self.pagetable.referenced_pages:
-                new_pages += 1
-        for s in self.sequences:
-            new_pages += s.new_unique_pages
-        return new_pages
+        return self.pagetable.current_new_pages_required(self)
 
 
     def prefill(self, results: list):
@@ -963,10 +975,20 @@ class Job:
                     if not extended:
                         break
 
+            # The default pagetable leaves the prefill span unchanged. Custom
+            # pagetables can clamp it when an architecture needs stricter local
+            # cache invariants, while non-Gemma models keep the original path.
+            prefill_end = self.pagetable.clamp_prefill_end(
+                seq,
+                prefill_start,
+                prefill_end,
+                embeddings = self.embeddings,
+                atomic_mm_prefill = atomic_mm_prefill,
+            )
+
             if prefill_end <= prefill_start:
                 continue
 
-            assert prefill_start % PAGE_SIZE == 0
             prefill_ids = seq.sequence_ids.torch_slice(prefill_start, prefill_end)
 
             # Special case for partial last page, check if there's a page anywhere in the cache that
@@ -978,7 +1000,7 @@ class Job:
                 prev_hash = None if p0 == 0 else seq.allocated_pages[p0 - 1].phash
                 best_match = 0
                 best_match_page = None
-                for page in self.pagetable.all_pages:
+                for page in self.pagetable.iter_pages():
                     if page.prev_hash != prev_hash or id(page) == id(seq.allocated_pages[p0]):
                         continue
                     match = ext.count_match_tensor(page.sequence, prefill_ids, page.kv_position)
@@ -987,23 +1009,54 @@ class Job:
                         best_match_page = page
                 if best_match_page and best_match > 1:
                     page = seq.allocated_pages[p0]
-                    for c in [self.generator.cache] if not self.generator.draft_model else \
-                            [self.generator.cache, self.generator.draft_cache]:
-                        c.copy_page(
-                            c,
-                            best_match_page.page_index,
-                            page.page_index,
-                            best_match,
-                        )
-                    page.prev_hash = best_match_page.prev_hash
-                    page.sequence[:, :best_match].copy_(prefill_ids[:, :best_match])
-                    prefill_ids = prefill_ids[:, best_match:]
-                    prefill_start += best_match
-                    seq.kv_position += best_match
-                    page.kv_position = best_match
-                    page.can_revert = False
-                    self.cached_tokens += best_match
-                    progress += best_match
+                    copy_plan = self.pagetable.build_cache_copy_plan(
+                        best_match_page,
+                        page,
+                        best_match,
+                        seq = seq,
+                    )
+                    did_copy = False
+                    if copy_plan is False:
+                        # The default pagetable keeps the original whole-cache page
+                        # copy path. Custom pagetables return either a role-aware
+                        # plan dict or None to skip the optimization entirely.
+                        for c in [self.generator.cache] if not self.generator.draft_model else \
+                                [self.generator.cache, self.generator.draft_cache]:
+                            c.copy_page(
+                                c,
+                                best_match_page.page_index,
+                                page.page_index,
+                                best_match,
+                            )
+                        did_copy = True
+                    elif copy_plan is not None:
+                        for c in [self.generator.cache] if not self.generator.draft_model else \
+                                [self.generator.cache, self.generator.draft_cache]:
+                            c.copy_page(
+                                c,
+                                best_match_page.page_index,
+                                page.page_index,
+                                best_match,
+                                page_plan = copy_plan,
+                            )
+                        did_copy = True
+                    else:
+                        # A custom pagetable can decline the partial-copy optimization
+                        # for a specific source/target pair. In that case, keep the
+                        # original prefill path and ingest the remaining tokens
+                        # normally instead of stalling the sequence on this page.
+                        did_copy = False
+                    if did_copy:
+                        page.prev_hash = best_match_page.prev_hash
+                        page.sequence[:, :best_match].copy_(prefill_ids[:, :best_match])
+                        prefill_ids = prefill_ids[:, best_match:]
+                        prefill_start += best_match
+                        seq.kv_position += best_match
+                        page.kv_position = best_match
+                        page.can_revert = False
+                        self.cached_tokens += best_match
+                        progress += best_match
+                        self.pagetable.sync_sequence_views(seq)
 
             # For recurrent models, do a separate forward pass for the last page to get the latest possible checkpoint
             recurrent_last_page = False
@@ -1019,26 +1072,26 @@ class Job:
             if prefill_end > prefill_start:
 
                 if self.generator.draft_model:
+                    cache_params = self.pagetable.build_prefill_params(seq, prefill_start)
                     self.generator.draft_model.prefill(
                         input_ids = prefill_ids,
                         params = {
                             "attn_mode": "flash_attn",
-                            "block_table": seq.block_index_tensor,
                             "cache": self.generator.draft_cache,
-                            "cache_seqlens": torch.tensor([prefill_start], dtype = torch.int32)
+                            **cache_params,
                         }
                     )
 
+                cache_params = self.pagetable.build_prefill_params(seq, prefill_start)
                 self.generator.model.prefill(
                     input_ids = prefill_ids,
                     params = {
                         "attn_mode": "flash_attn",
-                        "block_table": seq.block_index_tensor,
                         "cache": self.generator.cache,
-                        "cache_seqlens": torch.tensor([prefill_start], dtype = torch.int32),
                         "recurrent_states": self.recurrent_state,
                         "indexed_embeddings": self.embeddings,
                         "inv_freq": self.alt_rope_freqs,
+                        **cache_params,
                     }
                 )
 
@@ -1058,10 +1111,12 @@ class Job:
                     pfp_b = pf_b - local_idx * PAGE_SIZE
                     page.sequence[:, pfp_a:pfp_b].copy_(seq.sequence_ids.torch_slice(pf_a, pf_b))
                     page.can_revert = False
+                self.pagetable.sync_sequence_views(seq)
 
                 progress += prefill_end - prefill_start
                 if self.sequences[0].kv_position >= len(seq.sequence_ids) - 1:
                     seq.prefill_complete = True
+                    self.pagetable.cache_prefill_copy_source(seq)
 
                 if recurrent_last_page:
                     self.maybe_stash_recurrent(self.generator.recurrent_cache, PAGE_SIZE)
@@ -1084,7 +1139,7 @@ class Job:
     def allocate_pages(self):
         for seq in self.sequences:
             allocated_pages, cached_pages, non_sequential_pages, recurrent_state = \
-                seq.allocate_pages(self.pagetable, self.generator.recurrent_cache)
+                self.pagetable.allocate_sequence(seq, self.generator.recurrent_cache)
 
             self.recurrent_state = None
             if self.generator.recurrent_cache is not None:
@@ -1101,9 +1156,7 @@ class Job:
 
     def deallocate_pages(self):
         for seq in self.sequences:
-            if seq.allocated_pages is not None:
-                self.pagetable.deallocate_pages(seq.allocated_pages)
-                seq.allocated_pages = []
+            self.pagetable.deallocate_sequence(seq)
 
 
     def prepare_sampling_past_ids(self):

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -909,6 +909,7 @@ class Job:
             self.time_first_prefill = time.time()
 
         progress = 0
+        atomic_mm_prefill = bool(self.embeddings) and self.generator.model.caps.get("atomic_mm_prefill", False)
         for seq in self.sequences:
             if seq.prefill_complete:
                 continue
@@ -922,26 +923,45 @@ class Job:
 
             p0 = prefill_start // PAGE_SIZE
             p1 = (prefill_end + PAGE_SIZE - 1) // PAGE_SIZE
-            for local_idx in range(p0, p1):
-                if 0 <= cp_pos <= seq.kv_position:
-                    break
-                page = seq.allocated_pages[local_idx]
-                if page.kv_position == PAGE_SIZE:
-                    prefill_start = (local_idx + 1) * PAGE_SIZE
-                    seq.kv_position = prefill_start
-                    self.cached_pages += 1
-                    page.can_revert = False
-                else:
-                    break
+            if not atomic_mm_prefill:
+                for local_idx in range(p0, p1):
+                    if 0 <= cp_pos <= seq.kv_position:
+                        break
+                    page = seq.allocated_pages[local_idx]
+                    if page.kv_position == PAGE_SIZE:
+                        prefill_start = (local_idx + 1) * PAGE_SIZE
+                        seq.kv_position = prefill_start
+                        self.cached_pages += 1
+                        page.can_revert = False
+                    else:
+                        break
 
-            p0 = prefill_start // PAGE_SIZE
-            for local_idx in range(p0, p1):
-                if 0 <= cp_pos <= seq.kv_position:
-                    break
-                page = seq.allocated_pages[local_idx]
-                if page.kv_position == PAGE_SIZE:
-                    prefill_end = local_idx * PAGE_SIZE
-                    break
+                p0 = prefill_start // PAGE_SIZE
+                for local_idx in range(p0, p1):
+                    if 0 <= cp_pos <= seq.kv_position:
+                        break
+                    page = seq.allocated_pages[local_idx]
+                    if page.kv_position == PAGE_SIZE:
+                        prefill_end = local_idx * PAGE_SIZE
+                        break
+
+            if atomic_mm_prefill:
+                seq_limit = len(seq.sequence_ids) - 1
+                seq_tokens = seq.sequence_ids.torch().view(-1)
+                while True:
+                    extended = False
+                    for embedding in self.embeddings:
+                        mask = (seq_tokens >= embedding.first_index) & (seq_tokens < embedding.last_index)
+                        if not mask.any():
+                            continue
+                        mm_positions = torch.nonzero(mask, as_tuple = False).flatten()
+                        mm_start = int(mm_positions[0])
+                        mm_end = int(mm_positions[-1]) + 1
+                        if prefill_start < mm_end and mm_start < prefill_end < mm_end:
+                            prefill_end = min(seq_limit, mm_end)
+                            extended = True
+                    if not extended:
+                        break
 
             if prefill_end <= prefill_start:
                 continue
@@ -954,7 +974,7 @@ class Job:
             # since the recurrent checkpoint will always be on a page boundary
             p0 = prefill_start // PAGE_SIZE
             p1 = prefill_end // PAGE_SIZE
-            if prefill_start == p0 * PAGE_SIZE and self.generator.recurrent_cache is None:
+            if prefill_start == p0 * PAGE_SIZE and self.generator.recurrent_cache is None and not atomic_mm_prefill:
                 prev_hash = None if p0 == 0 else seq.allocated_pages[p0 - 1].phash
                 best_match = 0
                 best_match_page = None

--- a/exllamav3/generator/pagetable.py
+++ b/exllamav3/generator/pagetable.py
@@ -399,6 +399,12 @@ class PageTable:
             "cache_seqlens": cache_seqlens,
         }
 
+    def advance_draft_decode_params(self, params: dict, step: int = 1) -> None:
+        # Default pagetable still advances the original single cache-seqlens
+        # tensor only. Custom pagetables can extend this when they expose
+        # additional role-aware seqlens tensors.
+        params["cache_seqlens"] += step
+
     def build_decode_params(self, active_jobs: list, max_seq_len: int, use_offsets: bool = False) -> dict:
         # Non-Gemma models stay on this original single-cache path. Custom
         # pagetables can extend it with extra role-aware tables while keeping the

--- a/exllamav3/generator/pagetable.py
+++ b/exllamav3/generator/pagetable.py
@@ -37,7 +37,7 @@ random_hash = _randomhash
 @dataclass
 class CachePage:
 
-    pagetable: PageTable
+    arena: PageArena
     page_index: int
 
     # Hash of this page if kv_position == PAGE_SIZE, else random hash. Also used to index (un)referenced_pages
@@ -95,9 +95,9 @@ class CachePage:
     # Increase reference count
     def add_ref(self, serial):
         if self.ref_count == 0:
-            del self.pagetable.unreferenced_pages[self.phash]
-            assert self.phash not in self.pagetable.referenced_pages
-            self.pagetable.referenced_pages[self.phash] = self
+            del self.arena.unreferenced_pages[self.phash]
+            assert self.phash not in self.arena.referenced_pages
+            self.arena.referenced_pages[self.phash] = self
         self.ref_count += 1
         self.access_serial = max(serial, self.access_serial)
         self.can_revert = False
@@ -105,10 +105,10 @@ class CachePage:
     # Increase reference count and clear page
     def add_ref_clear(self, serial, newhash):
         assert self.ref_count == 0
-        del self.pagetable.unreferenced_pages[self.phash]
+        del self.arena.unreferenced_pages[self.phash]
         self.phash = newhash
-        assert self.phash not in self.pagetable.referenced_pages
-        self.pagetable.referenced_pages[self.phash] = self
+        assert self.phash not in self.arena.referenced_pages
+        self.arena.referenced_pages[self.phash] = self
         self.ref_count += 1
         self.access_serial = serial
         self.prev_hash = None
@@ -119,10 +119,10 @@ class CachePage:
     def add_ref_unique(self, serial):
         self.backup()
         assert self.ref_count == 0
-        del self.pagetable.unreferenced_pages[self.phash]
+        del self.arena.unreferenced_pages[self.phash]
         self.phash = _randomhash()
-        assert self.phash not in self.pagetable.referenced_pages
-        self.pagetable.referenced_pages[self.phash] = self
+        assert self.phash not in self.arena.referenced_pages
+        self.arena.referenced_pages[self.phash] = self
         self.ref_count += 1
         self.access_serial = serial
         self.prev_hash = None
@@ -132,26 +132,26 @@ class CachePage:
     def sub_ref(self):
         self.ref_count -= 1
         if self.ref_count == 0:
-            del self.pagetable.referenced_pages[self.phash]
+            del self.arena.referenced_pages[self.phash]
             if self.can_revert:
                 self.revert()
-            if self.phash in self.pagetable.referenced_pages or self.phash in self.pagetable.unreferenced_pages:
+            if self.phash in self.arena.referenced_pages or self.phash in self.arena.unreferenced_pages:
                 self.phash = _randomhash()
                 self.prev_hash = None
-            assert self.phash not in self.pagetable.unreferenced_pages
-            self.pagetable.unreferenced_pages[self.phash] = self
+            assert self.phash not in self.arena.unreferenced_pages
+            self.arena.unreferenced_pages[self.phash] = self
 
     # Clear page
     def clear(self):
         assert self.ref_count == 0
-        del self.pagetable.unreferenced_pages[self.phash]
+        del self.arena.unreferenced_pages[self.phash]
         self.phash = _randomhash()
         self.prev_hash = None
         self.kv_position = 0
         self.can_revert = False
         self.sequence[:, :] = 0
-        assert self.phash not in self.pagetable.unreferenced_pages
-        self.pagetable.unreferenced_pages[self.phash] = self
+        assert self.phash not in self.arena.unreferenced_pages
+        self.arena.unreferenced_pages[self.phash] = self
 
     # Update hash
     def update_hash(self, newhash = None):
@@ -159,21 +159,64 @@ class CachePage:
             newhash = tensor_hash_checksum(self.sequence, self.prev_hash)
         assert self.ref_count > 0
         assert self.kv_position == PAGE_SIZE
-        del self.pagetable.referenced_pages[self.phash]
+        del self.arena.referenced_pages[self.phash]
         self.phash = newhash
         self.can_revert = False
-        assert self.phash not in self.pagetable.referenced_pages
-        self.pagetable.referenced_pages[self.phash] = self
+        assert self.phash not in self.arena.referenced_pages
+        self.arena.referenced_pages[self.phash] = self
 
     # Clear allocated page to repeat prefill
     def make_unique(self):
         assert self.ref_count > 0
-        del self.pagetable.referenced_pages[self.phash]
+        del self.arena.referenced_pages[self.phash]
         self.phash = _randomhash()
-        assert self.phash not in self.pagetable.referenced_pages
-        self.pagetable.referenced_pages[self.phash] = self
+        assert self.phash not in self.arena.referenced_pages
+        self.arena.referenced_pages[self.phash] = self
         self.prev_hash = None
         self.kv_position = 0
+
+
+class PageArena:
+
+    def __init__(self, pagetable: PageTable, max_pages: int, role: str = "default"):
+        self.pagetable = pagetable
+        self.role = role
+        self.max_pages = max_pages
+        self.access_serial = max_pages
+        self.referenced_pages = {}
+        self.unreferenced_pages = {}
+        self.all_pages = []
+        self.last_defrag_serial = max_pages
+        self.reset()
+
+    def reset(self):
+        self.referenced_pages = {}
+        self.unreferenced_pages = {}
+        self.all_pages = []
+        for idx in range(self.max_pages):
+            h = _randomhash()
+            cp = CachePage(
+                arena = self,
+                page_index = idx,
+                phash = h,
+                phash_revert = h,
+                prev_hash = None,
+                prev_hash_revert = None,
+                sequence = torch.empty((1, PAGE_SIZE), dtype = torch.long),
+                ref_count = 0,
+                access_serial = idx,
+                access_serial_revert = idx,
+                kv_position = 0,
+                kv_position_revert = 0,
+                can_revert = False,
+                new_page_index = 0,
+                children = [],
+                longest_chain = 1,
+            )
+            self.all_pages.append(cp)
+            self.unreferenced_pages[h] = cp
+        self.access_serial = self.max_pages
+        self.last_defrag_serial = self.access_serial
 
 
 class Sequence:
@@ -190,7 +233,7 @@ class Sequence:
         self.prefill_complete = False
 
 
-    def prepare(self, has_prefix_token: bool, max_new_tokens: int):
+    def prepare(self, has_prefix_token: bool, max_new_tokens: int, allow_page_reuse: bool = True):
         self.page_hashes = []
         unique_hashes = set()
 
@@ -202,9 +245,12 @@ class Sequence:
         r_hash = None
         for i in range(context_pages):
             # TODO: profile/optimize hash function
-            page_ids = self.sequence_ids.torch_slice(i * PAGE_SIZE, (i + 1) * PAGE_SIZE)
-            assert page_ids.shape[-1] == PAGE_SIZE
-            r_hash = tensor_hash_checksum(page_ids, r_hash)
+            if allow_page_reuse:
+                page_ids = self.sequence_ids.torch_slice(i * PAGE_SIZE, (i + 1) * PAGE_SIZE)
+                assert page_ids.shape[-1] == PAGE_SIZE
+                r_hash = tensor_hash_checksum(page_ids, r_hash)
+            else:
+                r_hash = _randomhash()
             self.page_hashes.append(r_hash)
             unique_hashes.add(r_hash)
 
@@ -212,10 +258,14 @@ class Sequence:
         return unique_hashes, self.new_unique_pages
 
     def build_block_index_tensor(self):
-        self.block_index_tensor = torch.tensor(
-            [[page.page_index for page in self.allocated_pages]],
-            dtype = torch.int32,
-        )
+        if self.allocated_pages is None:
+            self.block_index_tensor = None
+        else:
+            self.block_index_tensor = torch.tensor(
+                [[page.page_index for page in self.allocated_pages]],
+                dtype = torch.int32,
+            )
+        return self.block_index_tensor
 
     def allocate_pages(self, pagetable: PageTable, recurrent_cache: None | RecurrentCache):
         # If recurrent model, find logest recurrent prefix
@@ -253,55 +303,262 @@ class PageTable:
     ):
         self.generator = generator
         self.cache = cache
-        self.max_pages = cache.max_num_tokens // PAGE_SIZE
+        self.default_arena = PageArena(self, cache.max_num_tokens // PAGE_SIZE, role = "default")
 
-        self.access_serial = self.max_pages
-        self.referenced_pages = {}
-        self.unreferenced_pages = {}
-        self.all_pages = []
-        self.reset_page_table()
-        self.last_defrag_serial = self.max_pages
+    @property
+    def max_pages(self):
+        return self.default_arena.max_pages
+
+    @property
+    def access_serial(self):
+        return self.default_arena.access_serial
+
+    @access_serial.setter
+    def access_serial(self, value):
+        self.default_arena.access_serial = value
+
+    @property
+    def referenced_pages(self):
+        return self.default_arena.referenced_pages
+
+    @referenced_pages.setter
+    def referenced_pages(self, value):
+        self.default_arena.referenced_pages = value
+
+    @property
+    def unreferenced_pages(self):
+        return self.default_arena.unreferenced_pages
+
+    @unreferenced_pages.setter
+    def unreferenced_pages(self, value):
+        self.default_arena.unreferenced_pages = value
+
+    @property
+    def all_pages(self):
+        return self.default_arena.all_pages
+
+    @all_pages.setter
+    def all_pages(self, value):
+        self.default_arena.all_pages = value
+
+    @property
+    def last_defrag_serial(self):
+        return self.default_arena.last_defrag_serial
+
+    @last_defrag_serial.setter
+    def last_defrag_serial(self, value):
+        self.default_arena.last_defrag_serial = value
+
+    def build_batch_block_index(
+        self,
+        active_jobs: list,
+        max_seq_len: int,
+        role: str = "default",
+        single_sequence_per_job: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if role != "default":
+            raise KeyError(f"Unknown page arena role: {role}")
+        batch_size = 0
+        for job in active_jobs:
+            if not job.is_prefill_done():
+                continue
+            batch_size += 1 if single_sequence_per_job else len(job.sequences)
+
+        max_pages_batch = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+        block_index = torch.zeros((batch_size, max_pages_batch), dtype = torch.int32)
+        cache_seqlens = torch.zeros((batch_size,), dtype = torch.int32)
+
+        batch = 0
+        for job in active_jobs:
+            if not job.is_prefill_done():
+                continue
+            for seq in job.sequences:
+                seq_block_index = seq.block_index_tensor
+                if seq_block_index is None:
+                    continue
+                seq_block_index = seq_block_index[:, :max_pages_batch]
+                block_index[batch : batch + 1, :seq_block_index.shape[-1]].copy_(seq_block_index)
+                cache_seqlens[batch] = seq.kv_position
+                batch += 1
+                if single_sequence_per_job:
+                    break
+
+        return block_index, cache_seqlens
+
+    def build_draft_decode_params(self, active_jobs: list, max_seq_len: int) -> dict:
+        # The default pagetable exposes the same single-cache decode metadata the
+        # generator used inline before custom pagetables were introduced.
+        block_index, cache_seqlens = self.build_batch_block_index(
+            active_jobs,
+            max_seq_len,
+            role = "default",
+            single_sequence_per_job = True,
+        )
+        return {
+            "block_table": block_index,
+            "cache_seqlens": cache_seqlens,
+        }
+
+    def build_decode_params(self, active_jobs: list, max_seq_len: int, use_offsets: bool = False) -> dict:
+        # Non-Gemma models stay on this original single-cache path. Custom
+        # pagetables can extend it with extra role-aware tables while keeping the
+        # default contract intact for every other architecture.
+        block_index, cache_seqlens = self.build_batch_block_index(
+            active_jobs,
+            max_seq_len,
+            role = "default",
+            single_sequence_per_job = False,
+        )
+        positions = torch.zeros_like(cache_seqlens) if use_offsets else None
+
+        batch = 0
+        for job in active_jobs:
+            if not job.is_prefill_done():
+                continue
+            for seq in job.sequences:
+                if positions is not None:
+                    positions[batch] = seq.kv_position + job.alt_rope_offset
+                batch += 1
+
+        params = {
+            "block_table": block_index,
+            "cache_seqlens": cache_seqlens,
+        }
+        if positions is not None:
+            params["positions"] = positions
+        return params
+
+    def build_prefill_params(self, seq: Sequence, prefill_start: int) -> dict:
+        # Default prefill still uses one block table and one cache_seqlens tensor.
+        return {
+            "block_table": seq.block_index_tensor,
+            "cache_seqlens": torch.tensor([prefill_start], dtype = torch.int32),
+        }
+
+    def build_cache_copy_plan(
+        self,
+        source_page: CachePage,
+        target_page: CachePage,
+        num_tokens: int,
+        seq: Sequence | None = None,
+    ) -> dict[str, tuple[int, int]] | bool | None:
+        # The default pagetable keeps the original single-cache copy behavior. Custom
+        # pagetables can return a role-aware plan when they need extra copy targets.
+        return False
+
+    def get_arena(self, role: str = "default") -> PageArena:
+        if role != "default":
+            raise KeyError(f"Unknown page arena role: {role}")
+        return self.default_arena
+
+    def num_unreferenced_pages_by_role(self) -> dict[str, int]:
+        return { "default": self.num_unreferenced_pages() }
+
+    def current_new_pages_required_by_role(self, job) -> dict[str, int]:
+        return { "default": self.current_new_pages_required(job) }
+
+    def can_admit_job(self, job, current_batch_size: int, max_batch_size: int) -> bool:
+        if len(job.sequences) + current_batch_size > max_batch_size:
+            return False
+        required = self.current_new_pages_required_by_role(job)
+        available = self.num_unreferenced_pages_by_role()
+        for role, pages in required.items():
+            if pages > available.get(role, 0):
+                return False
+        return True
+
+    def get_visualizer_num_pages(self) -> int:
+        return self.get_arena("default").max_pages
+
+    def get_visualizer_state(self, active_jobs: list) -> tuple[list[tuple[int, list[int]]], list[float]]:
+        chains = []
+        for job in active_jobs:
+            for seq in job.sequences:
+                idx = job.serial_number
+                pages = seq.allocated_pages or []
+                chain = [page.page_index for page in pages]
+                chains.append((idx, chain))
+        usage = [0.0] * self.get_visualizer_num_pages()
+        for page in self.all_pages:
+            usage[page.page_index] = page.kv_position / PAGE_SIZE
+        return chains, usage
+
+    def get_max_pages_for_job(self, job) -> int:
+        return self.get_arena("default").max_pages
+
+    def find_referenced_page(self, page_hash: bytes, role: str = "default"):
+        return self.get_arena(role).referenced_pages.get(page_hash)
+
+    def find_unreferenced_page(self, page_hash: bytes, role: str = "default"):
+        return self.get_arena(role).unreferenced_pages.get(page_hash)
+
+    def iter_pages(self, role: str = "default"):
+        return iter(self.get_arena(role).all_pages)
+
+    def prepare_sequence(
+        self,
+        seq: Sequence,
+        has_prefix_token: bool,
+        max_new_tokens: int,
+        allow_page_reuse: bool = True,
+    ):
+        return seq.prepare(has_prefix_token, max_new_tokens, allow_page_reuse = allow_page_reuse)
+
+    def clamp_prefill_end(
+        self,
+        seq: Sequence,
+        prefill_start: int,
+        prefill_end: int,
+        embeddings = None,
+        atomic_mm_prefill: bool = False,
+    ) -> int:
+        return prefill_end
+
+    def sync_sequence_views(self, seq: Sequence):
+        # Default pagetable has only one logical cache view, so there is nothing to
+        # synchronize after page mutations.
+        pass
+
+    def cache_prefill_copy_source(self, seq: Sequence):
+        # Default pagetable does not snapshot role-specific local pages after prefill.
+        pass
+
+    def clear_page(self, page: CachePage, role: str = "default"):
+        page.clear()
+
+    def allocate_sequence(self, seq: Sequence, recurrent_cache: None | RecurrentCache):
+        return seq.allocate_pages(self, recurrent_cache)
+
+    def deallocate_sequence(self, seq: Sequence):
+        if seq.allocated_pages is not None:
+            self.deallocate_pages(seq.allocated_pages)
+            seq.allocated_pages = []
+
+    def current_new_pages_required(self, job) -> int:
+        arena = self.get_arena("default")
+        new_pages = 0
+        for h in job.all_unique_hashes:
+            if h not in arena.referenced_pages:
+                new_pages += 1
+        for s in job.sequences:
+            new_pages += s.new_unique_pages
+        return new_pages
 
 
     def reset_page_table(self):
         """
         Reset the page table.
         """
-        self.referenced_pages = {}
-        self.unreferenced_pages = {}
-        self.all_pages = []
-        for idx in range(self.max_pages):
-            h = _randomhash()
-            cp = CachePage(
-                pagetable = self,
-                page_index = idx,
-                phash = h,
-                phash_revert = h,
-                prev_hash = None,
-                prev_hash_revert = None,
-                sequence = torch.empty((1, PAGE_SIZE), dtype = torch.long),
-                ref_count = 0,
-                access_serial = idx,
-                access_serial_revert = idx,
-                kv_position = 0,
-                kv_position_revert = 0,
-                can_revert = False,
-                new_page_index = 0,
-                children = [],
-                longest_chain = 1,
-            )
-            self.all_pages.append(cp)
-            self.unreferenced_pages[h] = cp
-        self.access_serial = self.max_pages
-        self.last_defrag_serial = self.access_serial
+        self.default_arena.reset()
 
 
     def print_page_list(self, short: bool = True):
-        for cp in self.all_pages:
-            if cp.phash in self.referenced_pages:
+        arena = self.get_arena("default")
+        for cp in arena.all_pages:
+            if cp.phash in arena.referenced_pages:
                 assert cp.ref_count > 0
                 ref = str(cp.ref_count) if cp.ref_count < 10 else "+"
-            elif cp.phash in self.unreferenced_pages:
+            elif cp.phash in arena.unreferenced_pages:
                 assert cp.ref_count == 0
                 ref = "."
             else:
@@ -315,26 +572,28 @@ class PageTable:
         self,
         page_hashes: list,
         new_unique_pages: int,
-        recurrent_pages: list[int] | None
+        recurrent_pages: list[int] | None,
+        role: str = "default",
     ):
+        arena = self.get_arena(role)
         allocated_pages = []
         available_pages = None
 
         # Allocate whole pages
         for lp, h in enumerate(page_hashes):
-            self.access_serial += 1
+            arena.access_serial += 1
 
             # Find matching referenced page
-            rp = self.referenced_pages.get(h)
+            rp = arena.referenced_pages.get(h)
             if rp:
-                rp.add_ref(self.access_serial)
+                rp.add_ref(arena.access_serial)
                 allocated_pages.append(rp)
 
             # If possible, reuse an unreferenced page with matching hash
             else:
-                up = self.unreferenced_pages.get(h)
+                up = arena.unreferenced_pages.get(h)
                 if up:
-                    up.add_ref(self.access_serial)
+                    up.add_ref(arena.access_serial)
                     allocated_pages.append(up)
 
                 # No matching pages
@@ -342,7 +601,7 @@ class PageTable:
 
                     # Get list of unreferenced pages in order of oldest to newest
                     if available_pages is None:
-                        available_pages = list(self.unreferenced_pages.values())
+                        available_pages = list(arena.unreferenced_pages.values())
                         available_pages.sort(key = lambda x: x.access_serial)
                         available_pages = deque(available_pages)
                     else:
@@ -351,16 +610,16 @@ class PageTable:
 
                     # Allocate oldest unreferenced page
                     op = available_pages.popleft()
-                    op.add_ref_clear(self.access_serial, h)
+                    op.add_ref_clear(arena.access_serial, h)
                     allocated_pages.append(op)
 
         # Allocate unique pages
         for npi in range(new_unique_pages):
-            self.access_serial += 1
+            arena.access_serial += 1
 
             # Get list of unreferenced pages in order of oldest to newest
             if available_pages is None:
-                available_pages = list(self.unreferenced_pages.values())
+                available_pages = list(arena.unreferenced_pages.values())
                 available_pages.sort(key = lambda x: x.access_serial)
                 available_pages = deque(available_pages)
             else:
@@ -368,7 +627,7 @@ class PageTable:
                     available_pages.popleft()
 
             op = available_pages.popleft()
-            op.add_ref_unique(self.access_serial)
+            op.add_ref_unique(arena.access_serial)
             allocated_pages.append(op)
 
         # List prefilled pages
@@ -406,10 +665,11 @@ class PageTable:
 
 
     def num_unreferenced_pages(self):
-        return len(self.unreferenced_pages)
+        return len(self.get_arena("default").unreferenced_pages)
 
 
     def validate_pagetable(self, active_jobs):
+        arena = self.get_arena("default")
 
         def p_assert(exp):
             # assert exp
@@ -418,34 +678,34 @@ class PageTable:
 
         # Check page collections
         ids = set()
-        for p in self.referenced_pages.values():
+        for p in arena.referenced_pages.values():
             p_assert(p.ref_count > 0)
             ids.add(id(p))
-        for p in self.unreferenced_pages.values():
+        for p in arena.unreferenced_pages.values():
             p_assert(p.ref_count == 0)
             ids.add(id(p))
-        p_assert(len(ids) == self.max_pages)
-        p_assert(len(self.all_pages) == self.max_pages)
+        p_assert(len(ids) == arena.max_pages)
+        p_assert(len(arena.all_pages) == arena.max_pages)
 
         # Check job reference counts
-        refcounts = [0] * self.max_pages
+        refcounts = [0] * arena.max_pages
         for job in active_jobs:
             for seq in job.sequences:
                 for page in seq.allocated_pages:
                     refcounts[page.page_index] += 1
 
-        for page in self.all_pages:
+        for page in arena.all_pages:
             p_assert(page.ref_count == refcounts[page.page_index])
 
         # Check that all hashes are unique
         hashes = set()
-        for page in self.all_pages:
+        for page in arena.all_pages:
             p_assert(page.phash not in hashes)
             hashes.add(page.phash)
-        p_assert(len(hashes) == self.max_pages)
+        p_assert(len(hashes) == arena.max_pages)
 
         # Check individual hashes
-        for page in self.all_pages:
+        for page in arena.all_pages:
             if page.kv_position == PAGE_SIZE and page.phash[:8] != b'\x00\x00\x00\x00\x00\x00\x00\x00':
                 h = tensor_hash_checksum(page.sequence, page.prev_hash)
                 p_assert(page.phash == h)
@@ -463,16 +723,17 @@ class PageTable:
 
 
     def defrag(self, debug = False):
+        arena = self.get_arena("default")
 
         if not self.generator.enable_defrag:
             return
 
         # Defragment once job queue is empty and all pages have been touched at least once
-        if self.access_serial < self.last_defrag_serial + self.max_pages * 8:
+        if arena.access_serial < arena.last_defrag_serial + arena.max_pages * 8:
             return
-        self.last_defrag_serial = self.access_serial
+        arena.last_defrag_serial = arena.access_serial
 
-        assert not self.referenced_pages
+        assert not arena.referenced_pages
 
         if debug:
             torch.cuda.synchronize()
@@ -483,7 +744,7 @@ class PageTable:
         def build_page_index():
             nonlocal page_index
             page_index = {}
-            for page in self.all_pages:
+            for page in arena.all_pages:
                 page_index[page.phash] = page
                 page.children = []
                 page.longest_chain = 1
@@ -494,7 +755,7 @@ class PageTable:
         def build_root_pages():
             nonlocal root_pages
             root_pages = []
-            for page in self.all_pages:
+            for page in arena.all_pages:
                 if page.prev_hash is None:
                     root_pages.append(page)
                 else:
@@ -589,7 +850,7 @@ class PageTable:
                 shift_counts[shift] += 1
                 new_page_index += 1
 
-        assert new_page_index == self.max_pages
+        assert new_page_index == arena.max_pages
 
         # Adjust overall shift to minimize page copies
         shift_adjust = max(shift_counts, key = shift_counts.get)
@@ -599,15 +860,15 @@ class PageTable:
             print("Page shifts")
 
         defrag_map = {}
-        for page in self.all_pages:
-            page.new_page_index = (page.new_page_index - shift_adjust + self.max_pages) % self.max_pages
+        for page in arena.all_pages:
+            page.new_page_index = (page.new_page_index - shift_adjust + arena.max_pages) % arena.max_pages
             if page.page_index != page.new_page_index:
                 defrag_map[page.new_page_index] = page.page_index
                 if debug:
                     print(f"{page.new_page_index:2} ← {page.page_index:2}")
 
         # Don't bother if less than 10% of cache is fragmented
-        if len(defrag_map) <= max(self.max_pages // 10, 2):
+        if len(defrag_map) <= max(arena.max_pages // 10, 2):
             return
 
         # Find page rotations
@@ -658,7 +919,7 @@ class PageTable:
                 ext.cache_rotate(cache, all_rotations, buffer)
 
         # Write new page indices
-        for page in self.all_pages:
+        for page in arena.all_pages:
             page.page_index = page.new_page_index
 
         # Debug stuff

--- a/exllamav3/model_init.py
+++ b/exllamav3/model_init.py
@@ -178,18 +178,22 @@ def init(
                 k_bits, v_bits = tuple(split)
             else:
                 raise ValueError("Specify either one or two bitrates for cache quantization")
+            # Most models continue to instantiate the default quantized cache
+            # layer. Gemma4 opts in through model caps so model_init can keep
+            # the public cache_quant interface unchanged for non-Gemma models.
+            layer_type = model.caps.get("quantized_kv_cache_layer", CacheLayer_quant)
             cache = Cache(
                 model,
                 max_num_tokens = args.cache_size,
-                layer_type = CacheLayer_quant,
+                layer_type = layer_type,
                 k_bits = k_bits,
-                v_bits = v_bits
+                v_bits = v_bits,
             )
         else:
             cache = Cache(
                 model,
                 max_num_tokens = args.cache_size,
-                layer_type = CacheLayer_fp16
+                layer_type = CacheLayer_fp16,
             )
     else:
         cache = None

--- a/exllamav3/modules/__init__.py
+++ b/exllamav3/modules/__init__.py
@@ -16,3 +16,16 @@ from .qwen3_vl_pos_embedding import Qwen3VLPosEmbedding
 from .glm4v_pos_embedding import Glm4VPosEmbedding
 from .deepstack import DeepstackEmbed
 from .value_embeddings import ValueEmbeddings
+from .gemma4 import (
+    Gemma4Attention,
+    Gemma4Experts,
+    Gemma4MoEFeedForward,
+    Gemma4MoETransformerBlock,
+    Gemma4Router,
+    Gemma4TransformerBlock,
+    Gemma4VisionAttention,
+    Gemma4VisionPatchEmbedder,
+    Gemma4VisionPooler,
+    Gemma4VisionProjector,
+    Gemma4VisionStandardize,
+)

--- a/exllamav3/modules/__init__.py
+++ b/exllamav3/modules/__init__.py
@@ -18,14 +18,15 @@ from .deepstack import DeepstackEmbed
 from .value_embeddings import ValueEmbeddings
 from .gemma4 import (
     Gemma4Attention,
-    Gemma4Experts,
-    Gemma4MoEFeedForward,
-    Gemma4MoETransformerBlock,
-    Gemma4Router,
-    Gemma4TransformerBlock,
+    Gemma4GatedMLP,
     Gemma4VisionAttention,
     Gemma4VisionPatchEmbedder,
     Gemma4VisionPooler,
     Gemma4VisionProjector,
     Gemma4VisionStandardize,
+    Gemma4Experts,
+    Gemma4MoEFeedForward,
+    Gemma4MoETransformerBlock,
+    Gemma4Router,
+    Gemma4TransformerBlock,
 )

--- a/exllamav3/modules/gemma4.py
+++ b/exllamav3/modules/gemma4.py
@@ -1,0 +1,1362 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from typing_extensions import override
+
+from ..model.config import Config
+from ..model.model_tp_alloc import TPAllocation
+from ..util.rope import RoPE
+from ..util.tensor import get_for_device
+from ..constants import PAGE_SIZE
+from ..util.tensor import to2
+from . import Attention, GatedMLP, Linear, Module, RMSNorm, TransformerBlock
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2:]
+    return torch.cat((-x2, x1), dim = -1)
+
+
+def _apply_rotary_pos_emb(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    cos = cos.unsqueeze(2)
+    sin = sin.unsqueeze(2)
+    return (x * cos) + (_rotate_half(x) * sin)
+
+
+def _apply_multidimensional_rope(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    ndim = 2
+    channels_per_dim = 2 * (x.shape[-1] // (2 * ndim))
+    if channels_per_dim <= 0:
+        raise ValueError(f"Invalid multidimensional RoPE channel count: {x.shape[-1]}")
+
+    split_sizes = [channels_per_dim] * ndim
+    remainder = x.shape[-1] - channels_per_dim * ndim
+    if remainder > 0:
+        split_sizes.append(remainder)
+
+    x_parts = torch.split(x, split_sizes, dim = -1)
+    cos_parts = torch.split(cos, channels_per_dim, dim = -1)
+    sin_parts = torch.split(sin, channels_per_dim, dim = -1)
+    out_parts = [
+        _apply_rotary_pos_emb(x_part, cos_part, sin_part)
+        for x_part, cos_part, sin_part in zip(x_parts[:ndim], cos_parts, sin_parts)
+    ]
+    if remainder > 0:
+        out_parts.append(x_parts[-1])
+    return torch.cat(out_parts, dim = -1)
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+class Gemma4VisionRoPE:
+
+    def __init__(
+        self,
+        device: torch.device,
+        head_dim: int,
+        rope_theta: float,
+    ):
+        spatial_dim = head_dim // 2
+        self.device = device
+        self.inv_freq = 1.0 / (
+            rope_theta ** (
+                torch.arange(0, spatial_dim, 2, dtype = torch.int64, device = device).float() / spatial_dim
+            )
+        )
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        all_cos = []
+        all_sin = []
+        for i in range(2):
+            dim_position_ids = position_ids[:, :, i][:, None, :].float()
+            freqs = (inv_freq_expanded @ dim_position_ids).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim = -1)
+            all_cos.append(emb.cos())
+            all_sin.append(emb.sin())
+        cos = torch.cat(all_cos, dim = -1).to(dtype = x.dtype, device = x.device)
+        sin = torch.cat(all_sin, dim = -1).to(dtype = x.dtype, device = x.device)
+        return cos, sin
+
+
+class Gemma4Attention(Attention):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        layer_idx: int,
+        hidden_size: int,
+        head_dim: int,
+        num_q_heads: int,
+        num_kv_heads: int,
+        use_k_as_v: bool,
+        v_norm: RMSNorm | None,
+        **kwargs,
+    ):
+        key_v = kwargs.get("key_v")
+        super().__init__(
+            config=config,
+            key=key,
+            layer_idx=layer_idx,
+            hidden_size=hidden_size,
+            head_dim=head_dim,
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            key_v=kwargs["key_k"] if use_k_as_v else key_v,
+            **{k: v for k, v in kwargs.items() if k != "key_v"},
+        )
+
+        self.use_k_as_v = use_k_as_v
+        if use_k_as_v:
+            self.modules.remove(self.v_proj)
+            self.v_proj = None
+
+        self.v_norm = v_norm
+        self.register_submodule(self.v_norm)
+
+
+    def _get_vision_group_ids(self, params: dict) -> torch.Tensor | None:
+        group_ids = get_for_device(params, "vision_group_ids", self.device, None)
+        if group_ids is None:
+            return None
+        if group_ids.numel() == 0 or not (group_ids >= 0).any():
+            return None
+        return group_ids
+
+
+    def _build_mm_mask(
+        self,
+        bsz: int,
+        seqlen: int,
+        total_lens: torch.Tensor,
+        cache_seqlens: torch.Tensor | None,
+        vision_group_ids: torch.Tensor | None,
+        q_dtype: torch.dtype,
+        device: torch.device,
+        causal: bool,
+    ) -> torch.Tensor:
+        max_total = int(total_lens.max())
+        mask = torch.full(
+            (bsz, 1, seqlen, max_total),
+            torch.finfo(q_dtype).min,
+            dtype = q_dtype,
+            device = device,
+        )
+        for b in range(bsz):
+            total = int(total_lens[b])
+            if total == 0:
+                continue
+            past = int(cache_seqlens[b]) if cache_seqlens is not None else 0
+            full_groups = None
+            if vision_group_ids is not None:
+                full_groups = torch.full((total,), -1, dtype = torch.int32, device = device)
+                full_groups[past : past + seqlen] = vision_group_ids[b]
+            for qi in range(seqlen):
+                q_abs = past + qi
+                if not causal:
+                    start = 0 if self.sliding_window < 0 else max(0, q_abs - self.sliding_window)
+                    end = total if self.sliding_window < 0 else min(total, q_abs + self.sliding_window + 1)
+                    mask[b, 0, qi, start:end] = 0
+                else:
+                    end = min(total, q_abs + 1)
+                    start = 0 if self.sliding_window < 0 else max(0, q_abs - self.sliding_window)
+                    if end > start:
+                        mask[b, 0, qi, start:end] = 0
+                if full_groups is not None:
+                    q_group = int(full_groups[q_abs])
+                    if q_group >= 0:
+                        same_group = full_groups[:total] == q_group
+                        mask[b, 0, qi, same_group] = 0
+        return mask
+
+
+    def _mm_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        scale = self.sm_scale if self.sm_scale is not None else self.head_dim ** -0.5
+        if self.logit_softcapping:
+            if self.gqa and k.shape[1] != q.shape[1]:
+                repeat = q.shape[1] // k.shape[1]
+                k = k.repeat_interleave(repeat, dim = 1)
+                v = v.repeat_interleave(repeat, dim = 1)
+            scores = torch.matmul(q.float(), k.transpose(-1, -2).float()) * scale
+            scores = torch.tanh(scores / self.logit_softcapping) * self.logit_softcapping
+            scores = scores + mask.float()
+            probs = torch.softmax(scores, dim = -1, dtype = torch.float32)
+            return torch.matmul(probs, v.float()).to(q.dtype)
+
+        return F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask = mask,
+            is_causal = False,
+            enable_gqa = self.gqa,
+            scale = scale,
+        )
+
+
+    def optimizer_targets(self):
+        q = self.q_proj.optimizer_targets()
+        k = self.k_proj.optimizer_targets()
+        o = self.o_proj.optimizer_targets()
+        return [[q, k, o]]
+
+
+    def load_local(self, device, **kwargs):
+
+        if self.num_kv_heads == 0:
+            return
+
+        for cl in self.cache_layers:
+            cl.alloc(device)
+
+        if self.rope_settings:
+            self.rope = RoPE(
+                device,
+                self.rope_settings,
+            )
+
+        if self.q_norm and isinstance(self.q_norm, RMSNorm) and not self.q_norm.span_heads:
+            self.q_norm_tensor = self.q_norm.weight.data
+            self.k_norm_tensor = self.k_norm.weight.data
+
+
+    def project_qkv(self, x: torch.Tensor, params: dict) -> tuple:
+        bsz, q_len, _ = x.shape
+        q = self.q_proj.forward(x, params)
+
+        if self.interleaved_gate:
+            q, g = torch.chunk(q.view(bsz, q_len, -1, self.head_dim * 2), 2, dim = -1)
+            g = g.reshape(bsz, q_len, -1)
+        elif self.g_proj:
+            g = self.g_proj.forward(x, params)
+        else:
+            g = None
+
+        k = self.k_proj.forward(x, params)
+        v = k if self.v_proj is None else self.v_proj.forward(x, params)
+
+        if self.v_norm is not None:
+            v = v.view(bsz, q_len, self.num_kv_heads, self.head_dim)
+            v = self.v_norm.forward(v, params, out_dtype = torch.half)
+            v = v.view(bsz, q_len, self.num_kv_heads * self.head_dim)
+
+        return q, k, v, g
+
+
+    def _write_cache_pages(
+        self,
+        cache_tensor: torch.Tensor,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        values: torch.Tensor,
+    ) -> None:
+        bsz, seqlen, _, _ = values.shape
+        for b in range(bsz):
+            start = int(cache_seqlens[b])
+            for t in range(seqlen):
+                pos = start + t
+                page = int(block_table[b, pos // PAGE_SIZE])
+                page_pos = pos % PAGE_SIZE
+                cache_tensor[page, page_pos].copy_(values[b, t], non_blocking = True)
+
+
+    def _gather_cache_pages(
+        self,
+        cache_tensor: torch.Tensor,
+        block_table: torch.Tensor,
+        total_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        bsz = block_table.shape[0]
+        max_total = int(total_lens.max())
+        gathered = torch.zeros(
+            (bsz, max_total, self.num_kv_heads, self.head_dim),
+            dtype = cache_tensor.dtype,
+            device = cache_tensor.device,
+        )
+        for b in range(bsz):
+            total = int(total_lens[b])
+            if total == 0:
+                continue
+            num_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+            pages = block_table[b, :num_pages].long()
+            flat = cache_tensor.index_select(0, pages).reshape(-1, self.num_kv_heads, self.head_dim)
+            gathered[b, :total].copy_(flat[:total], non_blocking = True)
+        return gathered
+
+
+    def decode_flash_attn_fallback(
+        self,
+        x: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        params: dict,
+    ):
+        cache = params.get("cache")
+        block_table = get_for_device(params, "block_table", self.device)
+        cache_seqlens = get_for_device(params, "cache_seqlens", self.device)
+        position = params.get("position", 0)
+        positions = get_for_device(params, "positions", self.device, None)
+        position_ids = get_for_device(params, "position_ids", self.device, None)
+        inv_freq = get_for_device(params, "inv_freq", self.device, None)
+        causal = params.get("causal", True)
+        vision_group_ids = self._get_vision_group_ids(params)
+        if self.sliding_window < 0:
+            vision_group_ids = None
+
+        q, k, v, g = self.project_qkv(x, params)
+        q = q.view(bsz, seqlen, self.num_q_heads, self.head_dim)
+        k = k.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+
+        if self.q_norm:
+            if self.tp_span_heads_norm:
+                q, k = self.apply_qk_norms_tp(q, k, params)
+            elif not self.rope or self.q_norm_tensor is None:
+                q = self.q_norm.forward(q, params, out_dtype = torch.half)
+                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+
+        if self.rope:
+            q, k = self.rope.apply(
+                q, k,
+                position,
+                positions,
+                position_ids,
+                True,
+                self.q_norm_tensor if not self.tp_span_heads_norm else None,
+                self.k_norm_tensor if not self.tp_span_heads_norm else None,
+                self.norm_eps,
+                self.norm_constant_bias,
+                inv_freq,
+                self.post_rope_norm
+            )
+
+        cache_k, cache_v = cache.get_layer(self.layer_idx, cache_seqlens, block_table)
+        self._write_cache_pages(cache_k, block_table, cache_seqlens, k)
+        self._write_cache_pages(cache_v, block_table, cache_seqlens, v)
+
+        total_lens = cache_seqlens + seqlen
+        all_k = self._gather_cache_pages(cache_k, block_table, total_lens).transpose(1, 2)
+        all_v = self._gather_cache_pages(cache_v, block_table, total_lens).transpose(1, 2)
+        q = q.transpose(1, 2)
+        mask = self._build_mm_mask(
+            bsz,
+            seqlen,
+            total_lens,
+            cache_seqlens,
+            vision_group_ids,
+            q.dtype,
+            q.device,
+            causal,
+        )
+        o = self._mm_attention(q, all_k, all_v, mask)
+
+        cache_layer = cache.layers[self.layer_idx]
+        if hasattr(cache_layer, "qk"):
+            cache.update_layer(self.layer_idx, cache_seqlens, block_table, k, v, seqlen)
+
+        if self.headwise_gate:
+            o *= g.sigmoid().unsqueeze(-1)
+        o = o.transpose(1, 2).contiguous().reshape((bsz, seqlen, self.num_q_heads * self.head_dim))
+        if self.interleaved_gate:
+            o *= g.sigmoid()
+
+        return self.project_o(o, bsz, seqlen, params)
+
+
+    def decode_sdpa_nc(
+        self,
+        x: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        params: dict,
+    ):
+        causal = params.get("causal", True)
+        position = params.get("position", 0)
+        positions = get_for_device(params, "positions", self.device, None)
+        position_ids = get_for_device(params, "position_ids", self.device, None)
+        inv_freq = get_for_device(params, "inv_freq", self.device, None)
+        vision_group_ids = self._get_vision_group_ids(params)
+        if self.sliding_window < 0:
+            vision_group_ids = None
+
+        q, k, v, g = self.project_qkv(x, params)
+        q = q.view(bsz, seqlen, self.num_q_heads, self.head_dim)
+        k = k.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+
+        if self.q_norm:
+            if self.tp_span_heads_norm:
+                q, k = self.apply_qk_norms_tp(q, k, params)
+            elif not self.rope or self.q_norm_tensor is None:
+                q = self.q_norm.forward(q, params, out_dtype = torch.half)
+                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+
+        if self.rope:
+            q, k = self.rope.apply(
+                q, k,
+                position,
+                positions,
+                position_ids,
+                True,
+                self.q_norm_tensor if not self.tp_span_heads_norm else None,
+                self.k_norm_tensor if not self.tp_span_heads_norm else None,
+                self.norm_eps,
+                self.norm_constant_bias,
+                inv_freq,
+                self.post_rope_norm
+            )
+
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        if vision_group_ids is not None:
+            total_lens = torch.full((bsz,), seqlen, dtype = torch.int32, device = q.device)
+            mask = self._build_mm_mask(
+                bsz,
+                seqlen,
+                total_lens,
+                None,
+                vision_group_ids,
+                q.dtype,
+                q.device,
+                causal,
+            )
+            o = self._mm_attention(q, k, v, mask)
+        else:
+            o = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                is_causal = causal,
+                enable_gqa = self.gqa,
+                scale = self.sm_scale,
+            )
+
+        if self.headwise_gate:
+            o *= g.sigmoid().unsqueeze(-1)
+        o = o.transpose(1, 2).contiguous().reshape((bsz, seqlen, self.num_q_heads * self.head_dim))
+        if self.interleaved_gate:
+            o *= g.sigmoid()
+
+        return self.project_o(o, bsz, seqlen, params)
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        if self.num_kv_heads == 0:
+            x = torch.zeros_like(x, dtype = self.out_dtype)
+            return to2(x, out_dtype, self.out_dtype)
+
+        bsz, seqlen, _ = x.shape
+        attn_mode = params.get("attn_mode", "flash_attn_nc")
+        vision_group_ids = self._get_vision_group_ids(params)
+        if self.sliding_window < 0:
+            vision_group_ids = None
+
+        if self.head_dim > 256 or vision_group_ids is not None:
+            match attn_mode:
+                case "flash_attn_nc":
+                    x = self.decode_sdpa_nc(x, bsz, seqlen, params)
+                case "flash_attn":
+                    x = self.decode_flash_attn_fallback(x, bsz, seqlen, params)
+                case "sdpa_nc":
+                    x = self.decode_sdpa_nc(x, bsz, seqlen, params)
+                case _:
+                    raise ValueError(f"Unknown attn_mode: {attn_mode}")
+            return to2(x, out_dtype, self.out_dtype)
+
+        return super().forward(x, params, out_dtype)
+
+
+    def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        storage = 0
+        storage += self.q_proj.storage_size()
+        storage += self.k_proj.storage_size()
+        storage += self.o_proj.storage_size()
+        for cl in self.cache_layers:
+            storage += cl.storage_size()
+        overhead_d = 0
+        overhead_d += self.hidden_size * (self.out_dtype or torch.half).itemsize
+        overhead_s = 0
+        for cl in self.cache_layers:
+            overhead_s += cl.overhead_size()
+        overhead_s += 2 * self.num_q_heads * self.head_dim * torch.half.itemsize
+        overhead_s += 2 * self.num_kv_heads * self.head_dim * torch.half.itemsize
+        recons = max(
+            self.q_proj.recons_size(),
+            self.k_proj.recons_size(),
+            self.o_proj.recons_size(),
+        )
+        channel_width = 1
+        channels_to_split = self.num_kv_heads
+        while channel_width * self.head_dim < 128:
+            assert channels_to_split % 2 == 0, \
+                "Model's K/V heads cannot divide into 128-channel tensors"
+            channel_width *= 2
+            channels_to_split //= 2
+        assert (channel_width * self.head_dim) % 128 == 0, \
+            "Model's K/V heads cannot divide into 128-channel tensors"
+        return [
+            TPAllocation(
+                key = self.key,
+                channel_width = channel_width,
+                channel_unit = "heads",
+                storage_per_device = 0,
+                storage_to_split = storage,
+                overhead_per_device = overhead_d,
+                overhead_to_split = overhead_s,
+                recons_temp = recons,
+                channels_to_split = channels_to_split,
+                limit_key = "attn"
+            )
+        ]
+
+
+class Gemma4TransformerBlock(TransformerBlock):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        **kwargs,
+    ):
+        super().__init__(config=config, key=key, **kwargs)
+        self.layer_scalar_key = f"{key}.layer_scalar"
+        self.layer_scalar = None
+        self.layer_scalar_numel = 1
+
+
+    def optimizer_targets(self):
+        return super().optimizer_targets()
+
+
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        layer_scalar = self.config.stc.get_tensor(
+            self.layer_scalar_key,
+            device,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.layer_scalar = nn.Parameter(layer_scalar, requires_grad = False)
+        self.layer_scalar_numel = layer_scalar.numel()
+
+
+    def unload(self):
+        super().unload()
+        self.layer_scalar = None
+
+
+    def get_tensors(self):
+        if self.layer_scalar is None:
+            return {}
+        return {
+            self.layer_scalar_key: self.layer_scalar.data.contiguous(),
+        }
+
+
+    def weights_numel(self):
+        return super().weights_numel() + self.layer_scalar_numel
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        x = super().forward(x, params, out_dtype = None)
+        if self.layer_scalar is not None:
+            x = x * self.layer_scalar.to(dtype = x.dtype)
+        return to2(x, out_dtype, self.out_dtype)
+
+
+class Gemma4Router(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        hidden_size: int,
+        num_experts: int,
+        num_experts_per_tok: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.scalar_root_size = hidden_size ** -0.5
+        self.scale_key = f"{key}.scale"
+        self.per_expert_scale_key = f"{key}.per_expert_scale"
+        self.scale = None
+        self.per_expert_scale = None
+        self.extra_numel = 0
+
+        self.norm = RMSNorm(
+            config = config,
+            key = f"{key}.norm",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.float,
+            unweighted = True,
+        )
+        self.proj = Linear(
+            config = config,
+            key = f"{key}.proj",
+            in_features = hidden_size,
+            out_features = num_experts,
+            qmap = None,
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+        self.register_submodule(self.norm)
+        self.register_submodule(self.proj)
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.scale = self.config.stc.get_tensor(
+            self.scale_key,
+            device,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.per_expert_scale = self.config.stc.get_tensor(
+            self.per_expert_scale_key,
+            device,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.extra_numel = self.scale.numel() + self.per_expert_scale.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.scale = None
+        self.per_expert_scale = None
+        self.extra_numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.scale is None or self.per_expert_scale is None:
+            return {}
+        return {
+            self.scale_key: self.scale.data.contiguous(),
+            self.per_expert_scale_key: self.per_expert_scale.data.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return super().weights_numel() + self.extra_numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        y = self.norm.forward_torch(x, params, out_dtype = torch.float)
+        y = y * self.scale.to(dtype = y.dtype)
+        y *= self.scalar_root_size
+
+        logits = self.proj.forward(y.half(), params, out_dtype = torch.float).float()
+        probs = torch.softmax(logits, dim = -1)
+
+        if params.get("activate_all_experts"):
+            selected = (
+                torch.arange(self.num_experts, dtype = torch.long, device = x.device)
+                .repeat((x.shape[0], 1))
+            )
+            weights = probs * self.per_expert_scale.to(dtype = probs.dtype).unsqueeze(0)
+            return selected, weights
+
+        top_k_weights, top_k_index = torch.topk(
+            probs,
+            k = self.num_experts_per_tok,
+            dim = -1,
+        )
+        top_k_weights /= top_k_weights.sum(dim = -1, keepdim = True)
+        top_k_weights *= self.per_expert_scale[top_k_index].to(dtype = top_k_weights.dtype)
+        return top_k_index, top_k_weights
+
+
+class Gemma4Experts(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+        qmap: str,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_experts = num_experts
+
+        self.gates = []
+        self.ups = []
+        self.downs = []
+
+        fkey_gate_up = f"{key}.experts.gate_up_proj"
+        fkey_down = f"{key}.experts.down_proj"
+
+        for idx in range(num_experts):
+            gate = Linear(
+                config = config,
+                key = f"{key}.experts.{idx}.gate_proj",
+                fkey = fkey_gate_up,
+                fidx = idx,
+                frange = (0, intermediate_size),
+                frange_dim = 1,
+                in_features = hidden_size,
+                out_features = intermediate_size,
+                qmap = qmap + ".input",
+                out_dtype = torch.half,
+                transposed_load = True,
+                transpose_fused_weights = True,
+                ftranspose_after_load = False,
+                qgroup = key + ".experts.gud",
+            )
+            up = Linear(
+                config = config,
+                key = f"{key}.experts.{idx}.up_proj",
+                fkey = fkey_gate_up,
+                fidx = idx,
+                frange = (intermediate_size, intermediate_size * 2),
+                frange_dim = 1,
+                in_features = hidden_size,
+                out_features = intermediate_size,
+                qmap = qmap + ".input",
+                out_dtype = torch.half,
+                transposed_load = True,
+                transpose_fused_weights = True,
+                ftranspose_after_load = False,
+                qgroup = key + ".experts.gud",
+            )
+            down = Linear(
+                config = config,
+                key = f"{key}.experts.{idx}.down_proj",
+                fkey = fkey_down,
+                fidx = idx,
+                in_features = intermediate_size,
+                out_features = hidden_size,
+                qmap = qmap + f".{idx}.down",
+                out_dtype = torch.float,
+                allow_input_padding = True,
+                transposed_load = True,
+                transpose_fused_weights = True,
+                ftranspose_after_load = False,
+                qgroup = key + ".experts.gud",
+            )
+
+            self.gates.append(gate)
+            self.ups.append(up)
+            self.downs.append(down)
+            self.register_submodule(gate)
+            self.register_submodule(up)
+            self.register_submodule(down)
+
+
+    @override
+    def optimizer_targets(self):
+        g, u, d = [], [], []
+        for m in self.gates:
+            g += m.optimizer_targets()
+        for m in self.ups:
+            u += m.optimizer_targets()
+        for m in self.downs:
+            d += m.optimizer_targets()
+        return [[g + u, d]]
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        selected_experts: torch.Tensor,
+        routing_weights: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        y = x.view(-1, self.hidden_size)
+        final_hidden_states = torch.zeros_like(y, dtype = torch.float)
+
+        num_tokens, top_k = selected_experts.shape
+        flat_experts = selected_experts.reshape(-1)
+        flat_weights = routing_weights.reshape(-1).to(dtype = torch.float)
+        flat_tokens = torch.arange(num_tokens, device = y.device).repeat_interleave(top_k)
+
+        order = flat_experts.argsort()
+        expert_sorted = flat_experts[order]
+        token_sorted = flat_tokens[order]
+        weight_sorted = flat_weights[order]
+
+        expert_count = torch.bincount(expert_sorted, minlength = self.num_experts)
+        expert_ptr = torch.empty(self.num_experts + 1, dtype = torch.long, device = y.device)
+        expert_ptr[0] = 0
+        expert_ptr[1:] = expert_count.cumsum(0)
+
+        for expert_idx in range(self.num_experts):
+            start = int(expert_ptr[expert_idx])
+            end = int(expert_ptr[expert_idx + 1])
+            if start == end:
+                continue
+
+            top_x = token_sorted[start:end]
+            current_state = y.index_select(0, top_x)
+            gate = self.gates[expert_idx].forward(current_state, params)
+            up = self.ups[expert_idx].forward(current_state, params)
+            current_hidden_states = F.gelu(gate, approximate = "tanh") * up
+            current_hidden_states = self.downs[expert_idx].forward(current_hidden_states, params)
+            current_hidden_states *= weight_sorted[start:end].unsqueeze(1).to(dtype = current_hidden_states.dtype)
+            final_hidden_states.index_add_(0, top_x, current_hidden_states)
+
+        return to2(final_hidden_states.view(x.shape), out_dtype, torch.float)
+
+
+class Gemma4MoEFeedForward(Module):
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        hidden_size: int,
+        intermediate_size: int,
+        moe_intermediate_size: int,
+        num_experts: int,
+        num_experts_per_tok: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+
+        self.dense_mlp = GatedMLP(
+            config = config,
+            key = f"{key}.mlp",
+            hidden_size = hidden_size,
+            intermediate_size = intermediate_size,
+            key_up = "up_proj",
+            key_gate = "gate_proj",
+            key_down = "down_proj",
+            qmap = "block.mlp",
+            activation_fn = "gelu",
+            interm_dtype = torch.half,
+            out_dtype = torch.float,
+        )
+        self.dense_post_norm = RMSNorm(
+            config = config,
+            key = f"{key}.post_feedforward_layernorm_1",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.float,
+        )
+        self.routed_pre_norm = RMSNorm(
+            config = config,
+            key = f"{key}.pre_feedforward_layernorm_2",
+            rms_norm_eps = rms_norm_eps,
+        )
+        self.routed_post_norm = RMSNorm(
+            config = config,
+            key = f"{key}.post_feedforward_layernorm_2",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.float,
+        )
+        self.router = Gemma4Router(
+            config = config,
+            key = f"{key}.router",
+            hidden_size = hidden_size,
+            num_experts = num_experts,
+            num_experts_per_tok = num_experts_per_tok,
+            rms_norm_eps = rms_norm_eps,
+        )
+        self.experts = Gemma4Experts(
+            config = config,
+            key = key,
+            hidden_size = hidden_size,
+            intermediate_size = moe_intermediate_size,
+            num_experts = num_experts,
+            qmap = "block.mlp",
+        )
+
+        self.register_submodule(self.dense_mlp)
+        self.register_submodule(self.dense_post_norm)
+        self.register_submodule(self.routed_pre_norm)
+        self.register_submodule(self.routed_post_norm)
+        self.register_submodule(self.router)
+        self.register_submodule(self.experts)
+
+
+    @override
+    def optimizer_targets(self):
+        return [self.dense_mlp.optimizer_targets(), self.experts.optimizer_targets()]
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        dense = self.dense_mlp.forward(x, params)
+        dense = self.dense_post_norm.forward(dense, params)
+
+        selected_experts, routing_weights = self.router.forward(
+            residual.view(-1, self.hidden_size),
+            params,
+        )
+        routed_input = self.routed_pre_norm.forward(residual, params, out_dtype = torch.half)
+        routed = self.experts.forward(routed_input, selected_experts, routing_weights, params)
+        routed = self.routed_post_norm.forward(routed, params)
+
+        y = dense + routed
+        return to2(y, out_dtype, torch.float)
+
+
+class Gemma4MoETransformerBlock(Gemma4TransformerBlock):
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+
+        if self.attn:
+            y = self.attn_norm.forward(x, params, out_dtype = torch.half) if self.attn_norm else x.half()
+            y = self.attn.forward(y, params)
+            if params.get("prefill"):
+                return x
+            if self.attn_post_norm:
+                y = self.attn_post_norm.forward(y, params)
+            x = x + y
+
+        if self.mlp:
+            residual = x
+            y = self.mlp_norm.forward(x, params, out_dtype = torch.half) if self.mlp_norm else x.half()
+            y = self.mlp.forward(y, residual, params)
+            if self.mlp_post_norm:
+                y = self.mlp_post_norm.forward(y, params)
+            x = residual + y
+
+        if self.layer_scalar is not None:
+            x = x * self.layer_scalar.to(dtype = x.dtype)
+
+        return to2(x, out_dtype, self.out_dtype)
+
+
+class Gemma4VisionPatchEmbedder(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        hidden_size: int,
+        patch_dim: int,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+        self.position_embedding_size = config.vision.position_embedding_size
+        self.position_embedding_key = f"{key}.position_embedding_table"
+        self.position_embedding_table = None
+        self.position_embedding_numel = 0
+
+        self.input_proj = Linear(
+            config = config,
+            key = f"{key}.input_proj",
+            in_features = patch_dim,
+            out_features = hidden_size,
+            qmap = None,
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+        self.register_submodule(self.input_proj)
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.position_embedding_table = self.config.stc.get_tensor(
+            self.position_embedding_key,
+            device,
+            float2half = True,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self.position_embedding_numel = self.position_embedding_table.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.position_embedding_table = None
+        self.position_embedding_numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.position_embedding_table is None:
+            return {}
+        return {
+            self.position_embedding_key: self.position_embedding_table.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return super().weights_numel() + self.position_embedding_numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        position_ids = get_for_device(params, "image_position_ids", self.device)
+        padding_positions = (position_ids == -1).all(dim = -1)
+        clamped_positions = position_ids.clamp(min = 0)
+        x = 2.0 * (x - 0.5)
+        hidden_states = self.input_proj.forward(x, params, out_dtype = torch.half)
+
+        pos_x = clamped_positions[..., 0].reshape(-1)
+        pos_y = clamped_positions[..., 1].reshape(-1)
+        table = self.position_embedding_table
+        pos_emb = table[0].index_select(0, pos_x) + table[1].index_select(0, pos_y)
+        pos_emb = pos_emb.view(position_ids.shape[0], position_ids.shape[1], self.hidden_size).to(hidden_states.dtype)
+        pos_emb = torch.where(padding_positions.unsqueeze(-1), torch.zeros_like(pos_emb), pos_emb)
+        hidden_states = hidden_states + pos_emb
+        return to2(hidden_states, out_dtype, torch.half)
+
+
+class Gemma4VisionAttention(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        layer_idx: int,
+        hidden_size: int,
+        head_dim: int,
+        num_q_heads: int,
+        num_kv_heads: int,
+        rope_theta: float,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.layer_idx = layer_idx
+        self.hidden_size = hidden_size
+        self.head_dim = head_dim
+        self.num_q_heads = num_q_heads
+        self.num_kv_heads = num_kv_heads
+        self.gqa = (num_q_heads != num_kv_heads)
+        self.rope_theta = rope_theta
+        self.rope = None
+
+        self.q_proj = Linear(config, f"{key}.q_proj.linear", hidden_size, num_q_heads * head_dim, qmap = None)
+        self.k_proj = Linear(config, f"{key}.k_proj.linear", hidden_size, num_kv_heads * head_dim, qmap = None)
+        self.v_proj = Linear(config, f"{key}.v_proj.linear", hidden_size, num_kv_heads * head_dim, qmap = None)
+        self.o_proj = Linear(config, f"{key}.o_proj.linear", num_q_heads * head_dim, hidden_size, qmap = None)
+        self.q_norm = RMSNorm(config, f"{key}.q_norm", rms_norm_eps = rms_norm_eps)
+        self.k_norm = RMSNorm(config, f"{key}.k_norm", rms_norm_eps = rms_norm_eps)
+        self.v_norm = RMSNorm(config, f"{key}.v_norm", rms_norm_eps = rms_norm_eps, unweighted = True)
+
+        self.register_submodule(self.q_proj)
+        self.register_submodule(self.k_proj)
+        self.register_submodule(self.v_proj)
+        self.register_submodule(self.o_proj)
+        self.register_submodule(self.q_norm)
+        self.register_submodule(self.k_norm)
+        self.register_submodule(self.v_norm)
+
+
+    @override
+    def optimizer_targets(self):
+        q = self.q_proj.optimizer_targets()
+        k = self.k_proj.optimizer_targets()
+        v = self.v_proj.optimizer_targets()
+        o = self.o_proj.optimizer_targets()
+        return [[q, k + v, o]]
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.rope = Gemma4VisionRoPE(device, self.head_dim, self.rope_theta)
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.rope = None
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        position_ids = get_for_device(params, "image_position_ids", self.device)
+        padding_positions = (position_ids == -1).all(dim = -1)
+        bsz, seqlen, _ = x.shape
+
+        q = self.q_proj.forward(x, params).view(bsz, seqlen, self.num_q_heads, self.head_dim)
+        k = self.k_proj.forward(x, params).view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.v_proj.forward(x, params).view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+
+        q = self.q_norm.forward(q, params, out_dtype = torch.half)
+        k = self.k_norm.forward(k, params, out_dtype = torch.half)
+        v = self.v_norm.forward(v, params, out_dtype = torch.half)
+
+        cos, sin = self.rope.forward(q, position_ids)
+        q = _apply_multidimensional_rope(q, cos, sin).transpose(1, 2)
+        k = _apply_multidimensional_rope(k, cos, sin).transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        if self.gqa:
+            repeat = self.num_q_heads // self.num_kv_heads
+            k = _repeat_kv(k, repeat)
+            v = _repeat_kv(v, repeat)
+
+        attn_mask = torch.zeros((bsz, 1, 1, seqlen), dtype = q.dtype, device = q.device)
+        attn_mask.masked_fill_(padding_positions.unsqueeze(1).unsqueeze(1), torch.finfo(q.dtype).min)
+
+        attn_weights = torch.matmul(q, k.transpose(2, 3)) * 1.0
+        attn_weights = attn_weights + attn_mask
+        attn_weights = torch.softmax(attn_weights, dim = -1, dtype = torch.float32).to(q.dtype)
+        y = torch.matmul(attn_weights, v)
+        y = y.transpose(1, 2).contiguous().view(bsz, seqlen, self.num_q_heads * self.head_dim)
+        y = self.o_proj.forward(y, params)
+        return to2(y, out_dtype, torch.half)
+
+
+class Gemma4VisionPooler(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        hidden_size: int,
+    ):
+        super().__init__(config, key, None)
+        self.root_hidden_size = hidden_size ** 0.5
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        position_ids = get_for_device(params, "image_position_ids", self.device)
+        output_length = int(params["image_output_length"])
+        if output_length > x.shape[1]:
+            raise ValueError(f"Cannot pool {x.shape[1]} patches to {output_length} soft tokens.")
+
+        padding_positions = (position_ids == -1).all(dim = -1)
+        x = x.masked_fill(padding_positions.unsqueeze(-1), 0.0)
+
+        if x.shape[1] != output_length:
+            input_seq_len = x.shape[1]
+            k = int((input_seq_len // output_length) ** 0.5)
+            k_squared = k ** 2
+            if k_squared * output_length != input_seq_len:
+                raise ValueError(f"Cannot pool {x.shape} to {output_length}: {k=}^2 mismatch")
+            clamped_positions = position_ids.clamp(min = 0)
+            max_x = clamped_positions[..., 0].max(dim = -1, keepdim = True)[0] + 1
+            kernel_idxs = torch.div(clamped_positions, k, rounding_mode = "floor")
+            kernel_idxs = kernel_idxs[..., 0] + (max_x // k) * kernel_idxs[..., 1]
+            weights = F.one_hot(kernel_idxs.long(), output_length).float() / k_squared
+            x = weights.transpose(1, 2) @ x.float()
+            params["image_pooler_mask"] = torch.logical_not((weights == 0).all(dim = 1))
+        else:
+            x = x.float()
+            params["image_pooler_mask"] = ~padding_positions
+
+        x = x * self.root_hidden_size
+        return to2(x, out_dtype, torch.float)
+
+
+class Gemma4VisionStandardize(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+    ):
+        super().__init__(config, key, None)
+        self.bias_key = f"{key}.std_bias"
+        self.scale_key = f"{key}.std_scale"
+        self.std_bias = None
+        self.std_scale = None
+        self.extra_numel = 0
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.std_bias = self.config.stc.get_tensor(self.bias_key, device, float2half = True, allow_bf16 = True, no_defer = True)
+        self.std_scale = self.config.stc.get_tensor(self.scale_key, device, float2half = True, allow_bf16 = True, no_defer = True)
+        self.extra_numel = self.std_bias.numel() + self.std_scale.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.std_bias = None
+        self.std_scale = None
+        self.extra_numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.std_bias is None or self.std_scale is None:
+            return {}
+        return {
+            self.bias_key: self.std_bias.contiguous(),
+            self.scale_key: self.std_scale.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return self.extra_numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        y = (x.float() - self.std_bias.float()) * self.std_scale.float()
+        return to2(y, out_dtype, torch.float)
+
+
+class Gemma4VisionProjector(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        in_features: int,
+        out_features: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.in_features = in_features
+        self.out_features = out_features
+        self.rms_norm_eps = rms_norm_eps
+        self.weight = None
+        self._numel = 0
+
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.weight = self.config.stc.get_tensor(
+            f"{self.key}.weight",
+            device,
+            transpose = True,
+            allow_bf16 = True,
+            no_defer = True,
+        )
+        self._numel = self.weight.numel()
+
+
+    @override
+    def unload(self):
+        super().unload()
+        self.weight = None
+        self._numel = 0
+
+
+    @override
+    def get_tensors(self):
+        if self.weight is None:
+            return {}
+        return {
+            f"{self.key}.weight": self.weight.T.contiguous(),
+        }
+
+
+    @override
+    def weights_numel(self):
+        return self._numel
+
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        y = torch.matmul(x.float(), self.weight.float())
+        y = y * torch.rsqrt(y.pow(2).mean(dim = -1, keepdim = True) + self.rms_norm_eps)
+        return to2(y, out_dtype, torch.float)

--- a/exllamav3/modules/gemma4.py
+++ b/exllamav3/modules/gemma4.py
@@ -5,6 +5,8 @@ import torch.nn.functional as F
 from torch import nn
 from typing_extensions import override
 
+from ..cache.gemma4 import Gemma4QuantCacheLayer, Gemma4SingleQuantCacheLayer
+from ..ext import exllamav3_ext as ext
 from ..model.config import Config
 from ..model.model_tp_alloc import TPAllocation
 from ..util.rope import RoPE
@@ -106,9 +108,13 @@ class Gemma4Attention(Attention):
         num_kv_heads: int,
         use_k_as_v: bool,
         v_norm: RMSNorm | None,
+        force_quantized_fallback: bool = False,
         **kwargs,
     ):
         key_v = kwargs.get("key_v")
+        super_key_v = kwargs.get("key_k") if use_k_as_v and kwargs.get("key_k") is not None else key_v
+        if use_k_as_v and kwargs.get("key_k") is None and kwargs.get("v_proj") is None:
+            kwargs["v_proj"] = kwargs.get("k_proj")
         super().__init__(
             config=config,
             key=key,
@@ -117,11 +123,19 @@ class Gemma4Attention(Attention):
             head_dim=head_dim,
             num_q_heads=num_q_heads,
             num_kv_heads=num_kv_heads,
-            key_v=kwargs["key_k"] if use_k_as_v else key_v,
+            key_v=super_key_v,
             **{k: v for k, v in kwargs.items() if k != "key_v"},
         )
 
         self.use_k_as_v = use_k_as_v
+        self.force_quantized_fallback = force_quantized_fallback
+        self.disable_exl3_mgemm = (
+            config is not None and
+            getattr(config, "num_hidden_layers", None) == 30 and
+            bool(getattr(config, "enable_moe_block", False)) and
+            getattr(config, "num_kv_heads", None) == 8 and
+            getattr(config, "num_global_kv_heads", None) == 2
+        )
         if use_k_as_v:
             self.modules.remove(self.v_proj)
             self.v_proj = None
@@ -138,6 +152,42 @@ class Gemma4Attention(Attention):
             return None
         return group_ids
 
+    @override
+    def get_block_table(self, params: dict) -> torch.Tensor:
+        key = "block_table_full" if self.sliding_window < 0 else "block_table_swa"
+        block_table = get_for_device(params, key, self.device, None)
+        if block_table is None:
+            block_table = get_for_device(params, "block_table", self.device)
+        return block_table
+
+    @override
+    def get_cache_seqlens(self, params: dict) -> torch.Tensor:
+        key = "cache_seqlens_full" if self.sliding_window < 0 else "cache_seqlens_swa"
+        cache_seqlens = get_for_device(params, key, self.device, None)
+        if cache_seqlens is None:
+            cache_seqlens = get_for_device(params, "cache_seqlens", self.device)
+        return cache_seqlens
+
+    @override
+    def project_qkv(self, x: torch.Tensor, params: dict) -> tuple:
+        if not self.disable_exl3_mgemm:
+            return super().project_qkv(x, params)
+
+        bsz, q_len, _ = x.shape
+        q = self.q_proj.forward(x, params)
+
+        if self.interleaved_gate:
+            q, g = torch.chunk(q.view(bsz, q_len, -1, self.head_dim * 2), 2, dim = -1)
+            g = g.reshape(bsz, q_len, -1)
+        elif self.g_proj:
+            g = self.g_proj.forward(x, params)
+        else:
+            g = None
+
+        k = self.k_proj.forward(x, params)
+        v = k if self.v_proj is None else self.v_proj.forward(x, params)
+        return q, k, v, g
+
 
     def _build_mm_mask(
         self,
@@ -151,38 +201,159 @@ class Gemma4Attention(Attention):
         causal: bool,
     ) -> torch.Tensor:
         max_total = int(total_lens.max())
-        mask = torch.full(
-            (bsz, 1, seqlen, max_total),
-            torch.finfo(q_dtype).min,
-            dtype = q_dtype,
-            device = device,
+        mask = torch.zeros((bsz, 1, seqlen, max_total), dtype = torch.bool, device = device)
+        if max_total == 0:
+            return mask
+
+        total_lens = total_lens.to(device = device, dtype = torch.long)
+        past = (
+            cache_seqlens.to(device = device, dtype = torch.long)
+            if cache_seqlens is not None else
+            torch.zeros((bsz,), dtype = torch.long, device = device)
         )
-        for b in range(bsz):
-            total = int(total_lens[b])
-            if total == 0:
-                continue
-            past = int(cache_seqlens[b]) if cache_seqlens is not None else 0
-            full_groups = None
-            if vision_group_ids is not None:
-                full_groups = torch.full((total,), -1, dtype = torch.int32, device = device)
-                full_groups[past : past + seqlen] = vision_group_ids[b]
-            for qi in range(seqlen):
-                q_abs = past + qi
-                if not causal:
-                    start = 0 if self.sliding_window < 0 else max(0, q_abs - self.sliding_window)
-                    end = total if self.sliding_window < 0 else min(total, q_abs + self.sliding_window + 1)
-                    mask[b, 0, qi, start:end] = 0
-                else:
-                    end = min(total, q_abs + 1)
-                    start = 0 if self.sliding_window < 0 else max(0, q_abs - self.sliding_window)
-                    if end > start:
-                        mask[b, 0, qi, start:end] = 0
-                if full_groups is not None:
-                    q_group = int(full_groups[q_abs])
-                    if q_group >= 0:
-                        same_group = full_groups[:total] == q_group
-                        mask[b, 0, qi, same_group] = 0
-        return mask
+
+        q_offsets = torch.arange(seqlen, device = device, dtype = torch.long).view(1, seqlen, 1)
+        q_abs = past.view(bsz, 1, 1) + q_offsets
+        kv_idx = torch.arange(max_total, device = device, dtype = torch.long).view(1, 1, max_total)
+        valid_kv = kv_idx < total_lens.view(bsz, 1, 1)
+
+        if self.sliding_window < 0:
+            visible = valid_kv.expand(-1, seqlen, -1) if not causal else (kv_idx <= q_abs) & valid_kv
+        else:
+            start = torch.clamp_min(q_abs - self.sliding_window, 0)
+            if causal:
+                visible = (kv_idx >= start) & (kv_idx <= q_abs) & valid_kv
+            else:
+                end = q_abs + self.sliding_window
+                visible = (kv_idx >= start) & (kv_idx <= end) & valid_kv
+
+        if vision_group_ids is not None:
+            vision_group_ids = vision_group_ids.to(device = device, dtype = torch.int32)
+            full_groups = torch.full((bsz, max_total), -1, dtype = torch.int32, device = device)
+            group_pos = past.view(bsz, 1) + torch.arange(seqlen, device = device, dtype = torch.long).view(1, seqlen)
+            row_idx = torch.arange(bsz, device = device, dtype = torch.long).view(bsz, 1).expand(-1, seqlen)
+            valid_group_pos = group_pos < total_lens.view(bsz, 1)
+            full_groups[row_idx[valid_group_pos], group_pos[valid_group_pos]] = vision_group_ids[valid_group_pos]
+            q_groups = vision_group_ids.view(bsz, seqlen, 1)
+            same_group = (q_groups >= 0) & (full_groups.unsqueeze(1) == q_groups)
+            visible = (visible | same_group) & valid_kv
+
+        return visible.unsqueeze(1)
+
+    def _get_mm_mask_cached(
+        self,
+        params: dict,
+        bsz: int,
+        seqlen: int,
+        total_lens: torch.Tensor,
+        cache_seqlens: torch.Tensor | None,
+        vision_group_ids: torch.Tensor | None,
+        q_dtype: torch.dtype,
+        device: torch.device,
+        causal: bool,
+    ) -> torch.Tensor:
+        cache = params.setdefault("_gemma4_mm_mask_cache", {})
+        cache_key = (
+            device.type,
+            device.index if device.index is not None else -1,
+            self.sliding_window < 0,
+            causal,
+            bsz,
+            seqlen,
+            tuple(total_lens.shape),
+            int(total_lens.data_ptr()),
+            0 if cache_seqlens is None else int(cache_seqlens.data_ptr()),
+            0 if vision_group_ids is None else int(vision_group_ids.data_ptr()),
+        )
+        if cache_key not in cache:
+            cache[cache_key] = self._build_mm_mask(
+                bsz,
+                seqlen,
+                total_lens,
+                cache_seqlens,
+                vision_group_ids,
+                q_dtype,
+                device,
+                causal,
+            )
+        return cache[cache_key]
+
+    def _get_mm_visible_positions_cached(
+        self,
+        params: dict,
+        mask: torch.Tensor,
+        total_lens: torch.Tensor,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        cache = params.setdefault("_gemma4_mm_visible_kv_cache", {})
+        cache_key = (
+            device.type,
+            device.index if device.index is not None else -1,
+            self.sliding_window < 0,
+            tuple(mask.shape),
+            int(mask.data_ptr()),
+            int(total_lens.data_ptr()),
+        )
+        if cache_key not in cache:
+            bsz = mask.shape[0]
+            seqlen = mask.shape[2]
+            visible_any = mask.squeeze(1).any(dim = 1)
+            counts = visible_any.sum(dim = 1, dtype = torch.int32)
+            max_selected = int(counts.max().item()) if counts.numel() > 0 else 0
+            if max_selected == 0:
+                selected_positions = torch.zeros((bsz, 0), dtype = torch.int32, device = device)
+                reduced_mask = torch.zeros((bsz, 1, seqlen, 0), dtype = torch.bool, device = device)
+                cache[cache_key] = (selected_positions, counts, reduced_mask)
+                return cache[cache_key]
+
+            max_total = visible_any.shape[1]
+            positions = torch.arange(max_total, dtype = torch.int32, device = device).unsqueeze(0).expand(bsz, -1)
+            sentinel = torch.full_like(positions, max_total)
+            packed_positions = torch.where(visible_any, positions, sentinel)
+            packed_positions = torch.sort(packed_positions, dim = 1, stable = True).values[:, :max_selected]
+
+            valid_selected = (
+                torch.arange(max_selected, device = device, dtype = torch.int32).unsqueeze(0) <
+                counts.unsqueeze(1)
+            )
+            gather_positions = packed_positions.clamp_max(max_total - 1).to(dtype = torch.long)
+            selected_positions = torch.where(
+                valid_selected,
+                packed_positions,
+                torch.zeros_like(packed_positions),
+            )
+            reduced_mask = torch.take_along_dim(
+                mask.squeeze(1),
+                gather_positions.unsqueeze(1).expand(-1, seqlen, -1),
+                dim = 2,
+            ) & valid_selected.unsqueeze(1)
+            reduced_mask = reduced_mask.unsqueeze(1)
+            cache[cache_key] = (selected_positions, counts, reduced_mask)
+        return cache[cache_key]
+
+    def _validate_local_cache_span(
+        self,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor | None,
+        seqlen: int,
+    ) -> None:
+        if cache_seqlens is None:
+            return
+        capacity = block_table.shape[1] * PAGE_SIZE
+        required = cache_seqlens + seqlen
+        if not (required <= capacity).all():
+            actual = int(required.max())
+            raise ValueError(
+                f"Gemma4 local cache view overflow in layer {self.layer_idx}: "
+                f"need {actual} tokens, but local block table only covers {capacity}. "
+                "Increase swa_cache_size or reduce the effective local write span."
+            )
+
+
+    def _get_cache_layer(self, cache):
+        if self.has_split_cache:
+            return self.tp_cache_lookup[cache]
+        return cache.layers[self.layer_idx]
 
 
     def _mm_attention(
@@ -194,15 +365,24 @@ class Gemma4Attention(Attention):
     ) -> torch.Tensor:
         scale = self.sm_scale if self.sm_scale is not None else self.head_dim ** -0.5
         if self.logit_softcapping:
+            qf = q.float()
+            kf = k.float()
+            vf = v.float()
             if self.gqa and k.shape[1] != q.shape[1]:
                 repeat = q.shape[1] // k.shape[1]
-                k = k.repeat_interleave(repeat, dim = 1)
-                v = v.repeat_interleave(repeat, dim = 1)
-            scores = torch.matmul(q.float(), k.transpose(-1, -2).float()) * scale
+                qf = qf.reshape(q.shape[0], k.shape[1], repeat, q.shape[2], q.shape[3])
+                scores = torch.matmul(qf, kf.unsqueeze(2).transpose(-1, -2)) * scale
+                scores = torch.tanh(scores / self.logit_softcapping) * self.logit_softcapping
+                scores.masked_fill_(mask.unsqueeze(2).logical_not(), torch.finfo(scores.dtype).min)
+                probs = torch.softmax(scores, dim = -1, dtype = torch.float32)
+                out = torch.matmul(probs, vf.unsqueeze(2))
+                return out.reshape(q.shape[0], q.shape[1], q.shape[2], q.shape[3]).to(q.dtype)
+
+            scores = torch.matmul(qf, kf.transpose(-1, -2)) * scale
             scores = torch.tanh(scores / self.logit_softcapping) * self.logit_softcapping
-            scores = scores + mask.float()
+            scores.masked_fill_(mask.logical_not(), torch.finfo(scores.dtype).min)
             probs = torch.softmax(scores, dim = -1, dtype = torch.float32)
-            return torch.matmul(probs, v.float()).to(q.dtype)
+            return torch.matmul(probs, vf).to(q.dtype)
 
         return F.scaled_dot_product_attention(
             q,
@@ -286,14 +466,18 @@ class Gemma4Attention(Attention):
         cache_tensor: torch.Tensor,
         block_table: torch.Tensor,
         total_lens: torch.Tensor,
+        gathered: torch.Tensor | None = None,
     ) -> torch.Tensor:
         bsz = block_table.shape[0]
         max_total = int(total_lens.max())
-        gathered = torch.zeros(
-            (bsz, max_total, self.num_kv_heads, self.head_dim),
-            dtype = cache_tensor.dtype,
-            device = cache_tensor.device,
-        )
+        target_shape = (bsz, max_total, self.num_kv_heads, self.head_dim)
+        target_shape_heads = (bsz, self.num_kv_heads, max_total, self.head_dim)
+        heads_first = gathered is not None and gathered.shape == target_shape_heads
+        if gathered is None:
+            gathered = torch.empty(target_shape, dtype = cache_tensor.dtype, device = cache_tensor.device)
+        elif gathered.shape not in (target_shape, target_shape_heads):
+            gathered = torch.empty(target_shape, dtype = cache_tensor.dtype, device = cache_tensor.device)
+            heads_first = False
         for b in range(bsz):
             total = int(total_lens[b])
             if total == 0:
@@ -301,8 +485,174 @@ class Gemma4Attention(Attention):
             num_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
             pages = block_table[b, :num_pages].long()
             flat = cache_tensor.index_select(0, pages).reshape(-1, self.num_kv_heads, self.head_dim)
-            gathered[b, :total].copy_(flat[:total], non_blocking = True)
+            if heads_first:
+                gathered[b, :, :total].copy_(flat[:total].transpose(0, 1), non_blocking = True)
+            else:
+                gathered[b, :total].copy_(flat[:total], non_blocking = True)
         return gathered
+
+    def _gather_selected_cache_pages(
+        self,
+        cache_tensor: torch.Tensor,
+        block_table: torch.Tensor,
+        selected_positions: torch.Tensor,
+        selected_counts: torch.Tensor,
+        gathered: torch.Tensor,
+    ) -> torch.Tensor:
+        bsz = block_table.shape[0]
+        target_shape = (bsz, selected_positions.shape[1], self.num_kv_heads, self.head_dim)
+        target_shape_heads = (bsz, self.num_kv_heads, selected_positions.shape[1], self.head_dim)
+        heads_first = gathered.shape == target_shape_heads
+        assert gathered.shape in (target_shape, target_shape_heads)
+        for b in range(bsz):
+            total = int(selected_counts[b].item())
+            if total == 0:
+                continue
+            idx = selected_positions[b, :total].to(dtype = torch.long)
+            pages = block_table[b].gather(0, torch.div(idx, PAGE_SIZE, rounding_mode = "floor"))
+            page_pos = idx.remainder(PAGE_SIZE)
+            flat = cache_tensor[pages, page_pos]
+            if heads_first:
+                gathered[b, :, :total].copy_(flat.transpose(0, 1), non_blocking = True)
+            else:
+                gathered[b, :total].copy_(flat, non_blocking = True)
+        return gathered
+
+    def _get_kv_workspace(
+        self,
+        params: dict,
+        bsz: int,
+        max_total: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        heads_first: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cache = params.setdefault("_gemma4_kv_workspace", {})
+        key = (
+            device.type,
+            device.index if device.index is not None else -1,
+            bsz,
+            max_total,
+            self.num_kv_heads,
+            self.head_dim,
+            dtype,
+            heads_first,
+        )
+        pair = cache.get(key)
+        target_shape = (
+            (bsz, self.num_kv_heads, max_total, self.head_dim)
+            if heads_first else
+            (bsz, max_total, self.num_kv_heads, self.head_dim)
+        )
+        if pair is None or pair[0].shape != target_shape:
+            pair = (
+                torch.empty(target_shape, dtype = dtype, device = device),
+                torch.empty(target_shape, dtype = dtype, device = device),
+            )
+            cache[key] = pair
+        return pair
+
+    def _get_kv_flat_workspace(
+        self,
+        params: dict,
+        max_tokens: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cache = params.setdefault("_gemma4_kv_flat_workspace", {})
+        token_dim = self.num_kv_heads * self.head_dim
+        key = (
+            device.type,
+            device.index if device.index is not None else -1,
+            max_tokens,
+            token_dim,
+            dtype,
+        )
+        pair = cache.get(key)
+        target_shape = (max_tokens, token_dim)
+        if pair is None or pair[0].shape != target_shape:
+            pair = (
+                torch.empty(target_shape, dtype = dtype, device = device),
+                torch.empty(target_shape, dtype = dtype, device = device),
+            )
+            cache[key] = pair
+        return pair
+
+    def _gather_selected_compact_kv(
+        self,
+        cache_layer: Gemma4SingleQuantCacheLayer,
+        params: dict,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        selected_positions: torch.Tensor,
+        selected_counts: torch.Tensor,
+        k_delta: torch.Tensor,
+        v_delta: torch.Tensor,
+        gathered_k: torch.Tensor,
+        gathered_v: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        bsz = block_table.shape[0]
+        max_selected = selected_positions.shape[1]
+        if hasattr(ext, "dequant_cache_paged_select_delta_heads"):
+            ext.dequant_cache_paged_select_delta_heads(
+                cache_layer.qk, cache_layer.sk, k_delta.contiguous(), gathered_k,
+                cache_layer.qv, cache_layer.sv, v_delta.contiguous(), gathered_v,
+                cache_seqlens, block_table,
+                selected_positions.contiguous(), selected_counts.contiguous(),
+                PAGE_SIZE,
+                max_selected,
+                k_delta.shape[1],
+            )
+            return gathered_k, gathered_v
+        flat_k, flat_v = self._get_kv_flat_workspace(params, max_selected, torch.half, gathered_k.device)
+        cache_k_tmp, cache_v_tmp = self._get_kv_flat_workspace(
+            params,
+            max_selected,
+            torch.half,
+            gathered_k.device,
+        )
+
+        for b in range(bsz):
+            total = int(selected_counts[b].item())
+            if total == 0:
+                continue
+
+            idx = selected_positions[b, :total]
+            cache_len = int(cache_seqlens[b].item())
+            cache_mask = idx < cache_len
+            delta_mask = ~cache_mask
+            flat_k_b = flat_k[:total]
+            flat_v_b = flat_v[:total]
+
+            if cache_mask.any():
+                cache_idx = idx[cache_mask]
+                pages = block_table[b].gather(0, torch.div(cache_idx, PAGE_SIZE, rounding_mode = "floor"))
+                page_pos = cache_idx.remainder(PAGE_SIZE)
+                qk_tokens = cache_layer.qk[pages, page_pos]
+                qv_tokens = cache_layer.qv[pages, page_pos]
+                sk_tokens = cache_layer.sk[pages, page_pos]
+                sv_tokens = cache_layer.sv[pages, page_pos]
+                cache_total = int(cache_idx.numel())
+                ext.dequant_cache_cont(qk_tokens, sk_tokens, cache_k_tmp[:cache_total])
+                ext.dequant_cache_cont(qv_tokens, sv_tokens, cache_v_tmp[:cache_total])
+                flat_k_b[cache_mask] = cache_k_tmp[:cache_total]
+                flat_v_b[cache_mask] = cache_v_tmp[:cache_total]
+
+            if delta_mask.any():
+                delta_idx = idx[delta_mask] - cache_len
+                flat_k_b[delta_mask] = k_delta[b, delta_idx].reshape(-1, self.num_kv_heads * self.head_dim)
+                flat_v_b[delta_mask] = v_delta[b, delta_idx].reshape(-1, self.num_kv_heads * self.head_dim)
+
+            gathered_k[b, :, :total].copy_(
+                flat_k_b.view(total, self.num_kv_heads, self.head_dim).transpose(0, 1),
+                non_blocking = True,
+            )
+            gathered_v[b, :, :total].copy_(
+                flat_v_b.view(total, self.num_kv_heads, self.head_dim).transpose(0, 1),
+                non_blocking = True,
+            )
+
+        return gathered_k, gathered_v
 
 
     def decode_flash_attn_fallback(
@@ -313,13 +663,14 @@ class Gemma4Attention(Attention):
         params: dict,
     ):
         cache = params.get("cache")
-        block_table = get_for_device(params, "block_table", self.device)
-        cache_seqlens = get_for_device(params, "cache_seqlens", self.device)
+        block_table = self.get_block_table(params)
+        cache_seqlens = self.get_cache_seqlens(params)
         position = params.get("position", 0)
         positions = get_for_device(params, "positions", self.device, None)
         position_ids = get_for_device(params, "position_ids", self.device, None)
         inv_freq = get_for_device(params, "inv_freq", self.device, None)
         causal = params.get("causal", True)
+        has_mm_embeddings = bool(params.get("indexed_embeddings"))
         vision_group_ids = self._get_vision_group_ids(params)
         if self.sliding_window < 0:
             vision_group_ids = None
@@ -351,15 +702,10 @@ class Gemma4Attention(Attention):
                 self.post_rope_norm
             )
 
-        cache_k, cache_v = cache.get_layer(self.layer_idx, cache_seqlens, block_table)
-        self._write_cache_pages(cache_k, block_table, cache_seqlens, k)
-        self._write_cache_pages(cache_v, block_table, cache_seqlens, v)
-
         total_lens = cache_seqlens + seqlen
-        all_k = self._gather_cache_pages(cache_k, block_table, total_lens).transpose(1, 2)
-        all_v = self._gather_cache_pages(cache_v, block_table, total_lens).transpose(1, 2)
         q = q.transpose(1, 2)
-        mask = self._build_mm_mask(
+        mask = self._get_mm_mask_cached(
+            params,
             bsz,
             seqlen,
             total_lens,
@@ -369,10 +715,127 @@ class Gemma4Attention(Attention):
             q.device,
             causal,
         )
-        o = self._mm_attention(q, all_k, all_v, mask)
+        selected_positions = None
+        selected_counts = None
+        reduced_mask = None
+        if vision_group_ids is not None:
+            selected_positions, selected_counts, reduced_mask = self._get_mm_visible_positions_cached(
+                params,
+                mask,
+                total_lens,
+                q.device,
+            )
+        cache_layer = self._get_cache_layer(cache)
+        # Full/global Gemma4 layers can use the compact quantized path when backed
+        # by the single-quant cache. MM still needs the downstream bsz1 graph fast
+        # path disabled; text-only can stay on the normal graph path.
+        allow_full_compact_cache = (
+            self.sliding_window < 0 and
+            isinstance(cache_layer, Gemma4SingleQuantCacheLayer)
+        )
+        use_shadow_cache = (
+            isinstance(cache_layer, Gemma4QuantCacheLayer) and
+            self.sliding_window < 0 and
+            not allow_full_compact_cache
+        )
+        use_compact_cache = (
+            isinstance(cache_layer, Gemma4SingleQuantCacheLayer) and
+            not use_shadow_cache and
+            (
+                allow_full_compact_cache or
+                self.force_quantized_fallback or
+                has_mm_embeddings or
+                vision_group_ids is not None
+            )
+        )
+        self._validate_local_cache_span(block_table, cache_seqlens, seqlen)
+        use_reduced_mm_gather = (
+            vision_group_ids is not None and
+            selected_positions is not None and
+            selected_positions.shape[1] > 0 and
+            not torch.equal(selected_counts.to(dtype = total_lens.dtype), total_lens)
+        )
+        gather_len = int(selected_counts.max().item()) if use_reduced_mm_gather else int(total_lens.max())
+        workspace_k, workspace_v = self._get_kv_workspace(
+            params,
+            bsz,
+            gather_len,
+            torch.half,
+            q.device,
+            heads_first = True,
+        )
 
-        cache_layer = cache.layers[self.layer_idx]
-        if hasattr(cache_layer, "qk"):
+        if use_shadow_cache:
+            cache_layer.write_shadow_pages(block_table, cache_seqlens, k, v)
+            all_k, all_v = cache_layer.gather_shadow_pages(
+                block_table,
+                total_lens,
+                gathered_k = workspace_k,
+                gathered_v = workspace_v,
+            )
+            attn_mask = mask
+            if isinstance(cache_layer, Gemma4SingleQuantCacheLayer):
+                cache_layer.update_kv_compact(cache_seqlens, block_table, k, v, seqlen)
+            else:
+                cache.update_layer(self.layer_idx, cache_seqlens, block_table, k, v, seqlen)
+        elif use_compact_cache:
+            if use_reduced_mm_gather:
+                compact_k, compact_v = self._gather_selected_compact_kv(
+                    cache_layer,
+                    params,
+                    block_table,
+                    cache_seqlens,
+                    selected_positions,
+                    selected_counts,
+                    k,
+                    v,
+                    workspace_k,
+                    workspace_v,
+                )
+                attn_mask = reduced_mask
+            else:
+                compact_k, compact_v = cache_layer.get_kv_compact(
+                    total_lens,
+                    cache_seqlens,
+                    block_table,
+                    k_delta = k,
+                    v_delta = v,
+                    delta_len = seqlen,
+                    gathered_k = workspace_k,
+                    gathered_v = workspace_v,
+                )
+                attn_mask = mask
+            all_k = compact_k
+            all_v = compact_v
+            cache_layer.update_kv_compact(cache_seqlens, block_table, k, v, seqlen)
+        else:
+            cache_k, cache_v = cache.get_layer(self.layer_idx, cache_seqlens, block_table)
+            self._write_cache_pages(cache_k, block_table, cache_seqlens, k)
+            self._write_cache_pages(cache_v, block_table, cache_seqlens, v)
+            if use_reduced_mm_gather:
+                all_k = self._gather_selected_cache_pages(
+                    cache_k,
+                    block_table,
+                    selected_positions,
+                    selected_counts,
+                    workspace_k,
+                )
+                all_v = self._gather_selected_cache_pages(
+                    cache_v,
+                    block_table,
+                    selected_positions,
+                    selected_counts,
+                    workspace_v,
+                )
+                attn_mask = reduced_mask
+            else:
+                all_k = self._gather_cache_pages(cache_k, block_table, total_lens, gathered = workspace_k)
+                all_v = self._gather_cache_pages(cache_v, block_table, total_lens, gathered = workspace_v)
+                attn_mask = mask
+
+        o = self._mm_attention(q, all_k, all_v, attn_mask)
+
+        if not use_shadow_cache and not use_compact_cache and hasattr(cache_layer, "qk"):
             cache.update_layer(self.layer_idx, cache_seqlens, block_table, k, v, seqlen)
 
         if self.headwise_gate:
@@ -433,7 +896,8 @@ class Gemma4Attention(Attention):
 
         if vision_group_ids is not None:
             total_lens = torch.full((bsz,), seqlen, dtype = torch.int32, device = q.device)
-            mask = self._build_mm_mask(
+            mask = self._get_mm_mask_cached(
+                params,
                 bsz,
                 seqlen,
                 total_lens,
@@ -475,11 +939,20 @@ class Gemma4Attention(Attention):
 
         bsz, seqlen, _ = x.shape
         attn_mode = params.get("attn_mode", "flash_attn_nc")
+        has_mm_embeddings = bool(params.get("indexed_embeddings"))
         vision_group_ids = self._get_vision_group_ids(params)
+        cache = params.get("cache")
         if self.sliding_window < 0:
             vision_group_ids = None
+        needs_custom_mm_mask = vision_group_ids is not None
+        force_quantized_fallback = (
+            self.force_quantized_fallback and
+            attn_mode == "flash_attn" and
+            cache is not None and
+            isinstance(self._get_cache_layer(cache), Gemma4QuantCacheLayer)
+        )
 
-        if self.head_dim > 256 or vision_group_ids is not None:
+        if self.head_dim > 256 or needs_custom_mm_mask or force_quantized_fallback:
             match attn_mode:
                 case "flash_attn_nc":
                     x = self.decode_sdpa_nc(x, bsz, seqlen, params)
@@ -489,6 +962,8 @@ class Gemma4Attention(Attention):
                     x = self.decode_sdpa_nc(x, bsz, seqlen, params)
                 case _:
                     raise ValueError(f"Unknown attn_mode: {attn_mode}")
+            if self.tp_reduce:
+                params["backend"].all_reduce(x)
             return to2(x, out_dtype, self.out_dtype)
 
         return super().forward(x, params, out_dtype)
@@ -538,6 +1013,140 @@ class Gemma4Attention(Attention):
         ]
 
 
+    def tp_export(self, plan, producer):
+        assert self.device is not None, "Cannot export module for TP before loading."
+
+        def _export(child):
+            nonlocal producer
+            return child.tp_export(plan, producer) if child is not None else None
+
+        q_norm_span_heads = (
+            self.q_norm is not None and
+            isinstance(self.q_norm, RMSNorm) and
+            self.q_norm.span_heads
+        )
+
+        return {
+            "cls": Gemma4Attention,
+            "kwargs": {
+                "key": self.key,
+                "layer_idx": self.layer_idx,
+                "hidden_size": self.hidden_size,
+                "head_dim": self.head_dim,
+                "rope_settings": self.rope_settings,
+                "sm_scale": self.sm_scale,
+                "out_dtype": self.out_dtype,
+                "sliding_window": self.sliding_window,
+                "logit_softcapping": self.logit_softcapping,
+                "post_rope_norm": self.post_rope_norm,
+                "tp_split_norm": self.tp_split_norm,
+                "use_k_as_v": self.use_k_as_v,
+                "force_quantized_fallback": self.force_quantized_fallback,
+            },
+            "num_kv_heads": self.num_kv_heads,
+            **{name: _export(getattr(self, name, None)) for name in (
+                "q_norm",
+                "k_norm",
+                "v_norm",
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "kv_proj",
+                "o_proj",
+                "g_proj",
+            )},
+            "device": self.device,
+            "cache_layers": [
+                cl.tp_export(plan) for cl in self.cache_layers
+            ],
+            "n_gqa": self.num_q_heads // self.num_kv_heads,
+            "q_norm_span_heads": q_norm_span_heads,
+            "q_global_dim": self.num_q_heads * self.head_dim if self.q_norm else 0,
+            "k_global_dim": self.num_kv_heads * self.head_dim if self.k_norm else 0,
+        }
+
+
+    @staticmethod
+    def tp_import(local_context, exported, plan, **kwargs):
+        key = exported["kwargs"]["key"]
+        head_dim = exported["kwargs"]["head_dim"]
+        n_gqa = exported["n_gqa"]
+        device = local_context["device"]
+        tp_split_norm = exported["kwargs"]["tp_split_norm"]
+        first, last, unit = plan[key]
+        assert unit == "heads"
+        num_kv_heads = last - first
+        num_q_heads = num_kv_heads * n_gqa
+
+        q_split = (True, first * head_dim * n_gqa, last * head_dim * n_gqa) \
+            if num_kv_heads else None
+        qh_split = (True, first * n_gqa, last * n_gqa) \
+            if num_kv_heads else None
+        kv_split = (True, first * head_dim, last * head_dim) \
+            if num_kv_heads else None
+        o_split = (False, first * head_dim * n_gqa, last * head_dim * n_gqa) \
+            if num_kv_heads else None
+        q_norm_span_heads = exported.get("q_norm_span_heads", False)
+        if q_norm_span_heads:
+            norm_q_split = (first * head_dim * n_gqa, last * head_dim * n_gqa) \
+                if num_kv_heads else None
+            norm_k_split = (first * head_dim, last * head_dim) \
+                if num_kv_heads else None
+        else:
+            norm_q_split = (first * n_gqa, last * n_gqa) \
+                if num_kv_heads else None
+            norm_k_split = (first, last) \
+                if num_kv_heads else None
+
+        def _import(name):
+            nonlocal exported, plan
+            return exported[name]["cls"].tp_import(local_context, exported[name], plan) \
+                if exported.get(name) else None
+
+        def _import_split(name, split):
+            nonlocal exported, plan
+            return exported[name]["cls"].tp_import_split(local_context, exported[name], plan, split) \
+                if split and exported.get(name) else None
+
+        k_proj = _import_split("k_proj", kv_split)
+        v_proj = _import_split("v_proj", kv_split)
+        if exported["kwargs"]["use_k_as_v"]:
+            v_proj = k_proj
+
+        module = Gemma4Attention(
+            config = None,
+            **exported["kwargs"],
+            num_q_heads = num_q_heads,
+            num_kv_heads = num_kv_heads,
+            q_norm = _import_split("q_norm", norm_q_split) if tp_split_norm else _import("q_norm"),
+            k_norm = _import_split("k_norm", norm_k_split) if tp_split_norm else _import("k_norm"),
+            v_norm = _import("v_norm"),
+            q_proj = _import_split("q_proj", q_split),
+            k_proj = k_proj,
+            v_proj = v_proj,
+            kv_proj = _import_split("kv_proj", kv_split),
+            o_proj = _import_split("o_proj", o_split),
+            g_proj = _import_split("g_proj", qh_split),
+        )
+
+        if num_kv_heads:
+            cache_layers = exported["cache_layers"]
+            if len(cache_layers):
+                module.has_split_cache = True
+                for cl in exported["cache_layers"]:
+                    cli = cl["cls"](None, module, **cl["args"])
+                    module.cache_layers.append(cli)
+                    module.tp_cache_lookup[cl["args"]["cache_id"]] = cli
+
+        module.device = device
+        module.q_global_dim = exported.get("q_global_dim", 0)
+        module.k_global_dim = exported.get("k_global_dim", 0)
+        if not kwargs.get("skip_reduction"):
+            module.tp_reduce = True
+        module.load_local(device)
+        return module
+
+
 class Gemma4TransformerBlock(TransformerBlock):
 
     def __init__(
@@ -585,6 +1194,36 @@ class Gemma4TransformerBlock(TransformerBlock):
         return super().weights_numel() + self.layer_scalar_numel
 
 
+    def _should_disable_bsz1_graph(self, params: dict) -> bool:
+        if self.mlp is None or not isinstance(self.attn, Gemma4Attention):
+            return False
+        if self.attn.sliding_window >= 0:
+            return False
+        has_mm_embeddings = bool(params.get("indexed_embeddings"))
+        has_vision_groups = self.attn._get_vision_group_ids(params) is not None
+        if not (has_mm_embeddings or has_vision_groups):
+            return False
+        return bool(params.get("_force_disable_bsz1_graph"))
+
+
+    def _set_bsz1_graph_flag(self, params: dict) -> tuple[bool, bool | None]:
+        disable_bsz1_graph = self._should_disable_bsz1_graph(params)
+        if not disable_bsz1_graph:
+            return False, None
+        previous = params.get("_disable_bsz1_graph")
+        params["_disable_bsz1_graph"] = True
+        return True, previous
+
+
+    def _restore_bsz1_graph_flag(self, params: dict, had_flag: bool, previous: bool | None) -> None:
+        if not had_flag:
+            return
+        if previous is None:
+            params.pop("_disable_bsz1_graph", None)
+        else:
+            params["_disable_bsz1_graph"] = previous
+
+
     def forward(
         self,
         x: torch.Tensor,
@@ -597,6 +1236,142 @@ class Gemma4TransformerBlock(TransformerBlock):
         return to2(x, out_dtype, self.out_dtype)
 
 
+    def tp_export(self, plan, producer):
+        assert self.device is not None, "Cannot export module for TP before loading."
+
+        def _export(child):
+            nonlocal producer
+            return child.tp_export(plan, producer) if child is not None else None
+
+        return {
+            "cls": Gemma4TransformerBlock,
+            "kwargs": {
+                "key": self.key,
+                "out_dtype": self.out_dtype,
+            },
+            **{name: _export(getattr(self, name, None)) for name in (
+                "attn_norm",
+                "attn",
+                "attn_post_norm",
+                "mlp_norm",
+                "mlp",
+                "mlp_post_norm",
+            )},
+            "layer_scalar": producer.send(self.layer_scalar),
+            "device": self.device,
+        }
+
+
+    @staticmethod
+    def tp_import(local_context, exported, plan):
+        consumer = local_context["consumer"]
+        device = local_context["device"]
+
+        def _import(name):
+            nonlocal exported, plan
+            return exported[name]["cls"].tp_import(local_context, exported[name], plan) \
+                if exported.get(name) else None
+
+        module = Gemma4TransformerBlock(
+            config = None,
+            **exported["kwargs"],
+            attn_norm = _import("attn_norm"),
+            attn = _import("attn"),
+            attn_post_norm = _import("attn_post_norm"),
+            mlp_norm = _import("mlp_norm"),
+            mlp = _import("mlp"),
+            mlp_post_norm = _import("mlp_post_norm"),
+        )
+        module.device = device
+        layer_scalar = consumer.recv(exported["layer_scalar"], cuda = True)
+        module.layer_scalar = nn.Parameter(layer_scalar, requires_grad = False) if layer_scalar is not None else None
+        module.layer_scalar_numel = 0 if layer_scalar is None else layer_scalar.numel()
+        torch.cuda.synchronize()
+        return module
+
+
+class Gemma4GatedMLP(GatedMLP):
+
+    def __init__(self, config: Config | None, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        self.disable_exl3_mgemm = (
+            config is not None and
+            getattr(config, "num_hidden_layers", None) == 30 and
+            bool(getattr(config, "enable_moe_block", False)) and
+            getattr(config, "num_kv_heads", None) == 8 and
+            getattr(config, "num_global_kv_heads", None) == 2
+        )
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        if not self.disable_exl3_mgemm and not params.get("_disable_bsz1_graph"):
+            return super().forward(x, params, out_dtype = out_dtype)
+
+        bsz, q_len, _ = x.shape
+
+        if self.num_slices == 0:
+            d = torch.zeros_like(x, dtype = self.out_dtype)
+            if self.tp_reduce:
+                params["backend"].all_reduce(d, False)
+            return to2(d, out_dtype, self.out_dtype)
+
+        qs = params.get("q_mlp_slice")
+        r = [qs] if qs is not None else range(0, self.num_slices)
+        d = None
+
+        for s in r:
+            # Keep the 26B Gemma4 path on the conservative per-linear route so
+            # the model does not depend on the shared EXL3 mixed-shape mGEMM
+            # bugfixes that are being split into a separate global PR.
+            if self.disable_exl3_mgemm or self.multi_gu[s] is None or bsz * q_len > 32:
+                g = self.gates[s].forward(x, params)
+                u = self.ups[s].forward(x, params)
+                a = torch.empty_like(u, dtype = torch.half) if self.interm_dtype != torch.half else u
+                self.activation_fn_call(g, u, a, self.act_limit)
+                d_ = self.downs[s].forward(a, params)
+            else:
+                xg = x.view(1, bsz * q_len, self.hidden_size)
+                guh = torch.empty((2, bsz * q_len, self.hidden_size), dtype = self.interm_dtype, device = x.device)
+                gu = torch.empty((2, bsz * q_len, self.multi_gu[s].out_features), dtype = self.interm_dtype, device = x.device)
+                ext.exl3_mgemm(
+                    xg,
+                    self.multi_gu[s].ptrs_trellis,
+                    gu,
+                    self.multi_gu[s].ptrs_suh,
+                    guh,
+                    self.multi_gu[s].ptrs_svh,
+                    None,
+                    None,
+                    self.multi_gu[s].K,
+                    -1,
+                    self.multi_gu[s].mcg,
+                    self.multi_gu[s].mul1,
+                    -1,
+                    -1,
+                    0,
+                )
+                g = gu[0].view(bsz, q_len, self.multi_gu[s].out_features)
+                u = gu[1].view(bsz, q_len, self.multi_gu[s].out_features)
+                a = torch.empty_like(u, dtype = torch.half) if self.interm_dtype != torch.half else u
+                self.activation_fn_call(g, u, a, self.act_limit)
+                d_ = self.downs[s].forward(a, params)
+
+            if d is None:
+                d = d_
+            else:
+                d += d_
+
+        if self.tp_reduce:
+            params["backend"].all_reduce(d)
+
+        return to2(d, out_dtype, self.out_dtype)
+
+
 class Gemma4Router(Module):
 
     def __init__(
@@ -607,6 +1382,8 @@ class Gemma4Router(Module):
         num_experts: int,
         num_experts_per_tok: int,
         rms_norm_eps: float,
+        norm: RMSNorm | None = None,
+        proj: Linear | None = None,
     ):
         super().__init__(config, key, None)
         self.hidden_size = hidden_size
@@ -619,14 +1396,14 @@ class Gemma4Router(Module):
         self.per_expert_scale = None
         self.extra_numel = 0
 
-        self.norm = RMSNorm(
+        self.norm = norm or RMSNorm(
             config = config,
             key = f"{key}.norm",
             rms_norm_eps = rms_norm_eps,
             out_dtype = torch.float,
             unweighted = True,
         )
-        self.proj = Linear(
+        self.proj = proj or Linear(
             config = config,
             key = f"{key}.proj",
             in_features = hidden_size,
@@ -717,6 +1494,58 @@ class Gemma4Router(Module):
         return top_k_index, top_k_weights
 
 
+    def tp_export(self, plan, producer):
+        assert self.device is not None, "Cannot export module for TP before loading."
+
+        def _export(child):
+            nonlocal producer
+            return child.tp_export(plan, producer) if child is not None else None
+
+        return {
+            "cls": Gemma4Router,
+            "kwargs": {
+                "key": self.key,
+                "hidden_size": self.hidden_size,
+                "num_experts": self.num_experts,
+                "num_experts_per_tok": self.num_experts_per_tok,
+                "rms_norm_eps": self.norm.rms_norm_eps,
+            },
+            "norm": _export(self.norm),
+            "proj": _export(self.proj),
+            "scale": producer.send(self.scale),
+            "per_expert_scale": producer.send(self.per_expert_scale),
+            "device": self.device,
+        }
+
+
+    @staticmethod
+    def tp_import(local_context, exported, plan):
+        consumer = local_context["consumer"]
+        device = local_context["device"]
+
+        def _import(name):
+            nonlocal exported, plan
+            return exported[name]["cls"].tp_import(local_context, exported[name], plan) \
+                if exported.get(name) else None
+
+        module = Gemma4Router(
+            config = None,
+            **exported["kwargs"],
+            norm = _import("norm"),
+            proj = _import("proj"),
+        )
+        module.device = device
+        module.scale = consumer.recv(exported["scale"], cuda = True)
+        module.per_expert_scale = consumer.recv(exported["per_expert_scale"], cuda = True)
+        module.extra_numel = 0
+        if module.scale is not None:
+            module.extra_numel += module.scale.numel()
+        if module.per_expert_scale is not None:
+            module.extra_numel += module.per_expert_scale.numel()
+        torch.cuda.synchronize()
+        return module
+
+
 class Gemma4Experts(Module):
 
     def __init__(
@@ -727,15 +1556,37 @@ class Gemma4Experts(Module):
         intermediate_size: int,
         num_experts: int,
         qmap: str,
+        num_local_experts: int | None = None,
+        gates: list[Linear | Module] | None = None,
+        ups: list[Linear | Module] | None = None,
+        downs: list[Linear | Module] | None = None,
+        routing_first: int | None = None,
+        routing_last: int | None = None,
     ):
         super().__init__(config, key, None)
         self.hidden_size = hidden_size
         self.intermediate_size = intermediate_size
         self.num_experts = num_experts
+        self.num_local_experts = num_local_experts if num_local_experts is not None else num_experts
+        self.routing_first = routing_first
+        self.routing_last = routing_last
+        self.tp_reduce = False
 
         self.gates = []
         self.ups = []
         self.downs = []
+
+        if gates is not None:
+            assert ups is not None and len(ups) == len(gates)
+            assert downs is not None and len(downs) == len(gates)
+            self.gates = gates
+            self.ups = ups
+            self.downs = downs
+            for gate, up, down in zip(gates, ups, downs):
+                self.register_submodule(gate)
+                self.register_submodule(up)
+                self.register_submodule(down)
+            return
 
         fkey_gate_up = f"{key}.experts.gate_up_proj"
         fkey_down = f"{key}.experts.down_proj"
@@ -826,17 +1677,31 @@ class Gemma4Experts(Module):
         flat_weights = routing_weights.reshape(-1).to(dtype = torch.float)
         flat_tokens = torch.arange(num_tokens, device = y.device).repeat_interleave(top_k)
 
-        order = flat_experts.argsort()
-        expert_sorted = flat_experts[order]
+        if self.routing_first is None or self.num_local_experts == self.num_experts:
+            flat_expert_local = flat_experts
+            num_bins = self.num_local_experts
+        else:
+            sentinel = self.num_local_experts
+            flat_expert_local = flat_experts - self.routing_first
+            valid = (flat_expert_local >= 0) & (flat_expert_local < self.num_local_experts)
+            flat_expert_local = torch.where(
+                valid,
+                flat_expert_local,
+                torch.full_like(flat_expert_local, sentinel),
+            )
+            num_bins = self.num_local_experts + 1
+
+        order = flat_expert_local.argsort()
+        expert_sorted = flat_expert_local[order]
         token_sorted = flat_tokens[order]
         weight_sorted = flat_weights[order]
 
-        expert_count = torch.bincount(expert_sorted, minlength = self.num_experts)
-        expert_ptr = torch.empty(self.num_experts + 1, dtype = torch.long, device = y.device)
+        expert_count = torch.bincount(expert_sorted, minlength = num_bins)
+        expert_ptr = torch.empty(num_bins + 1, dtype = torch.long, device = y.device)
         expert_ptr[0] = 0
         expert_ptr[1:] = expert_count.cumsum(0)
 
-        for expert_idx in range(self.num_experts):
+        for expert_idx in range(self.num_local_experts):
             start = int(expert_ptr[expert_idx])
             end = int(expert_ptr[expert_idx + 1])
             if start == end:
@@ -851,7 +1716,10 @@ class Gemma4Experts(Module):
             current_hidden_states *= weight_sorted[start:end].unsqueeze(1).to(dtype = current_hidden_states.dtype)
             final_hidden_states.index_add_(0, top_x, current_hidden_states)
 
-        return to2(final_hidden_states.view(x.shape), out_dtype, torch.float)
+        final_hidden_states = final_hidden_states.view(x.shape)
+        if self.tp_reduce:
+            params["backend"].all_reduce(final_hidden_states, self.num_local_experts > 0)
+        return to2(final_hidden_states, out_dtype, torch.float)
 
 
 class Gemma4MoEFeedForward(Module):
@@ -866,11 +1734,23 @@ class Gemma4MoEFeedForward(Module):
         num_experts: int,
         num_experts_per_tok: int,
         rms_norm_eps: float,
+        dense_mlp: GatedMLP | None = None,
+        dense_post_norm: RMSNorm | None = None,
+        routed_pre_norm: RMSNorm | None = None,
+        routed_post_norm: RMSNorm | None = None,
+        router: Gemma4Router | None = None,
+        experts: Gemma4Experts | None = None,
+        routing_device: int | None = None,
     ):
         super().__init__(config, key, None)
         self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.moe_intermediate_size = moe_intermediate_size
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.routing_device = routing_device
 
-        self.dense_mlp = GatedMLP(
+        self.dense_mlp = dense_mlp or Gemma4GatedMLP(
             config = config,
             key = f"{key}.mlp",
             hidden_size = hidden_size,
@@ -883,24 +1763,24 @@ class Gemma4MoEFeedForward(Module):
             interm_dtype = torch.half,
             out_dtype = torch.float,
         )
-        self.dense_post_norm = RMSNorm(
+        self.dense_post_norm = dense_post_norm or RMSNorm(
             config = config,
             key = f"{key}.post_feedforward_layernorm_1",
             rms_norm_eps = rms_norm_eps,
             out_dtype = torch.float,
         )
-        self.routed_pre_norm = RMSNorm(
+        self.routed_pre_norm = routed_pre_norm or RMSNorm(
             config = config,
             key = f"{key}.pre_feedforward_layernorm_2",
             rms_norm_eps = rms_norm_eps,
         )
-        self.routed_post_norm = RMSNorm(
+        self.routed_post_norm = routed_post_norm or RMSNorm(
             config = config,
             key = f"{key}.post_feedforward_layernorm_2",
             rms_norm_eps = rms_norm_eps,
             out_dtype = torch.float,
         )
-        self.router = Gemma4Router(
+        self.router = router or Gemma4Router(
             config = config,
             key = f"{key}.router",
             hidden_size = hidden_size,
@@ -908,7 +1788,7 @@ class Gemma4MoEFeedForward(Module):
             num_experts_per_tok = num_experts_per_tok,
             rms_norm_eps = rms_norm_eps,
         )
-        self.experts = Gemma4Experts(
+        self.experts = experts or Gemma4Experts(
             config = config,
             key = key,
             hidden_size = hidden_size,
@@ -930,6 +1810,142 @@ class Gemma4MoEFeedForward(Module):
         return [self.dense_mlp.optimizer_targets(), self.experts.optimizer_targets()]
 
 
+    def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        tpa_list = []
+        tpa_list += self.dense_mlp.make_tp_allocation(options)
+
+        stc = self.config.stc
+        def _norm_storage(module: RMSNorm) -> int:
+            if module.unweighted:
+                return 0
+            return sum(stc.get_tensor_sizes(f"{module.key}.weight"))
+
+        router_storage = (
+            _norm_storage(self.dense_post_norm) +
+            _norm_storage(self.routed_pre_norm) +
+            _norm_storage(self.routed_post_norm) +
+            _norm_storage(self.router.norm) +
+            self.router.proj.storage_size() +
+            sum(stc.get_tensor_sizes(self.router.scale_key)) +
+            sum(stc.get_tensor_sizes(self.router.per_expert_scale_key))
+        )
+
+        experts_storage = 0
+        for g in self.experts.gates:
+            experts_storage += g.storage_size()
+        for u in self.experts.ups:
+            experts_storage += u.storage_size()
+        for d in self.experts.downs:
+            experts_storage += d.storage_size()
+        recons = max(
+            self.experts.gates[0].recons_size(),
+            self.experts.ups[0].recons_size(),
+            self.experts.downs[0].recons_size(),
+        )
+        tpa_list.append(
+            TPAllocation(
+                key = self.key,
+                channel_width = 1,
+                channel_unit = "experts",
+                storage_per_device = router_storage,
+                storage_to_split = experts_storage,
+                overhead_per_device = self.hidden_size * torch.float.itemsize,
+                overhead_to_split = 2 * self.moe_intermediate_size * torch.half.itemsize,
+                recons_temp = recons,
+                channels_to_split = self.num_experts,
+                limit_key = "moe",
+            )
+        )
+        return tpa_list
+
+
+    def tp_export(self, plan, producer):
+        assert self.device is not None, "Cannot export module for TP before loading."
+
+        def _export(child):
+            nonlocal producer
+            return child.tp_export(plan, producer) if child is not None else None
+
+        return {
+            "cls": Gemma4MoEFeedForward,
+            "kwargs": {
+                "key": self.key,
+                "hidden_size": self.hidden_size,
+                "intermediate_size": self.intermediate_size,
+                "moe_intermediate_size": self.moe_intermediate_size,
+                "num_experts": self.num_experts,
+                "num_experts_per_tok": self.num_experts_per_tok,
+                "rms_norm_eps": self.routed_pre_norm.rms_norm_eps,
+            },
+            "dense_mlp": _export(self.dense_mlp),
+            "dense_post_norm": _export(self.dense_post_norm),
+            "routed_pre_norm": _export(self.routed_pre_norm),
+            "routed_post_norm": _export(self.routed_post_norm),
+            "router": _export(self.router),
+            "experts": {
+                "key": self.experts.key,
+                "hidden_size": self.experts.hidden_size,
+                "intermediate_size": self.experts.intermediate_size,
+                "num_experts": self.experts.num_experts,
+                "gates": [_export(self.experts.gates[i]) for i in range(self.experts.num_experts)],
+                "ups": [_export(self.experts.ups[i]) for i in range(self.experts.num_experts)],
+                "downs": [_export(self.experts.downs[i]) for i in range(self.experts.num_experts)],
+            },
+            "device": self.device,
+        }
+
+
+    @staticmethod
+    def tp_import(local_context, exported, plan, **kwargs):
+        key = exported["kwargs"]["key"]
+        device = local_context["device"]
+        output_device = local_context["output_device"]
+        first, last, unit = plan[key]
+        assert unit == "experts"
+
+        def _import(name):
+            nonlocal exported, plan
+            return exported[name]["cls"].tp_import(local_context, exported[name], plan) \
+                if exported.get(name) else None
+
+        def _import_i(bucket, i):
+            nonlocal exported, plan
+            entry = exported["experts"][bucket][i]
+            return entry["cls"].tp_import(local_context, entry, plan) if entry is not None else None
+
+        num_local_experts = max(0, last - first)
+        experts = Gemma4Experts(
+            config = None,
+            key = exported["experts"]["key"],
+            hidden_size = exported["experts"]["hidden_size"],
+            intermediate_size = exported["experts"]["intermediate_size"],
+            num_experts = exported["experts"]["num_experts"],
+            qmap = "block.mlp",
+            num_local_experts = num_local_experts,
+            gates = [_import_i("gates", i) for i in range(first, last)],
+            ups = [_import_i("ups", i) for i in range(first, last)],
+            downs = [_import_i("downs", i) for i in range(first, last)],
+            routing_first = first,
+            routing_last = last,
+        )
+        experts.device = device
+        experts.tp_reduce = True
+
+        module = Gemma4MoEFeedForward(
+            config = None,
+            **exported["kwargs"],
+            dense_mlp = _import("dense_mlp"),
+            dense_post_norm = _import("dense_post_norm"),
+            routed_pre_norm = _import("routed_pre_norm"),
+            routed_post_norm = _import("routed_post_norm"),
+            router = _import("router"),
+            experts = experts,
+            routing_device = output_device,
+        )
+        module.device = device
+        return module
+
+
     def forward(
         self,
         x: torch.Tensor,
@@ -940,10 +1956,27 @@ class Gemma4MoEFeedForward(Module):
         dense = self.dense_mlp.forward(x, params)
         dense = self.dense_post_norm.forward(dense, params)
 
-        selected_experts, routing_weights = self.router.forward(
-            residual.view(-1, self.hidden_size),
-            params,
-        )
+        flat_residual = residual.view(-1, self.hidden_size)
+        if self.routing_device is not None:
+            backend = params["backend"]
+            num_tokens = flat_residual.shape[0]
+            if backend.device == self.routing_device:
+                selected_experts, routing_weights = self.router.forward(flat_residual, params)
+            else:
+                selected_experts = torch.empty(
+                    (num_tokens, self.num_experts_per_tok),
+                    dtype = torch.long,
+                    device = flat_residual.device,
+                )
+                routing_weights = torch.empty(
+                    (num_tokens, self.num_experts_per_tok),
+                    dtype = torch.float,
+                    device = flat_residual.device,
+                )
+            backend.broadcast(selected_experts, src_device = self.routing_device)
+            backend.broadcast(routing_weights, src_device = self.routing_device)
+        else:
+            selected_experts, routing_weights = self.router.forward(flat_residual, params)
         routed_input = self.routed_pre_norm.forward(residual, params, out_dtype = torch.half)
         routed = self.experts.forward(routed_input, selected_experts, routing_weights, params)
         routed = self.routed_post_norm.forward(routed, params)
@@ -974,7 +2007,11 @@ class Gemma4MoETransformerBlock(Gemma4TransformerBlock):
         if self.mlp:
             residual = x
             y = self.mlp_norm.forward(x, params, out_dtype = torch.half) if self.mlp_norm else x.half()
-            y = self.mlp.forward(y, residual, params)
+            had_flag, previous = self._set_bsz1_graph_flag(params)
+            try:
+                y = self.mlp.forward(y, residual, params)
+            finally:
+                self._restore_bsz1_graph_flag(params, had_flag, previous)
             if self.mlp_post_norm:
                 y = self.mlp_post_norm.forward(y, params)
             x = residual + y
@@ -983,6 +2020,60 @@ class Gemma4MoETransformerBlock(Gemma4TransformerBlock):
             x = x * self.layer_scalar.to(dtype = x.dtype)
 
         return to2(x, out_dtype, self.out_dtype)
+
+
+    def tp_export(self, plan, producer):
+        assert self.device is not None, "Cannot export module for TP before loading."
+
+        def _export(child):
+            nonlocal producer
+            return child.tp_export(plan, producer) if child is not None else None
+
+        return {
+            "cls": Gemma4MoETransformerBlock,
+            "kwargs": {
+                "key": self.key,
+                "out_dtype": self.out_dtype,
+            },
+            **{name: _export(getattr(self, name, None)) for name in (
+                "attn_norm",
+                "attn",
+                "attn_post_norm",
+                "mlp_norm",
+                "mlp",
+                "mlp_post_norm",
+            )},
+            "layer_scalar": producer.send(self.layer_scalar),
+            "device": self.device,
+        }
+
+
+    @staticmethod
+    def tp_import(local_context, exported, plan):
+        consumer = local_context["consumer"]
+        device = local_context["device"]
+
+        def _import(name):
+            nonlocal exported, plan
+            return exported[name]["cls"].tp_import(local_context, exported[name], plan) \
+                if exported.get(name) else None
+
+        module = Gemma4MoETransformerBlock(
+            config = None,
+            **exported["kwargs"],
+            attn_norm = _import("attn_norm"),
+            attn = _import("attn"),
+            attn_post_norm = _import("attn_post_norm"),
+            mlp_norm = _import("mlp_norm"),
+            mlp = _import("mlp"),
+            mlp_post_norm = _import("mlp_post_norm"),
+        )
+        module.device = device
+        layer_scalar = consumer.recv(exported["layer_scalar"], cuda = True)
+        module.layer_scalar = nn.Parameter(layer_scalar, requires_grad = False) if layer_scalar is not None else None
+        module.layer_scalar_numel = 0 if layer_scalar is None else layer_scalar.numel()
+        torch.cuda.synchronize()
+        return module
 
 
 class Gemma4VisionPatchEmbedder(Module):

--- a/exllamav3/modules/linear.py
+++ b/exllamav3/modules/linear.py
@@ -24,6 +24,7 @@ class Linear(Module):
         qbits_key: str = "bits",
         fkey : str | None = None,
         frange: tuple[int, int] | None = None,
+        frange_dim: int = 0,
         fidx: int | None = None,
         caps: dict = None,
         softcap: float = 0.0,
@@ -37,6 +38,7 @@ class Linear(Module):
         post_scale: float = 1.0,
         transposed_load: bool = True,
         transpose_fused_weights: bool = True,
+        ftranspose_after_load: bool = True,
         select_hq_bits: int = 0,
         qgroup: str = None
     ):
@@ -55,6 +57,7 @@ class Linear(Module):
         self.qbits_key = qbits_key
         self.fkey = fkey
         self.frange = frange
+        self.frange_dim = frange_dim
         self.fidx = fidx
         self.quant_type = None
         self.softcap = softcap
@@ -63,6 +66,7 @@ class Linear(Module):
         self.post_scale = post_scale
         self.transposed_load = transposed_load
         self.transpose_fused_weights = transpose_fused_weights
+        self.ftranspose_after_load = ftranspose_after_load
         self.select_hq_bits = select_hq_bits
         self.qgroup = qgroup or key
 
@@ -176,12 +180,19 @@ class Linear(Module):
                 fidx = self.fidx
             )
             if self.frange is not None:
-                weight = weight[self.frange[0] : self.frange[1]].contiguous()
+                if self.frange_dim == 0:
+                    weight = weight[self.frange[0] : self.frange[1]].contiguous()
+                elif self.frange_dim == 1:
+                    weight = weight[:, self.frange[0] : self.frange[1]].contiguous()
+                else:
+                    raise ValueError(f"Unsupported frange_dim={self.frange_dim} for {self.key}")
             weight = self.pad_out(weight)
+            if self.ftranspose_after_load:
+                weight = weight.T.contiguous()
             self.inner = LinearFP16(
                 self.in_features,
                 self.out_features,
-                weight.T.contiguous(),
+                weight,
                 None,
                 self.full_in_features,
                 self.full_out_features,
@@ -462,6 +473,11 @@ class Linear(Module):
                 "out_features": self.out_features,
                 "out_dtype": self.out_dtype,
                 "alt_key": self.alt_key,
+                "fkey": self.fkey,
+                "frange": self.frange,
+                "frange_dim": self.frange_dim,
+                "fidx": self.fidx,
+                "ftranspose_after_load": self.ftranspose_after_load,
                 "caps": self.caps,
                 "softcap": self.softcap,
                 "full_in_features": self.full_in_features,

--- a/exllamav3/tokenizer/tokenizer.py
+++ b/exllamav3/tokenizer/tokenizer.py
@@ -627,6 +627,7 @@ class Tokenizer:
         self,
         messages: list,
         add_generation_prompt: bool = True,
+        embeddings: list[MMEmbedding] | None = None,
         **template_kwargs
     ):
         """
@@ -642,6 +643,10 @@ class Tokenizer:
         :param add_generation_prompt:
             bool, add generation prompt
 
+        :param embeddings:
+            Optional list of MMEmbeddings. When present, HF chat template output is first rendered to text and
+            occurrences of the model's image placeholder token are replaced with embedding aliases before tokenizing.
+
         :param template_kwargs:
             Additional kwargs forwarded to `transformers` chat template rendering,
             e.g. `tools`, `chat_template_kwargs`, `enable_thinking`, etc.
@@ -649,6 +654,32 @@ class Tokenizer:
         :return:
             Token IDs tensor, shape (1, num_tokens)
         """
+
+        if embeddings:
+            if self.config.image_token_id is None:
+                raise ValueError("hf_chat_template(..., embeddings=...) requires config.image_token_id")
+            if not (0 <= self.config.image_token_id < len(self.id_to_piece)):
+                raise ValueError("config.image_token_id is out of tokenizer vocabulary range")
+
+            image_placeholder = self.id_to_piece[self.config.image_token_id]
+            rendered = self.hf_render_chat_template(
+                messages,
+                add_generation_prompt = add_generation_prompt,
+                **template_kwargs,
+            )
+            placeholder_count = rendered.count(image_placeholder)
+            if placeholder_count != len(embeddings):
+                raise ValueError(
+                    f"HF chat template rendered {placeholder_count} image placeholders but got "
+                    f"{len(embeddings)} embedding(s)"
+                )
+            for embedding in embeddings:
+                rendered = rendered.replace(image_placeholder, embedding.text_alias, 1)
+            return self.encode(
+                rendered,
+                encode_special_tokens = True,
+                embeddings = embeddings,
+            )
 
         from transformers import AutoTokenizer
         from transformers.tokenization_utils_base import BatchEncoding

--- a/exllamav3/util/rope.py
+++ b/exllamav3/util/rope.py
@@ -112,6 +112,8 @@ class RoPE:
                 self._rope_params_default()
             case "default" | "mrope":
                 self._rope_params_default()
+            case "proportional":
+                self._rope_params_proportional()
             case "llama3":
                 self._rope_params_llama3()
             case "linear":
@@ -158,6 +160,33 @@ class RoPE:
         self._rope_params_default()
         factor = rs.rope_scaling.get("factor", 1.0)
         self.inv_freq /= factor
+
+
+    def _rope_params_proportional(self):
+        rs = self.rope_settings
+        head_dim = rs.head_dim
+        base = rs.rope_theta
+        factor = rs.rope_scaling.get("factor", 1.0) if rs.rope_scaling else 1.0
+        rope_proportion = rs.partial_rotary_factor
+
+        rope_angles = int(rope_proportion * head_dim // 2)
+        inv_freq_rotated = 1.0 / (
+            base ** (
+                torch.arange(0, 2 * rope_angles, 2, dtype = torch.int64, device = self.device).float() / head_dim
+            )
+        )
+        nope_angles = head_dim // 2 - rope_angles
+        if nope_angles > 0:
+            inv_freq = torch.cat(
+                (
+                    inv_freq_rotated,
+                    torch.zeros(nope_angles, dtype = torch.float32, device = self.device),
+                ),
+                dim = 0,
+            )
+        else:
+            inv_freq = inv_freq_rotated
+        self.inv_freq, self.attn_factor = inv_freq / factor, 1.0
 
 
     def _rope_params_yarn(self):

--- a/tests/bench_gemma4_compare.py
+++ b/tests/bench_gemma4_compare.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+Compare Gemma4 support-only baseline vs current turboquant path.
+
+This benchmark intentionally follows the lightweight PR-validation style of
+`tests/bench_gemma4_turboquant.py`, but runs each comparison target in an
+isolated subprocess so different exllamav3 trees can be compared safely.
+
+Modes:
+1) compare mode (default): spawn one subprocess per repo/mode and summarize
+2) single mode: run one benchmark target and print one JSON result
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}", file = sys.stderr)
+    sys.exit(1)
+
+
+def parse_json_line(stdout: str) -> dict:
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    for line in reversed(lines):
+        if line.startswith("{") and line.endswith("}"):
+            return json.loads(line)
+    raise ValueError("No JSON result line found")
+
+
+def ratio(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator in (None, 0) or denominator in (None, 0):
+        return None
+    return round(numerator / denominator, 4)
+
+
+def run_subprocess(args, repo_root: str, mode: str) -> dict:
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--single",
+        "--repo_root", repo_root,
+        "--mode", mode,
+        "--model_dir", args.model_dir,
+        "--cache_bits", args.cache_bits,
+        "--cache_size", str(args.cache_size),
+        "--job_timeout_s", str(args.job_timeout_s),
+        "--text_repeats", str(args.text_repeats),
+        "--mm_repeats", str(args.mm_repeats),
+    ]
+    if args.reserve_per_device:
+        cmd += ["--reserve_per_device", args.reserve_per_device]
+    if args.swa_cache_size is not None:
+        cmd += ["--swa_cache_size", str(args.swa_cache_size)]
+    if args.cat_image:
+        cmd += ["--cat_image", args.cat_image]
+    if args.fruit_image:
+        cmd += ["--fruit_image", args.fruit_image]
+
+    proc = subprocess.run(
+        cmd,
+        text = True,
+        capture_output = True,
+        env = os.environ.copy(),
+    )
+
+    result = {
+        "mode": mode,
+        "repo_root": repo_root,
+        "returncode": proc.returncode,
+        "stdout_tail": proc.stdout.splitlines()[-20:],
+        "stderr_tail": proc.stderr.splitlines()[-20:],
+    }
+    if proc.returncode == 0:
+        try:
+            payload = parse_json_line(proc.stdout)
+            result.update(payload)
+            result["status"] = payload.get("status", "ok")
+        except Exception as exc:  # pragma: no cover - benchmark plumbing
+            result["status"] = "error"
+            result["parse_error"] = str(exc)
+    else:
+        result["status"] = "error"
+
+    return result
+
+
+def run_single(args) -> dict:
+    sys.path.insert(0, args.repo_root)
+
+    from PIL import Image
+    import torch
+    from exllamav3 import Cache, Config, Job, Model, Tokenizer
+    from exllamav3.cache import CacheLayer_quant
+    from exllamav3.generator import Generator
+    from exllamav3.generator.sampler import GreedySampler
+
+    def mib(num_bytes: int) -> float:
+        return num_bytes / (1024 ** 2)
+
+    def cache_footprint_bytes(cache: Cache) -> int:
+        return sum(layer.storage_size() + layer.overhead_size() for layer in cache.layers.values())
+
+    def run_job(generator: Generator, job: Job) -> tuple[str, float]:
+        generator.enqueue(job)
+        output = ""
+        t0 = time.perf_counter()
+        while generator.num_remaining_jobs():
+            if time.perf_counter() - t0 > args.job_timeout_s:
+                fail(f"Benchmark job timed out after {args.job_timeout_s:.1f}s")
+            for result in generator.iterate():
+                if result.get("stage") == "streaming":
+                    output += result.get("text", "")
+        return output.strip(), round(time.perf_counter() - t0, 4)
+
+    def run_repeated_jobs(generator: Generator, job_factory, repeats: int):
+        outputs = []
+        times = []
+        for _ in range(repeats):
+            out, dt = run_job(generator, job_factory())
+            outputs.append(out)
+            times.append(dt)
+        return outputs, times
+
+    def make_repeated_text_prompt() -> str:
+        repeated_clause = "The black cat sits on the warm window sill and watches the garden birds. "
+        return (
+            "Read the passage and answer with exactly one word: cat.\n\n"
+            + repeated_clause * 48
+        )
+
+    cfg = Config.from_directory(args.model_dir)
+    model = Model.from_config(cfg)
+    tokenizer = Tokenizer.from_config(cfg)
+
+    cat_image = args.cat_image or os.path.join(args.repo_root, "doc", "cat.png")
+    fruit_image = args.fruit_image or os.path.join(args.repo_root, "examples", "media", "strawberry.png")
+    if not os.path.exists(cat_image):
+        fail(f"Required image not found: {cat_image}")
+    if not os.path.exists(fruit_image):
+        fail(f"Required image not found: {fruit_image}")
+
+    reserve = None
+    if args.reserve_per_device:
+        reserve = [float(x) for x in args.reserve_per_device.split(",")]
+
+    split = [int(bits) for bits in args.cache_bits.split(",")]
+    if len(split) == 1:
+        k_bits = v_bits = split[0]
+    elif len(split) == 2:
+        k_bits, v_bits = split
+    else:
+        fail("--cache_bits must be 'bits' or 'k_bits,v_bits'")
+
+    vision_model = Model.from_config(cfg, component = "vision")
+    vision_model.load("cuda:0")
+    cat = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    cat_dup = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    fruit = vision_model.get_image_embeddings(tokenizer, Image.open(fruit_image).convert("RGB"))
+    vision_model.unload()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    if args.mode == "support_default":
+        cache = Cache(
+            model,
+            max_num_tokens = args.cache_size,
+        )
+    elif args.mode == "support_generic_quant":
+        cache = Cache(
+            model,
+            max_num_tokens = args.cache_size,
+            layer_type = CacheLayer_quant,
+            k_bits = k_bits,
+            v_bits = v_bits,
+        )
+    elif args.mode == "current_turboquant":
+        cache = Cache(
+            model,
+            max_num_tokens = args.cache_size,
+            layer_type = model.caps.get("quantized_kv_cache_layer"),
+            k_bits = k_bits,
+            v_bits = v_bits,
+            swa_max_num_tokens = args.swa_cache_size,
+        )
+    else:
+        fail(f"Unknown mode: {args.mode}")
+
+    model.load(reserve_per_device = reserve)
+    generator = Generator(model, cache, tokenizer)
+
+    def make_text_job() -> Job:
+        prompt_ids = tokenizer.hf_chat_template(
+            [{"role": "user", "content": make_repeated_text_prompt()}],
+            add_generation_prompt = True,
+            enable_thinking = False,
+        )
+        return Job(
+            input_ids = prompt_ids.cpu(),
+            max_new_tokens = 4,
+            stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+            decode_special_tokens = True,
+            sampler = GreedySampler(),
+        )
+
+    def make_mm_job(embeddings: list, question: str) -> Job:
+        prompt_ids = tokenizer.hf_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "image"} for _ in embeddings] + [{"type": "text", "text": question}],
+                }
+            ],
+            add_generation_prompt = True,
+            enable_thinking = False,
+            embeddings = embeddings,
+        )
+        return Job(
+            input_ids = prompt_ids.cpu(),
+            max_new_tokens = 16,
+            stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+            decode_special_tokens = True,
+            embeddings = embeddings,
+            sampler = GreedySampler(),
+        )
+
+    text_outputs, text_times = run_repeated_jobs(generator, make_text_job, args.text_repeats)
+
+    dup_outputs = []
+    dup_times = []
+    pair_output = None
+    pair_time = None
+    if args.mm_repeats > 0:
+        dup_outputs, dup_times = run_repeated_jobs(
+            generator,
+            lambda: make_mm_job([cat, cat_dup], "Do the two images show the same subject? Answer yes or no."),
+            args.mm_repeats,
+        )
+        pair_output, pair_time = run_job(
+            generator,
+            make_mm_job([cat, fruit], "Which image shows an animal? Answer first or second."),
+        )
+
+    result = {
+        "status": "ok",
+        "mode": args.mode,
+        "repo_root": args.repo_root,
+        "cache_footprint_mib": round(mib(cache_footprint_bytes(cache)), 2),
+        "text_repeat_times_s": text_times,
+        "dup_same_times_s": dup_times,
+        "pair_animal_s": pair_time,
+        "text_repeat_outputs": text_outputs,
+        "dup_same_outputs": dup_outputs,
+        "pair_animal_out": pair_output,
+    }
+    print(json.dumps(result), flush = True)
+
+    model.unload()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--single", action = "store_true")
+    ap.add_argument("--repo_root", default = str(REPO_ROOT))
+    ap.add_argument("--baseline_repo_root", default = None)
+    ap.add_argument("--current_repo_root", default = str(REPO_ROOT))
+    ap.add_argument("--model_dir", required = True)
+    ap.add_argument("--reserve_per_device", default = None)
+    ap.add_argument("--cache_bits", default = "4")
+    ap.add_argument("--cache_size", type = int, default = 4096)
+    ap.add_argument("--swa_cache_size", type = int, default = 1024)
+    ap.add_argument("--job_timeout_s", type = float, default = 120.0)
+    ap.add_argument("--text_repeats", type = int, default = 2)
+    ap.add_argument("--mm_repeats", type = int, default = 2)
+    ap.add_argument("--cat_image", default = None)
+    ap.add_argument("--fruit_image", default = None)
+    ap.add_argument("--mode", choices = ["support_default", "support_generic_quant", "current_turboquant"])
+    args = ap.parse_args()
+
+    if args.single:
+        try:
+            run_single(args)
+        except Exception as exc:  # pragma: no cover - benchmark plumbing
+            payload = {
+                "status": "error",
+                "mode": args.mode,
+                "repo_root": args.repo_root,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "traceback": traceback.format_exc().splitlines()[-20:],
+            }
+            print(json.dumps(payload), flush = True)
+            raise
+        return
+
+    if not args.baseline_repo_root:
+        fail("--baseline_repo_root is required in compare mode")
+
+    baseline = run_subprocess(args, args.baseline_repo_root, "support_default")
+    current = run_subprocess(args, args.current_repo_root, "current_turboquant")
+    summary = {
+        "baseline": baseline,
+        "current": current,
+    }
+    if baseline.get("status") == "ok" and current.get("status") == "ok":
+        baseline_text = baseline.get("text_repeat_times_s", [])
+        current_text = current.get("text_repeat_times_s", [])
+        baseline_dup = baseline.get("dup_same_times_s", [])
+        current_dup = current.get("dup_same_times_s", [])
+        baseline_cache = baseline.get("cache_footprint_mib")
+        current_cache = current.get("cache_footprint_mib")
+        comparison = {
+            "cache_ratio_baseline_over_current": ratio(baseline_cache, current_cache),
+            "cache_reduction_pct": round((1.0 - current_cache / baseline_cache) * 100.0, 2) if baseline_cache and current_cache else None,
+            "text_first_speedup": ratio(baseline_text[0] if baseline_text else None, current_text[0] if current_text else None),
+            "text_second_speedup": ratio(baseline_text[1] if len(baseline_text) > 1 else None, current_text[1] if len(current_text) > 1 else None),
+            "dup_same_first_speedup": ratio(baseline_dup[0] if baseline_dup else None, current_dup[0] if current_dup else None),
+            "dup_same_second_speedup": ratio(baseline_dup[1] if len(baseline_dup) > 1 else None, current_dup[1] if len(current_dup) > 1 else None),
+            "pair_animal_speedup": ratio(baseline.get("pair_animal_s"), current.get("pair_animal_s")),
+        }
+        summary["comparison"] = comparison
+    print(json.dumps(summary, indent = 2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench_gemma4_turboquant.py
+++ b/tests/bench_gemma4_turboquant.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Short benchmark harness for Gemma4 KV turboquant configurations.
+
+Measures:
+1) Cache footprint from cache layer metadata
+2) First-run / second-run latency for repeated prompts
+3) Optional multimodal short prompt latency sweep across SWA sizes
+
+This is intentionally lightweight and reproducible, aimed at PR validation rather
+than exhaustive serving benchmarks.
+"""
+
+import argparse
+import json
+import statistics
+import os
+import sys
+import time
+
+import torch
+from PIL import Image
+
+from exllamav3 import Cache, Config, Job, Model, Tokenizer
+from exllamav3.generator import Generator
+from exllamav3.generator.sampler import GreedySampler
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def mib(num_bytes: int) -> float:
+    return num_bytes / (1024 ** 2)
+
+
+def cache_footprint_bytes(cache: Cache) -> int:
+    return sum(layer.storage_size() + layer.overhead_size() for layer in cache.layers.values())
+
+
+def count_shadow_pages(cache: Cache) -> int:
+    total = 0
+    for layer in cache.layers.values():
+        shadow_pages = getattr(layer, "shadow_k_pages", None)
+        if shadow_pages:
+            total += len(shadow_pages)
+    return total
+
+
+def safe_mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return round(statistics.fmean(values), 4)
+
+
+def first_or_none(values: list):
+    return values[0] if values else None
+
+
+def second_or_none(values: list):
+    return values[1] if len(values) > 1 else None
+
+
+def get_role_max_tokens(cache: Cache, role: str) -> int | None:
+    role_tokens = [
+        layer.max_num_tokens
+        for layer in cache.layers.values()
+        if getattr(layer, "cache_role", "default") == role
+    ]
+    if not role_tokens:
+        return None
+    return min(role_tokens)
+
+
+def run_job(generator: Generator, job: Job, timeout_s: float) -> tuple[str, float]:
+    generator.enqueue(job)
+    output = ""
+    t0 = time.perf_counter()
+    while generator.num_remaining_jobs():
+        if time.perf_counter() - t0 > timeout_s:
+            fail(f"Benchmark job timed out after {timeout_s:.1f}s")
+        for result in generator.iterate():
+            if result.get("stage") == "streaming":
+                output += result.get("text", "")
+    return output, time.perf_counter() - t0
+
+
+def run_repeated_jobs(generator: Generator, job_factory, repeats: int, timeout_s: float):
+    jobs = []
+    outputs = []
+    times = []
+    for _ in range(repeats):
+        job = job_factory()
+        out, dt = run_job(generator, job, timeout_s)
+        jobs.append(job)
+        outputs.append(out.strip())
+        times.append(round(dt, 4))
+    return jobs, outputs, times
+
+
+def make_repeated_text_prompt() -> str:
+    repeated_clause = "The black cat sits on the warm window sill and watches the garden birds. "
+    return (
+        "Read the passage and answer with exactly one word: cat.\n\n"
+        + repeated_clause * 48
+    )
+
+
+def make_text_job(tokenizer: Tokenizer, prompt: str, max_new_tokens: int = 8) -> Job:
+    prompt_ids = tokenizer.hf_chat_template(
+        [{"role": "user", "content": prompt}],
+        add_generation_prompt = True,
+        enable_thinking = False,
+    )
+    return Job(
+        input_ids = prompt_ids.cpu(),
+        max_new_tokens = max_new_tokens,
+        stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+        decode_special_tokens = True,
+        sampler = GreedySampler(),
+    )
+
+
+def make_mm_job(tokenizer: Tokenizer, embeddings: list, question: str, max_new_tokens: int = 16) -> Job:
+    prompt_ids = tokenizer.hf_chat_template(
+        [
+            {
+                "role": "user",
+                "content": [{"type": "image"} for _ in embeddings] + [{"type": "text", "text": question}],
+            }
+        ],
+        add_generation_prompt = True,
+        enable_thinking = False,
+        embeddings = embeddings,
+    )
+    return Job(
+        input_ids = prompt_ids.cpu(),
+        max_new_tokens = max_new_tokens,
+        stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+        decode_special_tokens = True,
+        embeddings = embeddings,
+        sampler = GreedySampler(),
+    )
+
+
+def load_demo_embeddings(cfg: Config, tokenizer: Tokenizer, cat_image_path: str, fruit_image_path: str):
+    vision_model = Model.from_config(cfg, component = "vision")
+    vision_model.load("cuda:0")
+    cat = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image_path).convert("RGB"))
+    cat_dup = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image_path).convert("RGB"))
+    fruit = vision_model.get_image_embeddings(tokenizer, Image.open(fruit_image_path).convert("RGB"))
+    vision_model.unload()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return cat, cat_dup, fruit
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", required = True)
+    ap.add_argument("--device", default = "cuda:0")
+    ap.add_argument("--reserve_per_device", default = None, help = "e.g. 0.5,0.5")
+    ap.add_argument("--cache_bits", default = "4", help = "Either single value or k_bits,v_bits")
+    ap.add_argument("--cache_size", type = int, default = 1024)
+    ap.add_argument(
+        "--swa_sizes",
+        default = "1024,768",
+        help = "Comma separated requested SWA cache sizes in tokens. Values are page-aligned internally.",
+    )
+    ap.add_argument("--cat_image", default = None)
+    ap.add_argument("--fruit_image", default = None)
+    ap.add_argument("--job_timeout_s", type = float, default = 120.0)
+    ap.add_argument("--text_repeats", type = int, default = 2)
+    ap.add_argument("--mm_repeats", type = int, default = 2)
+    args = ap.parse_args()
+
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this benchmark")
+
+    cat_image = args.cat_image or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "doc",
+        "cat.png",
+    )
+    if not os.path.exists(cat_image):
+        fail(f"Required image not found: {cat_image}")
+    fruit_image = args.fruit_image or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "examples",
+        "media",
+        "strawberry.png",
+    )
+    if not os.path.exists(fruit_image):
+        fail(f"Required image not found: {fruit_image}")
+
+    reserve = None
+    if args.reserve_per_device:
+        reserve = [float(x) for x in args.reserve_per_device.split(",")]
+
+    split = [int(bits) for bits in args.cache_bits.split(",")]
+    if len(split) == 1:
+        k_bits = v_bits = split[0]
+    elif len(split) == 2:
+        k_bits, v_bits = split
+    else:
+        fail("--cache_bits must be 'bits' or 'k_bits,v_bits'")
+
+    cfg = Config.from_directory(args.model_dir)
+    model = Model.from_config(cfg)
+    tokenizer = Tokenizer.from_config(cfg)
+    print(f"[INFO] loading vision embeddings for {args.model_dir}", flush = True)
+    cat, cat_dup, fruit = load_demo_embeddings(cfg, tokenizer, cat_image, fruit_image)
+
+    results = []
+    for swa_size in [int(x.strip()) for x in args.swa_sizes.split(",") if x.strip()]:
+        print(f"[INFO] bench start swa_cache_size={swa_size}", flush = True)
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+
+        cache = Cache(
+            model,
+            max_num_tokens = args.cache_size,
+            layer_type = model.caps.get("quantized_kv_cache_layer"),
+            k_bits = k_bits,
+            v_bits = v_bits,
+            swa_max_num_tokens = swa_size,
+        )
+
+        print(f"[INFO] loading text model swa_cache_size={swa_size}", flush = True)
+        model.load(reserve_per_device = reserve)
+        generator = Generator(model, cache, tokenizer)
+        effective_full_cache_size = get_role_max_tokens(cache, "full")
+        effective_swa_cache_size = get_role_max_tokens(cache, "swa")
+        atomic_mm_prefill = bool(model.caps.get("atomic_mm_prefill", False))
+
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+
+        repeated_text_prompt = make_repeated_text_prompt()
+        text_jobs = []
+        text_outputs = []
+        text_times = []
+        if args.text_repeats > 0:
+            text_jobs, text_outputs, text_times = run_repeated_jobs(
+                generator,
+                lambda: make_text_job(tokenizer, repeated_text_prompt, max_new_tokens = 4),
+                args.text_repeats,
+                args.job_timeout_s,
+            )
+        for idx, dt in enumerate(text_times, start = 1):
+            print(f"[INFO] swa={swa_size} text-repeat #{idx} done in {dt:.4f}s", flush = True)
+        shadow_pages_after_text = count_shadow_pages(cache)
+
+        repeated_jobs = []
+        repeated_outputs = []
+        repeated_times = []
+        if args.mm_repeats > 0:
+            repeated_jobs, repeated_outputs, repeated_times = run_repeated_jobs(
+                generator,
+                lambda: make_mm_job(
+                    tokenizer,
+                    [cat, cat_dup],
+                    "Do the two images show the same subject? Answer yes or no.",
+                ),
+                args.mm_repeats,
+                args.job_timeout_s,
+            )
+        for idx, dt in enumerate(repeated_times, start = 1):
+            print(f"[INFO] swa={swa_size} duplicate #{idx} done in {dt:.4f}s", flush = True)
+
+        pair_job = make_mm_job(
+            tokenizer,
+            [cat, fruit],
+            "Which image shows an animal? Answer first or second.",
+        )
+        pair_out, pair_t = run_job(generator, pair_job, args.job_timeout_s)
+        print(f"[INFO] swa={swa_size} pair-animal done in {pair_t:.4f}s", flush = True)
+        shadow_pages_after_mm = count_shadow_pages(cache)
+
+        peak_alloc = 0
+        peak_reserved = 0
+        if torch.cuda.is_available():
+            peak_alloc = torch.cuda.max_memory_allocated()
+            peak_reserved = torch.cuda.max_memory_reserved()
+
+        result = {
+            "swa_cache_size": swa_size,
+            "effective_full_cache_size": effective_full_cache_size,
+            "effective_swa_cache_size": effective_swa_cache_size,
+            "cache_footprint_mib": round(mib(cache_footprint_bytes(cache)), 2),
+            "atomic_mm_prefill": atomic_mm_prefill,
+            "text_repeat_times_s": text_times,
+            "text_repeat_avg_s": safe_mean(text_times),
+            "text_repeat_outputs": text_outputs,
+            "text_repeat_cached_pages": [job.cached_pages for job in text_jobs],
+            "text_repeat_cached_tokens": [job.cached_tokens for job in text_jobs],
+            "text_repeat_first_s": first_or_none(text_times),
+            "text_repeat_second_s": second_or_none(text_times),
+            "text_repeat_first_out": first_or_none(text_outputs),
+            "text_repeat_second_out": second_or_none(text_outputs),
+            "dup_same_times_s": repeated_times,
+            "dup_same_avg_s": safe_mean(repeated_times),
+            "dup_same_outputs": repeated_outputs,
+            "dup_same_cached_pages": [job.cached_pages for job in repeated_jobs],
+            "dup_same_cached_tokens": [job.cached_tokens for job in repeated_jobs],
+            "dup_same_first_s": first_or_none(repeated_times),
+            "dup_same_second_s": second_or_none(repeated_times),
+            "pair_animal_s": round(pair_t, 4),
+            "dup_same_first_out": first_or_none(repeated_outputs),
+            "dup_same_second_out": second_or_none(repeated_outputs),
+            "pair_animal_out": pair_out.strip(),
+            "dup_same_first_cached_pages": first_or_none([job.cached_pages for job in repeated_jobs]),
+            "dup_same_first_cached_tokens": first_or_none([job.cached_tokens for job in repeated_jobs]),
+            "dup_same_second_cached_pages": second_or_none([job.cached_pages for job in repeated_jobs]),
+            "dup_same_second_cached_tokens": second_or_none([job.cached_tokens for job in repeated_jobs]),
+            "cached_swa_snapshots": len(getattr(generator.pagetable, "cached_full_to_swa_pages", {})),
+            "shadow_pages_after_text": shadow_pages_after_text,
+            "shadow_pages_after_mm": shadow_pages_after_mm,
+            "shadow_pages": shadow_pages_after_mm,
+            "peak_alloc_mib": round(mib(peak_alloc), 2),
+            "peak_reserved_mib": round(mib(peak_reserved), 2),
+        }
+        print(json.dumps(result, ensure_ascii = False), flush = True)
+        results.append(result)
+
+        model.unload()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    print("[SUMMARY]")
+    print(json.dumps(results, indent = 2, ensure_ascii = False), flush = True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_exl3_mgemm_state_mix.py
+++ b/tests/smoke_exl3_mgemm_state_mix.py
@@ -1,0 +1,130 @@
+import argparse
+import json
+import random
+import torch
+
+from PIL import Image
+
+from exllamav3 import Cache, Config, Job, Model, Tokenizer
+from exllamav3.generator import Generator
+from exllamav3.generator.sampler import GreedySampler
+
+
+TEXT_PROMPTS = {
+    "text_short": "Answer with one short word: hello.",
+    "text_repeat": "Repeat the word alpha exactly three times, separated by spaces.",
+    "text_long": "Summarize this sentence in one word: " + " ".join(["curious"] * 256),
+}
+
+KINDS = [
+    "text_short",
+    "text_repeat",
+    "text_long",
+    "mm_single_cat",
+    "mm_single_fruit",
+    "mm_dup_same",
+    "mm_pair_animal",
+]
+
+
+def run_job(generator, tokenizer, prompt_ids, embeddings=None):
+    job = Job(
+        input_ids=prompt_ids.cpu(),
+        max_new_tokens=16,
+        stop_conditions=[tokenizer.eos_token_id, "<turn|>"],
+        decode_special_tokens=True,
+        embeddings=embeddings,
+        sampler=GreedySampler(),
+    )
+    generator.enqueue(job)
+    output = ""
+    while generator.num_remaining_jobs():
+        for result in generator.iterate():
+            if result.get("stage") == "streaming":
+                output += result.get("text", "")
+    return output
+
+
+def run_text(generator, tokenizer, text):
+    prompt_ids = tokenizer.hf_chat_template(
+        [{"role": "user", "content": [{"type": "text", "text": text}]}],
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    return run_job(generator, tokenizer, prompt_ids)
+
+
+def run_mm(generator, tokenizer, embeddings, question):
+    prompt_ids = tokenizer.hf_chat_template(
+        [
+            {
+                "role": "user",
+                "content": ([{"type": "image"} for _ in embeddings] + [{"type": "text", "text": question}]),
+            }
+        ],
+        add_generation_prompt=True,
+        enable_thinking=False,
+        embeddings=embeddings,
+    )
+    return run_job(generator, tokenizer, prompt_ids, embeddings=embeddings)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_dir", required=True)
+    parser.add_argument("--reserve_per_device", default="0,0")
+    parser.add_argument("--seed", type=int, default=20260407)
+    parser.add_argument("--nreq", type=int, default=64)
+    args = parser.parse_args()
+
+    reserve = [float(x) for x in args.reserve_per_device.split(",")]
+    rng = random.Random(args.seed)
+    seq = [rng.choice(KINDS) for _ in range(args.nreq)]
+
+    cfg = Config.from_directory(args.model_dir)
+    model = Model.from_config(cfg)
+    vision_model = Model.from_config(cfg, component="vision")
+    tokenizer = Tokenizer.from_config(cfg)
+    cache = Cache(
+        model,
+        max_num_tokens=4096,
+        layer_type=model.caps.get("quantized_kv_cache_layer"),
+        k_bits=4,
+        v_bits=4,
+    )
+
+    cat_image = "/nvme512g/util/exllamav3/doc/cat.png"
+    fruit_image = "/nvme512g/util/exllamav3/examples/media/strawberry.png"
+
+    vision_model.load(torch.device("cuda:0"))
+    cat = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    cat_dup = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    fruit = vision_model.get_image_embeddings(tokenizer, Image.open(fruit_image).convert("RGB"))
+    vision_model.unload()
+
+    model.load(reserve_per_device=reserve)
+    generator = Generator(model, cache, tokenizer)
+
+    mm_map = {
+        "mm_single_cat": ([cat], "What animal is shown? Answer with one word."),
+        "mm_single_fruit": ([fruit], "What fruit is shown? Answer with one word."),
+        "mm_dup_same": ([cat, cat_dup], "Do the two images show the same subject? Answer yes or no."),
+        "mm_pair_animal": ([cat, fruit], "Which image shows an animal? Answer first or second."),
+    }
+
+    results = []
+    for i, kind in enumerate(seq, start=1):
+        if kind.startswith("text_"):
+            out = run_text(generator, tokenizer, TEXT_PROMPTS[kind])
+        else:
+            emb, q = mm_map[kind]
+            out = run_mm(generator, tokenizer, emb, q)
+        record = {"idx": i, "kind": kind, "out": out[:80]}
+        results.append(record)
+        print(json.dumps(record), flush=True)
+
+    print(json.dumps({"status": "OK", "nreq": len(results)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_gemma4_arch.py
+++ b/tests/smoke_gemma4_arch.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Lightweight smoke checks for Gemma4 text architecture integration.
+
+Checks:
+1) Config/architecture resolution
+2) Text and vision model graph construction
+3) One sliding-attn block forward
+4) One full-attn block forward
+5) One MoE block forward when enabled
+6) One image embedding extraction through the vision tower
+
+Optional:
+7) Attempt full text model load
+"""
+
+import argparse
+import os
+import sys
+import torch
+from PIL import Image
+
+from exllamav3 import Cache, Config, Generator, Job, Model, Tokenizer
+from exllamav3.generator.sampler import GreedySampler
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", required=True)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--full_load", action="store_true")
+    ap.add_argument("--reserve_per_device", default=None, help="e.g. 0.25,0.25")
+    ap.add_argument("--multimodal_generation", action="store_true")
+    ap.add_argument("--multimodal_image", default=None)
+    args = ap.parse_args()
+
+    cfg = Config.from_directory(args.model_dir)
+    print("[INFO] architecture:", cfg.architecture)
+    if cfg.architecture != "Gemma4ForConditionalGeneration":
+        fail(f"Unexpected architecture: {cfg.architecture}")
+
+    model = Model.from_config(cfg)
+    vision_model = Model.from_config(cfg, component = "vision")
+    tokenizer = Tokenizer.from_config(cfg)
+    print("[INFO] model graph ok")
+    print("[INFO] vision graph ok")
+
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this smoke check")
+
+    device = torch.device(args.device)
+    hidden_size = cfg.hidden_size
+
+    idx_sliding = model.first_block_idx + cfg.layer_types.index("sliding_attention")
+    blk_sliding = model.modules[idx_sliding]
+    blk_sliding.load(device)
+    if blk_sliding.attn.v_proj is None:
+        fail("Expected sliding attention to have a v_proj")
+    x = torch.randn((1, 8, hidden_size), device = device, dtype = torch.half)
+    with torch.inference_mode():
+        y = blk_sliding.forward(x, params = {})
+    print("[INFO] sliding block forward:", blk_sliding.key, tuple(y.shape))
+    blk_sliding.unload()
+
+    idx_full = model.first_block_idx + cfg.layer_types.index("full_attention")
+    blk_full = model.modules[idx_full]
+    blk_full.load(device)
+    if blk_full.attn.v_proj is not None:
+        fail("Expected Gemma4 full attention to omit v_proj")
+    x = torch.randn((1, 8, hidden_size), device = device, dtype = torch.half)
+    with torch.inference_mode():
+        y = blk_full.forward(x, params = {})
+    print("[INFO] full block forward:", blk_full.key, tuple(y.shape))
+    blk_full.unload()
+
+    if cfg.enable_moe_block:
+        idx_moe = model.first_block_idx
+        blk_moe = model.modules[idx_moe]
+        blk_moe.load(device)
+        x = torch.randn((1, 8, hidden_size), device = device, dtype = torch.half)
+        with torch.inference_mode():
+            y = blk_moe.forward(x, params = {})
+        print("[INFO] moe block forward:", blk_moe.key, tuple(y.shape))
+        blk_moe.unload()
+
+    vision_model.load(device)
+    image = Image.new("RGB", (640, 480), (255, 0, 0))
+    image_embedding = vision_model.get_image_embeddings(tokenizer, image)
+    print("[INFO] image embeddings:", image_embedding.mm_length)
+    if image_embedding.mm_length <= 0:
+        fail("Vision tower produced no image embeddings")
+    vision_model.unload()
+
+    if args.full_load:
+        reserve = None
+        if args.reserve_per_device:
+            reserve = [float(x) for x in args.reserve_per_device.split(",")]
+        print("[INFO] attempting full model load")
+        try:
+            model.load(reserve_per_device = reserve)
+            print("[INFO] full model load ok")
+            model.unload()
+        except Exception as e:
+            print("[WARN] full model load failed:", repr(e))
+
+    if args.multimodal_generation:
+        image_path = args.multimodal_image
+        if image_path is None:
+            image_path = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                "examples",
+                "media",
+                "cat.png",
+            )
+        if not os.path.exists(image_path):
+            fail(f"Multimodal test image not found: {image_path}")
+
+        reserve = None
+        if args.reserve_per_device:
+            reserve = [float(x) for x in args.reserve_per_device.split(",")]
+
+        cache = Cache(model, max_num_tokens = 4096)
+        vision_model.load(device)
+        image_embedding = vision_model.get_image_embeddings(tokenizer, Image.open(image_path).convert("RGB"))
+        prompt_ids = tokenizer.hf_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": "What animal is shown? Answer with one word."},
+                    ],
+                }
+            ],
+            add_generation_prompt = True,
+            enable_thinking = False,
+            embeddings = [image_embedding],
+        )
+        vision_model.unload()
+
+        model.load(reserve_per_device = reserve)
+        generator = Generator(model, cache, tokenizer)
+        job = Job(
+            input_ids = prompt_ids.cpu(),
+            max_new_tokens = 8,
+            stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+            decode_special_tokens = True,
+            embeddings = [image_embedding],
+            sampler = GreedySampler(),
+        )
+        generator.enqueue(job)
+        output_text = ""
+        while generator.num_remaining_jobs():
+            for result in generator.iterate():
+                if result.get("stage") == "streaming":
+                    output_text += result.get("text", "")
+        print("[INFO] multimodal generation:", repr(output_text))
+        if "cat" not in output_text.lower():
+            fail(f"Unexpected multimodal generation output: {output_text!r}")
+        model.unload()
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    print("[PASS] gemma4 smoke checks complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_gemma4_arch.py
+++ b/tests/smoke_gemma4_arch.py
@@ -35,6 +35,7 @@ def main() -> None:
     ap.add_argument("--device", default="cuda:0")
     ap.add_argument("--full_load", action="store_true")
     ap.add_argument("--reserve_per_device", default=None, help="e.g. 0.25,0.25")
+    ap.add_argument("--swa_cache_size", type=int, default=None)
     ap.add_argument("--multimodal_generation", action="store_true")
     ap.add_argument("--multimodal_image", default=None)
     args = ap.parse_args()
@@ -124,7 +125,10 @@ def main() -> None:
         if args.reserve_per_device:
             reserve = [float(x) for x in args.reserve_per_device.split(",")]
 
-        cache = Cache(model, max_num_tokens = 4096)
+        cache_kwargs = {}
+        if args.swa_cache_size is not None:
+            cache_kwargs["swa_max_num_tokens"] = args.swa_cache_size
+        cache = Cache(model, max_num_tokens = 4096, **cache_kwargs)
         vision_model.load(device)
         image_embedding = vision_model.get_image_embeddings(tokenizer, Image.open(image_path).convert("RGB"))
         prompt_ids = tokenizer.hf_chat_template(

--- a/tests/smoke_gemma4_mm.py
+++ b/tests/smoke_gemma4_mm.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Objective multimodal smoke checks for Gemma4 image understanding.
+
+Checks:
+1) Single-image recognition
+2) Ordered two-image reasoning
+3) Duplicate image consistency
+4) Optional quantized KV-cache path using the model-specific cache layer
+"""
+
+import argparse
+import os
+import sys
+
+import torch
+from PIL import Image
+
+from exllamav3 import Cache, Config, Job, Model, Tokenizer
+from exllamav3.generator import Generator
+from exllamav3.generator.sampler import GreedySampler
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def run_prompt(
+    generator: Generator,
+    tokenizer: Tokenizer,
+    embeddings: list,
+    question: str,
+) -> str:
+    prompt_ids = tokenizer.hf_chat_template(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"} for _ in embeddings
+                ] + [{"type": "text", "text": question}],
+            }
+        ],
+        add_generation_prompt = True,
+        enable_thinking = False,
+        embeddings = embeddings,
+    )
+    job = Job(
+        input_ids = prompt_ids.cpu(),
+        max_new_tokens = 16,
+        stop_conditions = [tokenizer.eos_token_id, "<turn|>"],
+        decode_special_tokens = True,
+        embeddings = embeddings,
+        sampler = GreedySampler(),
+    )
+    generator.enqueue(job)
+    output = ""
+    while generator.num_remaining_jobs():
+        for result in generator.iterate():
+            if result.get("stage") == "streaming":
+                output += result.get("text", "")
+    return output
+
+
+def expect_contains(label: str, output: str, expected: list[str]) -> None:
+    n = normalize(output)
+    if not any(e in n for e in expected):
+        fail(f"{label}: expected one of {expected!r}, got {output!r}")
+    print(f"[INFO] {label}: {output!r}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", required=True)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--reserve_per_device", default=None, help="e.g. 0.5,0.5")
+    ap.add_argument("--cache_bits", default=None, help="Either single value or k_bits,v_bits")
+    ap.add_argument("--swa_cache_size", type=int, default=None)
+    ap.add_argument("--cat_image", default=None)
+    ap.add_argument("--fruit_image", default=None)
+    args = ap.parse_args()
+
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this smoke check")
+
+    cat_image = args.cat_image or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "doc",
+        "cat.png",
+    )
+    fruit_image = args.fruit_image or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "examples",
+        "media",
+        "strawberry.png",
+    )
+    for path in [cat_image, fruit_image]:
+        if not os.path.exists(path):
+            fail(f"Required image not found: {path}")
+
+    reserve = None
+    if args.reserve_per_device:
+        reserve = [float(x) for x in args.reserve_per_device.split(",")]
+
+    cfg = Config.from_directory(args.model_dir)
+    model = Model.from_config(cfg)
+    vision_model = Model.from_config(cfg, component="vision")
+    tokenizer = Tokenizer.from_config(cfg)
+
+    cache_kwargs = {}
+    if args.cache_bits is not None:
+        split = [int(bits) for bits in args.cache_bits.split(",")]
+        if len(split) == 1:
+            k_bits = v_bits = split[0]
+        elif len(split) == 2:
+            k_bits, v_bits = split
+        else:
+            fail("--cache_bits must be 'bits' or 'k_bits,v_bits'")
+        cache_kwargs = {
+            "layer_type": model.caps.get("quantized_kv_cache_layer"),
+            "k_bits": k_bits,
+            "v_bits": v_bits,
+        }
+    if args.swa_cache_size is not None:
+        cache_kwargs["swa_max_num_tokens"] = args.swa_cache_size
+    cache = Cache(model, max_num_tokens=1024, **cache_kwargs)
+
+    device = torch.device(args.device)
+    vision_model.load(device)
+    cat = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    cat_dup = vision_model.get_image_embeddings(tokenizer, Image.open(cat_image).convert("RGB"))
+    fruit = vision_model.get_image_embeddings(tokenizer, Image.open(fruit_image).convert("RGB"))
+    vision_model.unload()
+
+    model.load(reserve_per_device=reserve)
+    generator = Generator(model, cache, tokenizer)
+
+    expect_contains(
+        "single cat",
+        run_prompt(generator, tokenizer, [cat], "What animal is shown? Answer with one word."),
+        ["cat"],
+    )
+    expect_contains(
+        "single fruit",
+        run_prompt(generator, tokenizer, [fruit], "What fruit is shown? Answer with one word."),
+        ["strawberry"],
+    )
+
+    pair = [cat, fruit]
+    expect_contains(
+        "animal position",
+        run_prompt(generator, tokenizer, pair, "Which image shows an animal? Answer first or second."),
+        ["first"],
+    )
+    expect_contains(
+        "fruit position",
+        run_prompt(generator, tokenizer, pair, "Which image shows a fruit? Answer first or second."),
+        ["second"],
+    )
+    expect_contains(
+        "first animal yesno",
+        run_prompt(generator, tokenizer, pair, "Does the first image show an animal? Answer yes or no."),
+        ["yes"],
+    )
+    expect_contains(
+        "second fruit yesno",
+        run_prompt(generator, tokenizer, pair, "Does the second image show a fruit? Answer yes or no."),
+        ["yes"],
+    )
+    expect_contains(
+        "same subject no",
+        run_prompt(generator, tokenizer, pair, "Do the two images show the same subject? Answer yes or no."),
+        ["no"],
+    )
+    expect_contains(
+        "duplicate subject yes",
+        run_prompt(
+            generator,
+            tokenizer,
+            [cat, cat_dup],
+            "Do the two images show the same subject? Answer yes or no.",
+        ),
+        ["yes"],
+    )
+
+    model.unload()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    print("[PASS] gemma4 multimodal smoke checks complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gemma4_kv_ext.py
+++ b/tests/test_gemma4_kv_ext.py
@@ -1,0 +1,428 @@
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from exllamav3.constants import PAGE_SIZE
+from exllamav3.ext import exllamav3_ext as ext
+
+
+def _maybe_skip_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Gemma4 KV ext tests")
+
+
+def _manual_gather_from_paged_cache(cache_tensor, total_lens, block_table):
+    bsz = block_table.shape[0]
+    max_total = int(total_lens.max().item())
+    gathered = torch.zeros(
+        (bsz, max_total, cache_tensor.shape[2], cache_tensor.shape[3]),
+        dtype = cache_tensor.dtype,
+        device = cache_tensor.device,
+    )
+    for batch_idx in range(bsz):
+        total = int(total_lens[batch_idx].item())
+        if total == 0:
+            continue
+        positions = torch.arange(total, device = cache_tensor.device, dtype = torch.long)
+        pages = block_table[batch_idx].gather(0, torch.div(positions, PAGE_SIZE, rounding_mode = "floor"))
+        page_pos = positions.remainder(PAGE_SIZE)
+        gathered[batch_idx, :total] = cache_tensor[pages, page_pos]
+    return gathered
+
+
+def _manual_dequant_token_slots(qcache, scales, pages, page_pos, num_kv_heads, head_dim):
+    q_tokens = qcache[pages, page_pos]
+    s_tokens = scales[pages, page_pos]
+    out = torch.empty((q_tokens.shape[0], num_kv_heads * head_dim), dtype = torch.half, device = qcache.device)
+    ext.dequant_cache_cont(q_tokens, s_tokens, out)
+    return out.view(q_tokens.shape[0], num_kv_heads, head_dim)
+
+
+@torch.inference_mode()
+def test_quant_cache_paged_delta_matches_quant_cache_paged():
+    _maybe_skip_cuda()
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    bsz = 2
+    pages = 8
+    num_kv_heads = 2
+    head_dim = 64
+    bits = 4
+    seq_len = 33
+
+    block_table = torch.tensor([[7, 1, 0, 2], [6, 4, 5, 3]], dtype = torch.int, device = device)
+    cache_seqlens = torch.tensor([5, 260], dtype = torch.int, device = device)
+    k_delta = torch.randn((bsz, seq_len, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_delta = torch.randn_like(k_delta)
+
+    qshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32 * bits)
+    sshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32)
+
+    qk_ref = torch.zeros(qshape, dtype = torch.int, device = device)
+    qv_ref = torch.zeros_like(qk_ref)
+    sk_ref = torch.zeros(sshape, dtype = torch.half, device = device)
+    sv_ref = torch.zeros_like(sk_ref)
+
+    qk_delta = torch.zeros_like(qk_ref)
+    qv_delta = torch.zeros_like(qk_ref)
+    sk_delta = torch.zeros_like(sk_ref)
+    sv_delta = torch.zeros_like(sk_ref)
+
+    staged_k = torch.zeros((pages, PAGE_SIZE, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    staged_v = torch.zeros_like(staged_k)
+    positions = (
+        cache_seqlens.to(dtype = torch.long).unsqueeze(1) +
+        torch.arange(seq_len, dtype = torch.long, device = device).unsqueeze(0)
+    )
+    target_pages = block_table.gather(1, torch.div(positions, PAGE_SIZE, rounding_mode = "floor")).reshape(-1)
+    target_pos = positions.remainder(PAGE_SIZE).reshape(-1)
+    staged_k[target_pages, target_pos] = k_delta.reshape(-1, num_kv_heads, head_dim)
+    staged_v[target_pages, target_pos] = v_delta.reshape(-1, num_kv_heads, head_dim)
+
+    full_block_table = torch.arange(pages, dtype = torch.int, device = device).view(1, pages)
+    full_cache_start = torch.zeros((1,), dtype = torch.int, device = device)
+    full_seq_len = pages * PAGE_SIZE
+    ext.quant_cache_paged(
+        staged_k, qk_ref, sk_ref,
+        staged_v, qv_ref, sv_ref,
+        full_cache_start, full_block_table,
+        PAGE_SIZE, full_seq_len,
+    )
+    ext.quant_cache_paged_delta(
+        k_delta, qk_delta, sk_delta,
+        v_delta, qv_delta, sv_delta,
+        cache_seqlens, block_table,
+        PAGE_SIZE, seq_len,
+    )
+
+    ref_k_tokens = _manual_dequant_token_slots(qk_ref, sk_ref, target_pages, target_pos, num_kv_heads, head_dim)
+    ref_v_tokens = _manual_dequant_token_slots(qv_ref, sv_ref, target_pages, target_pos, num_kv_heads, head_dim)
+    delta_k_tokens = _manual_dequant_token_slots(qk_delta, sk_delta, target_pages, target_pos, num_kv_heads, head_dim)
+    delta_v_tokens = _manual_dequant_token_slots(qv_delta, sv_delta, target_pages, target_pos, num_kv_heads, head_dim)
+
+    torch.testing.assert_close(delta_k_tokens, ref_k_tokens, atol = 0.08, rtol = 0.01)
+    torch.testing.assert_close(delta_v_tokens, ref_v_tokens, atol = 0.08, rtol = 0.01)
+
+
+@torch.inference_mode()
+def test_dequant_cache_paged_gather_matches_reference_gather():
+    _maybe_skip_cuda()
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    bsz = 2
+    pages = 8
+    num_kv_heads = 2
+    head_dim = 64
+    bits = 4
+    total_lens = torch.tensor([270, 37], dtype = torch.int, device = device)
+    max_total = int(total_lens.max().item())
+
+    block_table = torch.tensor([[7, 1, 0, 2], [6, 4, 5, 3]], dtype = torch.int, device = device)
+    cache_start = torch.zeros((bsz,), dtype = torch.int, device = device)
+    k_full = torch.randn((bsz, max_total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_full = torch.randn_like(k_full)
+
+    qshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32 * bits)
+    sshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32)
+    qk = torch.zeros(qshape, dtype = torch.int, device = device)
+    qv = torch.zeros_like(qk)
+    sk = torch.zeros(sshape, dtype = torch.half, device = device)
+    sv = torch.zeros_like(sk)
+
+    ext.quant_cache_paged(
+        k_full, qk, sk,
+        v_full, qv, sv,
+        cache_start, block_table,
+        PAGE_SIZE, max_total,
+    )
+
+    gathered_k = torch.zeros((bsz, max_total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    gathered_v = torch.zeros_like(gathered_k)
+    ext.dequant_cache_paged_gather(
+        qk, sk, gathered_k,
+        qv, sv, gathered_v,
+        total_lens, block_table,
+        PAGE_SIZE, max_total,
+    )
+
+    for batch_idx in range(bsz):
+        total = int(total_lens[batch_idx].item())
+        positions = torch.arange(total, device = device, dtype = torch.long)
+        pages_for_batch = block_table[batch_idx].gather(0, torch.div(positions, PAGE_SIZE, rounding_mode = "floor"))
+        pos_for_batch = positions.remainder(PAGE_SIZE)
+        ref_k = _manual_dequant_token_slots(qk, sk, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        ref_v = _manual_dequant_token_slots(qv, sv, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        torch.testing.assert_close(gathered_k[batch_idx, :total], ref_k, atol = 0.08, rtol = 0.01)
+        torch.testing.assert_close(gathered_v[batch_idx, :total], ref_v, atol = 0.08, rtol = 0.01)
+
+
+@torch.inference_mode()
+def test_dequant_cache_paged_gather_delta_matches_reference_append():
+    _maybe_skip_cuda()
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    bsz = 2
+    pages = 8
+    num_kv_heads = 2
+    head_dim = 64
+    bits = 4
+    cache_seqlens = torch.tensor([270, 37], dtype = torch.int, device = device)
+    delta_len = 5
+    total_lens = cache_seqlens + delta_len
+    max_total = int(total_lens.max().item())
+
+    block_table = torch.tensor([[7, 1, 0, 2], [6, 4, 5, 3]], dtype = torch.int, device = device)
+    cache_start = torch.zeros((bsz,), dtype = torch.int, device = device)
+    k_full = torch.randn((bsz, max_total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_full = torch.randn_like(k_full)
+    k_delta = torch.randn((bsz, delta_len, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_delta = torch.randn_like(k_delta)
+
+    qshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32 * bits)
+    sshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32)
+    qk = torch.zeros(qshape, dtype = torch.int, device = device)
+    qv = torch.zeros_like(qk)
+    sk = torch.zeros(sshape, dtype = torch.half, device = device)
+    sv = torch.zeros_like(sk)
+
+    ext.quant_cache_paged(
+        k_full, qk, sk,
+        v_full, qv, sv,
+        cache_start, block_table,
+        PAGE_SIZE, max_total,
+    )
+
+    gathered_k = torch.zeros((bsz, max_total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    gathered_v = torch.zeros_like(gathered_k)
+    ext.dequant_cache_paged_gather_delta(
+        qk, sk, k_delta, gathered_k,
+        qv, sv, v_delta, gathered_v,
+        cache_seqlens, block_table,
+        PAGE_SIZE, max_total, delta_len,
+    )
+
+    for batch_idx in range(bsz):
+        cache_total = int(cache_seqlens[batch_idx].item())
+        total = int(total_lens[batch_idx].item())
+        positions = torch.arange(cache_total, device = device, dtype = torch.long)
+        pages_for_batch = block_table[batch_idx].gather(0, torch.div(positions, PAGE_SIZE, rounding_mode = "floor"))
+        pos_for_batch = positions.remainder(PAGE_SIZE)
+        ref_k = _manual_dequant_token_slots(qk, sk, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        ref_v = _manual_dequant_token_slots(qv, sv, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        expected_k = torch.zeros((total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+        expected_v = torch.zeros_like(expected_k)
+        expected_k[:cache_total] = ref_k
+        expected_v[:cache_total] = ref_v
+        expected_k[cache_total:total] = k_delta[batch_idx]
+        expected_v[cache_total:total] = v_delta[batch_idx]
+        torch.testing.assert_close(gathered_k[batch_idx, :total], expected_k, atol = 0.08, rtol = 0.01)
+        torch.testing.assert_close(gathered_v[batch_idx, :total], expected_v, atol = 0.08, rtol = 0.01)
+
+
+@torch.inference_mode()
+def test_dequant_cache_paged_gather_heads_matches_reference_gather():
+    _maybe_skip_cuda()
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    bsz = 2
+    pages = 8
+    num_kv_heads = 2
+    head_dim = 64
+    bits = 4
+    total_lens = torch.tensor([270, 37], dtype = torch.int, device = device)
+    max_total = int(total_lens.max().item())
+
+    block_table = torch.tensor([[7, 1, 0, 2], [6, 4, 5, 3]], dtype = torch.int, device = device)
+    cache_start = torch.zeros((bsz,), dtype = torch.int, device = device)
+    k_full = torch.randn((bsz, max_total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_full = torch.randn_like(k_full)
+
+    qshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32 * bits)
+    sshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32)
+    qk = torch.zeros(qshape, dtype = torch.int, device = device)
+    qv = torch.zeros_like(qk)
+    sk = torch.zeros(sshape, dtype = torch.half, device = device)
+    sv = torch.zeros_like(sk)
+
+    ext.quant_cache_paged(
+        k_full, qk, sk,
+        v_full, qv, sv,
+        cache_start, block_table,
+        PAGE_SIZE, max_total,
+    )
+
+    gathered_k = torch.zeros((bsz, num_kv_heads, max_total, head_dim), dtype = torch.half, device = device)
+    gathered_v = torch.zeros_like(gathered_k)
+    ext.dequant_cache_paged_gather_heads(
+        qk, sk, gathered_k,
+        qv, sv, gathered_v,
+        total_lens, block_table,
+        PAGE_SIZE, max_total,
+    )
+
+    for batch_idx in range(bsz):
+        total = int(total_lens[batch_idx].item())
+        positions = torch.arange(total, device = device, dtype = torch.long)
+        pages_for_batch = block_table[batch_idx].gather(0, torch.div(positions, PAGE_SIZE, rounding_mode = "floor"))
+        pos_for_batch = positions.remainder(PAGE_SIZE)
+        ref_k = _manual_dequant_token_slots(qk, sk, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        ref_v = _manual_dequant_token_slots(qv, sv, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        torch.testing.assert_close(gathered_k[batch_idx, :, :total].transpose(0, 1), ref_k, atol = 0.08, rtol = 0.01)
+        torch.testing.assert_close(gathered_v[batch_idx, :, :total].transpose(0, 1), ref_v, atol = 0.08, rtol = 0.01)
+
+
+@torch.inference_mode()
+def test_dequant_cache_paged_gather_delta_heads_matches_reference_append():
+    _maybe_skip_cuda()
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    bsz = 2
+    pages = 8
+    num_kv_heads = 2
+    head_dim = 64
+    bits = 4
+    cache_seqlens = torch.tensor([270, 37], dtype = torch.int, device = device)
+    delta_len = 5
+    total_lens = cache_seqlens + delta_len
+    max_total = int(total_lens.max().item())
+
+    block_table = torch.tensor([[7, 1, 0, 2], [6, 4, 5, 3]], dtype = torch.int, device = device)
+    cache_start = torch.zeros((bsz,), dtype = torch.int, device = device)
+    k_full = torch.randn((bsz, max_total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_full = torch.randn_like(k_full)
+    k_delta = torch.randn((bsz, delta_len, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_delta = torch.randn_like(k_delta)
+
+    qshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32 * bits)
+    sshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32)
+    qk = torch.zeros(qshape, dtype = torch.int, device = device)
+    qv = torch.zeros_like(qk)
+    sk = torch.zeros(sshape, dtype = torch.half, device = device)
+    sv = torch.zeros_like(sk)
+
+    ext.quant_cache_paged(
+        k_full, qk, sk,
+        v_full, qv, sv,
+        cache_start, block_table,
+        PAGE_SIZE, max_total,
+    )
+
+    gathered_k = torch.zeros((bsz, num_kv_heads, max_total, head_dim), dtype = torch.half, device = device)
+    gathered_v = torch.zeros_like(gathered_k)
+    ext.dequant_cache_paged_gather_delta_heads(
+        qk, sk, k_delta, gathered_k,
+        qv, sv, v_delta, gathered_v,
+        cache_seqlens, block_table,
+        PAGE_SIZE, max_total, delta_len,
+    )
+
+    for batch_idx in range(bsz):
+        cache_total = int(cache_seqlens[batch_idx].item())
+        total = int(total_lens[batch_idx].item())
+        positions = torch.arange(cache_total, device = device, dtype = torch.long)
+        pages_for_batch = block_table[batch_idx].gather(0, torch.div(positions, PAGE_SIZE, rounding_mode = "floor"))
+        pos_for_batch = positions.remainder(PAGE_SIZE)
+        ref_k = _manual_dequant_token_slots(qk, sk, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        ref_v = _manual_dequant_token_slots(qv, sv, pages_for_batch, pos_for_batch, num_kv_heads, head_dim)
+        expected_k = torch.zeros((num_kv_heads, total, head_dim), dtype = torch.half, device = device)
+        expected_v = torch.zeros_like(expected_k)
+        expected_k[:, :cache_total] = ref_k.transpose(0, 1)
+        expected_v[:, :cache_total] = ref_v.transpose(0, 1)
+        expected_k[:, cache_total:total] = k_delta[batch_idx].transpose(0, 1)
+        expected_v[:, cache_total:total] = v_delta[batch_idx].transpose(0, 1)
+        torch.testing.assert_close(gathered_k[batch_idx, :, :total], expected_k, atol = 0.08, rtol = 0.01)
+        torch.testing.assert_close(gathered_v[batch_idx, :, :total], expected_v, atol = 0.08, rtol = 0.01)
+
+
+@torch.inference_mode()
+def test_dequant_cache_paged_select_delta_heads_matches_selected_reference():
+    _maybe_skip_cuda()
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    bsz = 2
+    pages = 8
+    num_kv_heads = 2
+    head_dim = 64
+    bits = 4
+    cache_seqlens = torch.tensor([270, 37], dtype = torch.int, device = device)
+    delta_len = 5
+    total_lens = cache_seqlens + delta_len
+    selected_positions = torch.tensor([[1, 269, 270, 274], [0, 10, 39, 41]], dtype = torch.int, device = device)
+    selected_counts = torch.tensor([4, 3], dtype = torch.int, device = device)
+    max_selected = selected_positions.size(1)
+    max_total = int(total_lens.max().item())
+
+    block_table = torch.tensor([[7, 1, 0, 2], [6, 4, 5, 3]], dtype = torch.int, device = device)
+    cache_start = torch.zeros((bsz,), dtype = torch.int, device = device)
+    k_full = torch.randn((bsz, max_total, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_full = torch.randn_like(k_full)
+    k_delta = torch.randn((bsz, delta_len, num_kv_heads, head_dim), dtype = torch.half, device = device)
+    v_delta = torch.randn_like(k_delta)
+
+    qshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32 * bits)
+    sshape = (pages, PAGE_SIZE, num_kv_heads * head_dim // 32)
+    qk = torch.zeros(qshape, dtype = torch.int, device = device)
+    qv = torch.zeros_like(qk)
+    sk = torch.zeros(sshape, dtype = torch.half, device = device)
+    sv = torch.zeros_like(sk)
+
+    ext.quant_cache_paged(
+        k_full, qk, sk,
+        v_full, qv, sv,
+        cache_start, block_table,
+        PAGE_SIZE, max_total,
+    )
+
+    gathered_k = torch.zeros((bsz, num_kv_heads, max_selected, head_dim), dtype = torch.half, device = device)
+    gathered_v = torch.zeros_like(gathered_k)
+    ext.dequant_cache_paged_select_delta_heads(
+        qk, sk, k_delta, gathered_k,
+        qv, sv, v_delta, gathered_v,
+        cache_seqlens, block_table,
+        selected_positions, selected_counts,
+        PAGE_SIZE, max_selected, delta_len,
+    )
+
+    for batch_idx in range(bsz):
+        total = int(selected_counts[batch_idx].item())
+        expected_k = torch.zeros((num_kv_heads, total, head_dim), dtype = torch.half, device = device)
+        expected_v = torch.zeros_like(expected_k)
+        cache_total = int(cache_seqlens[batch_idx].item())
+        for i, pos in enumerate(selected_positions[batch_idx, :total].tolist()):
+            if pos < cache_total:
+                page = int(block_table[batch_idx, pos // PAGE_SIZE].item())
+                page_pos = pos % PAGE_SIZE
+                token_k = _manual_dequant_token_slots(
+                    qk,
+                    sk,
+                    torch.tensor([page], dtype = torch.long, device = device),
+                    torch.tensor([page_pos], dtype = torch.long, device = device),
+                    num_kv_heads,
+                    head_dim,
+                )[0]
+                token_v = _manual_dequant_token_slots(
+                    qv,
+                    sv,
+                    torch.tensor([page], dtype = torch.long, device = device),
+                    torch.tensor([page_pos], dtype = torch.long, device = device),
+                    num_kv_heads,
+                    head_dim,
+                )[0]
+                expected_k[:, i] = token_k
+                expected_v[:, i] = token_v
+            else:
+                expected_k[:, i] = k_delta[batch_idx, pos - cache_total]
+                expected_v[:, i] = v_delta[batch_idx, pos - cache_total]
+
+        torch.testing.assert_close(gathered_k[batch_idx, :, :total], expected_k, atol = 0.08, rtol = 0.01)
+        torch.testing.assert_close(gathered_v[batch_idx, :, :total], expected_v, atol = 0.08, rtol = 0.01)

--- a/tests/test_gemma4_turboquant.py
+++ b/tests/test_gemma4_turboquant.py
@@ -1,0 +1,1439 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from exllamav3.cache.cache import Cache
+from exllamav3.cache.fp16 import CacheLayer_fp16
+from exllamav3.cache.gemma4 import (
+    Gemma4FullCacheLayer,
+    Gemma4FullQuantCacheLayer,
+    Gemma4QuantCacheLayer,
+    Gemma4SingleQuantCacheLayer,
+    Gemma4SWAQuantCacheLayer,
+    select_gemma4_cache_layer,
+)
+from exllamav3.cache.quant import CacheLayer_quant
+from exllamav3.constants import PAGE_SIZE
+from exllamav3.generator.gemma4_pagetable import Gemma4PageTable
+from exllamav3.generator.job import Job
+from exllamav3.generator.pagetable import PageTable, Sequence, tensor_hash_checksum
+from exllamav3.architecture.gemma4 import (
+    _filter_gemma4_indexed_embeddings,
+    _update_gemma4_reconstruct_mode,
+)
+from exllamav3.modules.gemma4 import Gemma4Attention, Gemma4TransformerBlock
+from exllamav3.tokenizer.mm_embedding import FIRST_MM_EMBEDDING_INDEX
+
+
+class _FakeAttention:
+
+    def __init__(self, layer_idx: int, sliding_window: int = 1024):
+        self.layer_idx = layer_idx
+        self.sliding_window = sliding_window
+
+
+class _DummyLayer:
+
+    def __init__(self, role: str):
+        self.cache_role = role
+        self.calls = []
+
+    def copy_page(self, source, from_page: int, to_page: int, num_tokens: int):
+        self.calls.append((getattr(source, "cache_role", "default"), from_page, to_page, num_tokens))
+
+
+class _NoCopyPlanPageTable(PageTable):
+
+    def build_cache_copy_plan(self, source_page, target_page, num_tokens, seq = None):
+        return None
+
+
+def _make_gemma4_pagetable(
+    *,
+    sliding_window: int = 256,
+    max_chunk_size: int = 4,
+    num_draft_tokens: int = 0,
+    full_max_num_tokens: int = 1024,
+    swa_max_num_tokens: int = 768,
+    profile: str = "generic",
+):
+    model = SimpleNamespace(
+        config = SimpleNamespace(sliding_window = sliding_window),
+        caps = {"gemma4_profile": profile},
+    )
+    generator = SimpleNamespace(
+        model = model,
+        max_chunk_size = max_chunk_size,
+        num_draft_tokens = num_draft_tokens,
+    )
+    cache = SimpleNamespace(
+        model = SimpleNamespace(loaded_tp = False),
+        max_num_tokens = full_max_num_tokens,
+        layers = {
+            0: SimpleNamespace(cache_role = "full", max_num_tokens = full_max_num_tokens),
+            1: SimpleNamespace(cache_role = "swa", max_num_tokens = swa_max_num_tokens),
+        },
+    )
+    return Gemma4PageTable(generator, cache)
+
+
+def _set_seq_pages(pagetable: Gemma4PageTable, seq: Sequence, pages, role: str) -> None:
+    pagetable._set_seq_allocated_pages(seq, pages, role = role)
+
+
+def _get_seq_pages(pagetable: Gemma4PageTable, seq: Sequence, role: str):
+    return pagetable._get_seq_allocated_pages(seq, role = role)
+
+
+def _set_seq_backing_pages(pagetable: Gemma4PageTable, seq: Sequence, pages, role: str) -> None:
+    pagetable._set_seq_backing_pages(seq, pages, role = role)
+
+
+def _get_seq_backing_pages(pagetable: Gemma4PageTable, seq: Sequence, role: str):
+    return pagetable._get_seq_backing_pages(seq, role = role)
+
+
+def _set_seq_kv(pagetable: Gemma4PageTable, seq: Sequence, kv_position: int, role: str) -> None:
+    pagetable._set_seq_kv_position(seq, kv_position, role = role)
+
+
+def _get_seq_page_map(pagetable: Gemma4PageTable, seq: Sequence, role: str):
+    return pagetable._get_seq_page_map(seq, role = role)
+
+
+def _build_mm_mask_reference(
+    *,
+    sliding_window: int,
+    bsz: int,
+    seqlen: int,
+    total_lens: torch.Tensor,
+    cache_seqlens: torch.Tensor | None,
+    vision_group_ids: torch.Tensor | None,
+    q_dtype: torch.dtype,
+    device: torch.device,
+    causal: bool,
+) -> torch.Tensor:
+    max_total = int(total_lens.max())
+    mask = torch.full(
+        (bsz, 1, seqlen, max_total),
+        torch.finfo(q_dtype).min,
+        dtype = q_dtype,
+        device = device,
+    )
+    for b in range(bsz):
+        total = int(total_lens[b])
+        if total == 0:
+            continue
+        past = int(cache_seqlens[b]) if cache_seqlens is not None else 0
+        full_groups = None
+        if vision_group_ids is not None:
+            full_groups = torch.full((total,), -1, dtype = torch.int32, device = device)
+            full_groups[past : past + seqlen] = vision_group_ids[b]
+        for qi in range(seqlen):
+            q_abs = past + qi
+            if not causal:
+                start = 0 if sliding_window < 0 else max(0, q_abs - sliding_window)
+                end = total if sliding_window < 0 else min(total, q_abs + sliding_window + 1)
+                mask[b, 0, qi, start:end] = 0
+            else:
+                end = min(total, q_abs + 1)
+                start = 0 if sliding_window < 0 else max(0, q_abs - sliding_window)
+                if end > start:
+                    mask[b, 0, qi, start:end] = 0
+                if full_groups is not None:
+                    q_group = int(full_groups[q_abs])
+                    if q_group >= 0:
+                        same_group = full_groups[:total] == q_group
+                        mask[b, 0, qi, :total][same_group] = 0
+    return mask
+
+
+def test_select_gemma4_cache_layer_quant_respects_roles_and_normalizes_tokens():
+    layer_types = ["full_attention", "sliding_attention"]
+
+    full_selected = select_gemma4_cache_layer(
+        CacheLayer_quant,
+        _FakeAttention(0),
+        layer_types,
+        cache_kwargs = {
+            "max_num_tokens": 1024,
+            "full_max_num_tokens": 4096,
+            "swa_max_num_tokens": 1537,
+            "sentinel": "keep",
+        },
+    )
+    assert full_selected["layer_type"] is Gemma4FullQuantCacheLayer
+    assert full_selected["max_num_tokens"] == 1024
+    assert full_selected["cache_kwargs"] == {"sentinel": "keep"}
+
+    swa_selected = select_gemma4_cache_layer(
+        CacheLayer_quant,
+        _FakeAttention(1),
+        layer_types,
+        cache_kwargs = {
+            "max_num_tokens": 4096,
+            "swa_max_num_tokens": 1537,
+            "sentinel": "keep",
+        },
+    )
+    assert swa_selected["layer_type"] is Gemma4SWAQuantCacheLayer
+    assert swa_selected["max_num_tokens"] == 1536
+    assert swa_selected["cache_kwargs"] == {"sentinel": "keep"}
+
+    tiny_swa = select_gemma4_cache_layer(
+        CacheLayer_quant,
+        _FakeAttention(1),
+        layer_types,
+        cache_kwargs = {
+            "max_num_tokens": 4096,
+            "swa_max_num_tokens": 128,
+        },
+    )
+    assert tiny_swa["max_num_tokens"] == 256
+
+    page_aligned_swa = select_gemma4_cache_layer(
+        CacheLayer_quant,
+        _FakeAttention(1),
+        layer_types,
+        cache_kwargs = {
+            "max_num_tokens": 4096,
+            "swa_max_num_tokens": 896,
+        },
+    )
+    assert page_aligned_swa["max_num_tokens"] == 768
+
+    full_fp16 = select_gemma4_cache_layer(
+        CacheLayer_fp16,
+        _FakeAttention(0),
+        layer_types,
+        cache_kwargs = {"max_num_tokens": 1024},
+    )
+    assert full_fp16["layer_type"] is Gemma4FullCacheLayer
+
+
+def test_select_gemma4_cache_layer_applies_auto_swa_default_only_when_unspecified():
+    layer_types = ["full_attention", "sliding_attention"]
+
+    auto_swa = select_gemma4_cache_layer(
+        CacheLayer_quant,
+        _FakeAttention(1),
+        layer_types,
+        cache_kwargs = {
+            "max_num_tokens": 4096,
+        },
+    )
+    assert auto_swa["layer_type"] is Gemma4SWAQuantCacheLayer
+    assert auto_swa["max_num_tokens"] == 1280
+
+    explicit_swa = select_gemma4_cache_layer(
+        CacheLayer_quant,
+        _FakeAttention(1),
+        layer_types,
+        cache_kwargs = {
+            "max_num_tokens": 4096,
+            "swa_max_num_tokens": 1537,
+        },
+    )
+    assert explicit_swa["max_num_tokens"] == 1536
+
+
+def test_gemma4_pagetable_reports_min_safe_swa_window_and_atomic_prefill_guard():
+    pagetable = _make_gemma4_pagetable(swa_max_num_tokens = 512)
+    assert pagetable.get_min_swa_capacity_tokens() == 516
+    assert pagetable.get_min_swa_capacity_pages() == 3
+
+    seq_len = 600
+    ids = torch.arange(seq_len, dtype = torch.long).unsqueeze(0)
+    seq = Sequence(ids, ids.clone())
+    _set_seq_pages(pagetable, seq, pagetable.swa_arena.all_pages[:2], role = "swa")
+    _set_seq_kv(pagetable, seq, 0, role = "swa")
+
+    embedding = SimpleNamespace(first_index = 0, last_index = 516)
+    with pytest.raises(ValueError, match = "next page-aligned safe size 768"):
+        pagetable.clamp_prefill_end(
+            seq,
+            0,
+            seq_len,
+            embeddings = [embedding],
+            atomic_mm_prefill = True,
+        )
+
+
+def test_gemma4_pagetable_builds_role_aware_copy_plan_from_cached_and_active_pages():
+    pagetable = _make_gemma4_pagetable()
+    source_full = pagetable.full_arena.all_pages[0]
+    target_full = pagetable.full_arena.all_pages[1]
+    source_swa = pagetable.swa_arena.all_pages[0]
+    target_swa = pagetable.swa_arena.all_pages[1]
+
+    pagetable.cached_full_to_swa_pages[pagetable._cached_full_page_key(source_full)] = source_swa
+    pagetable.active_full_to_swa_pages[id(target_full)] = target_swa
+
+    plan = pagetable.build_cache_copy_plan(source_full, target_full, 17)
+    assert plan == {
+        "full": (source_full.page_index, target_full.page_index),
+        "swa": (source_swa.page_index, target_swa.page_index),
+    }
+
+
+def test_gemma4_pagetable_cached_swa_lookup_tracks_full_page_hash():
+    pagetable = _make_gemma4_pagetable()
+    source_full = pagetable.full_arena.all_pages[0]
+    target_full = pagetable.full_arena.all_pages[1]
+    source_swa = pagetable.swa_arena.all_pages[0]
+    target_swa = pagetable.swa_arena.all_pages[1]
+
+    pagetable.cached_full_to_swa_pages[pagetable._cached_full_page_key(source_full)] = source_swa
+    pagetable.active_full_to_swa_pages[id(target_full)] = target_swa
+
+    source_full.phash = b"\xff" * 16
+
+    assert pagetable.build_cache_copy_plan(source_full, target_full, 17) is None
+
+
+def test_gemma4_pagetable_does_not_reuse_full_prefix_without_cached_swa_source():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    ids = torch.arange(0, 288, dtype = torch.long).unsqueeze(0)
+
+    seq_1 = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq_1, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq_1, None)
+    seq_1.kv_position = ids.shape[-1] - 1
+    _set_seq_kv(pagetable, seq_1, seq_1.kv_position, role = "full")
+    _get_seq_pages(pagetable, seq_1, "full")[0].kv_position = PAGE_SIZE
+    _get_seq_pages(pagetable, seq_1, "full")[1].kv_position = 31
+    _get_seq_pages(pagetable, seq_1, "full")[1].prev_hash = _get_seq_pages(pagetable, seq_1, "full")[0].phash
+    _get_seq_pages(pagetable, seq_1, "full")[1].sequence[:, :31].copy_(ids[:, PAGE_SIZE : PAGE_SIZE + 31])
+    _get_seq_backing_pages(pagetable, seq_1, "swa")[0].kv_position = 256
+    _get_seq_backing_pages(pagetable, seq_1, "swa")[1].kv_position = 31
+    _get_seq_backing_pages(pagetable, seq_1, "swa")[1].prev_hash = _get_seq_backing_pages(pagetable, seq_1, "swa")[0].phash
+    pagetable.sync_sequence_views(seq_1)
+    pagetable.deallocate_sequence(seq_1)
+
+    seq_2 = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq_2, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq_2, None)
+
+    assert seq_2.kv_position == 0
+
+
+def test_gemma4_pagetable_does_not_reuse_later_pages_after_prefix_miss():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    reusable_page = pagetable.full_arena.all_pages[1]
+    reusable_page.add_ref_clear(pagetable.full_arena.access_serial + 1, b"b" * 16)
+    reusable_page.kv_position = PAGE_SIZE
+
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    pagetable.cached_full_to_swa_pages[pagetable._cached_full_page_key(reusable_page)] = cached_swa
+
+    allocated_pages, kv_position, cached_pages, _ = pagetable.allocate_pages(
+        [b"a" * 16, b"b" * 16],
+        0,
+        None,
+    )
+
+    assert kv_position == 0
+    assert cached_pages == 0
+    assert allocated_pages[1] is not reusable_page
+    assert allocated_pages[1].kv_position == 0
+
+
+def test_gemma4_pagetable_evicted_cached_swa_snapshot_does_not_block_admission():
+    pagetable = _make_gemma4_pagetable()
+    source_full = pagetable.full_arena.all_pages[0]
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    pagetable.cached_full_to_swa_pages[pagetable._cached_full_page_key(source_full)] = cached_swa
+
+    seq = SimpleNamespace(page_hashes = [b"a", b"b", b"c"], new_unique_pages = 0)
+    job = SimpleNamespace(sequences = [seq], all_unique_hashes = set(), max_skips = 0)
+
+    assert len(pagetable.swa_arena.unreferenced_pages) == 2
+    assert pagetable.can_admit_job(job, 0, 8) is True
+    assert len(pagetable.cached_full_to_swa_pages) == 0
+    assert len(pagetable.swa_arena.unreferenced_pages) == 3
+
+
+def test_gemma4_pagetable_restores_cached_swa_prefix_for_reused_full_pages():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 1024)
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 1024
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    ids = torch.arange(0, 288, dtype = torch.long).unsqueeze(0)
+
+    seq_1 = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq_1, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq_1, None)
+    seq_1.kv_position = ids.shape[-1] - 1
+    _set_seq_kv(pagetable, seq_1, seq_1.kv_position, role = "full")
+    _get_seq_pages(pagetable, seq_1, "full")[0].kv_position = PAGE_SIZE
+    _get_seq_pages(pagetable, seq_1, "full")[1].kv_position = 31
+    _get_seq_pages(pagetable, seq_1, "full")[1].prev_hash = _get_seq_pages(pagetable, seq_1, "full")[0].phash
+    _get_seq_pages(pagetable, seq_1, "full")[1].sequence[:, :31].copy_(ids[:, PAGE_SIZE : PAGE_SIZE + 31])
+    _get_seq_backing_pages(pagetable, seq_1, "swa")[0].kv_position = 256
+    _get_seq_backing_pages(pagetable, seq_1, "swa")[1].kv_position = 31
+    _get_seq_backing_pages(pagetable, seq_1, "swa")[1].prev_hash = _get_seq_backing_pages(pagetable, seq_1, "swa")[0].phash
+    pagetable.sync_sequence_views(seq_1)
+
+    prompt_full_page = _get_seq_pages(pagetable, seq_1, "full")[0]
+    prompt_terminal_page = _get_seq_pages(pagetable, seq_1, "full")[1]
+    pagetable.cache_prefill_copy_source(seq_1)
+    cached_source_page = pagetable.cached_full_to_swa_pages[pagetable._cached_full_page_key(prompt_full_page)]
+    partial_key = pagetable._cached_partial_page_key(
+        prompt_terminal_page.prev_hash,
+        ids[:, PAGE_SIZE : PAGE_SIZE + 31],
+    )
+    assert pagetable.cached_partial_to_swa_pages[partial_key].kv_position == 31
+    pagetable.deallocate_sequence(seq_1)
+
+    seq_2 = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq_2, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq_2, None)
+
+    restored_page = _get_seq_backing_pages(pagetable, seq_2, "swa")[0]
+    assert restored_page is not cached_source_page
+    assert restored_page.kv_position == PAGE_SIZE
+    assert seq_2.kv_position == PAGE_SIZE
+    assert swa_layer.calls[0] == ("swa", 0, cached_source_page.page_index, PAGE_SIZE)
+    assert swa_layer.calls[-1] == ("swa", cached_source_page.page_index, restored_page.page_index, PAGE_SIZE)
+
+
+def test_gemma4_pagetable_keeps_prefill_terminal_snapshot_on_deallocate():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 768
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    ids = torch.arange(0, 64, dtype = torch.long).unsqueeze(0)
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+    seq.kv_position = ids.shape[-1] - 1
+    _set_seq_kv(pagetable, seq, seq.kv_position, role = "full")
+    _get_seq_pages(pagetable, seq, "full")[0].kv_position = 63
+    _get_seq_backing_pages(pagetable, seq, "swa")[0].kv_position = 63
+    pagetable.sync_sequence_views(seq)
+
+    prompt_terminal_page = _get_seq_pages(pagetable, seq, "full")[0]
+    active_terminal_swa = _get_seq_page_map(pagetable, seq, "swa")[id(prompt_terminal_page)]
+    pagetable.cache_prefill_copy_source(seq)
+    partial_key = pagetable._cached_partial_page_key(None, ids[:, :63])
+    snapshot_page = pagetable.cached_partial_to_swa_pages[partial_key]
+    assert snapshot_page is not active_terminal_swa
+
+    pagetable.deallocate_sequence(seq)
+
+    assert pagetable.cached_partial_to_swa_pages[partial_key] is snapshot_page
+
+
+def test_gemma4_pagetable_cached_full_snapshot_stays_pinned_after_capture():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 1024)
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 1024
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    ids = torch.arange(0, 288, dtype = torch.long).unsqueeze(0)
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+    seq.kv_position = ids.shape[-1] - 1
+    _set_seq_kv(pagetable, seq, seq.kv_position, role = "full")
+    _get_seq_pages(pagetable, seq, "full")[0].kv_position = PAGE_SIZE
+    _get_seq_pages(pagetable, seq, "full")[1].kv_position = 31
+    _get_seq_backing_pages(pagetable, seq, "swa")[0].kv_position = PAGE_SIZE
+    _get_seq_backing_pages(pagetable, seq, "swa")[1].kv_position = 31
+    pagetable.sync_sequence_views(seq)
+
+    prompt_full_page = _get_seq_pages(pagetable, seq, "full")[0]
+    pagetable.cache_prefill_copy_source(seq)
+
+    snapshot_page = pagetable.cached_full_to_swa_pages[pagetable._cached_full_page_key(prompt_full_page)]
+    assert snapshot_page.ref_count == 1
+    assert snapshot_page.phash in pagetable.swa_arena.referenced_pages
+
+
+def test_gemma4_pagetable_cached_partial_snapshot_stays_pinned_after_capture():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 768
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    ids = torch.arange(0, 64, dtype = torch.long).unsqueeze(0)
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+    seq.kv_position = ids.shape[-1] - 1
+    _set_seq_kv(pagetable, seq, seq.kv_position, role = "full")
+    _get_seq_pages(pagetable, seq, "full")[0].kv_position = 63
+    _get_seq_backing_pages(pagetable, seq, "swa")[0].kv_position = 63
+    pagetable.sync_sequence_views(seq)
+
+    pagetable.cache_prefill_copy_source(seq)
+    partial_key = pagetable._cached_partial_page_key(None, ids[:, :63])
+    snapshot_page = pagetable.cached_partial_to_swa_pages[partial_key]
+    assert snapshot_page.ref_count == 1
+    assert snapshot_page.phash in pagetable.swa_arena.referenced_pages
+
+
+def test_gemma4_pagetable_clears_fresh_full_and_swa_page_sequences():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    full_page = pagetable.full_arena.all_pages[0]
+    full_page.sequence.fill_(123)
+
+    swa_page = pagetable.swa_arena.all_pages[0]
+    swa_page.sequence.fill_(456)
+
+    allocated_full, _, _, _ = pagetable.allocate_pages([b"a" * 16], 0, None)
+    allocated_swa, _, _, _ = pagetable.allocate_pages([], 1, None, role = "swa")
+
+    assert allocated_full[0] is full_page
+    assert torch.count_nonzero(full_page.sequence) == 0
+    assert allocated_swa[0] is swa_page
+    assert torch.count_nonzero(swa_page.sequence) == 0
+
+
+def test_gemma4_pagetable_prefers_low_full_pages_for_fresh_prefill():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    for page in pagetable.full_arena.all_pages:
+        page.access_serial = 100 + page.page_index
+    for idx in range(5, pagetable.full_arena.max_pages):
+        pagetable.full_arena.all_pages[idx].access_serial = idx - 5
+    pagetable.full_arena.access_serial = 1000
+    pagetable.full_arena.last_defrag_serial = 1000
+
+    allocated_pages, kv_position, cached_pages, _ = pagetable.allocate_pages([], 2, None)
+
+    assert [page.page_index for page in allocated_pages] == [0, 1]
+    assert kv_position == 0
+    assert cached_pages == 0
+
+
+def test_gemma4_pagetable_prefers_low_full_pages_after_first_prefix_miss():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    for page in pagetable.full_arena.all_pages:
+        page.access_serial = 100 + page.page_index
+    for idx in range(5, pagetable.full_arena.max_pages):
+        pagetable.full_arena.all_pages[idx].access_serial = idx - 5
+    pagetable.full_arena.access_serial = 1000
+    pagetable.full_arena.last_defrag_serial = 1000
+
+    allocated_pages, kv_position, cached_pages, _ = pagetable.allocate_pages([b"a" * 16], 1, None)
+
+    assert [page.page_index for page in allocated_pages] == [0, 1]
+    assert kv_position == 0
+    assert cached_pages == 0
+
+
+def test_gemma4_pagetable_build_cache_copy_plan_uses_cached_partial_swa_source():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    source_page = pagetable.full_arena.all_pages[0]
+    source_page.add_ref_unique(pagetable.full_arena.access_serial + 1)
+    source_page.kv_position = 20
+    source_page.prev_hash = b"prev"
+    source_page.sequence[:, :20].copy_(torch.arange(PAGE_SIZE, PAGE_SIZE + 20, dtype = torch.long).unsqueeze(0))
+
+    target_page = pagetable.full_arena.all_pages[1]
+    target_page.add_ref_unique(pagetable.full_arena.access_serial + 2)
+
+    target_swa = pagetable.swa_arena.all_pages[0]
+    target_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    pagetable.active_full_to_swa_pages[id(target_page)] = target_swa
+
+    partial_key = pagetable._cached_partial_page_key(source_page.prev_hash, source_page.sequence[:, :20])
+    source_swa = pagetable.swa_arena.all_pages[1]
+    source_swa.add_ref_unique(pagetable.swa_arena.access_serial + 2)
+    pagetable.cached_partial_to_swa_pages[partial_key] = source_swa
+
+    plan = pagetable.build_cache_copy_plan(source_page, target_page, 20)
+
+    assert plan == {
+        "full": (source_page.page_index, target_page.page_index),
+        "swa": (source_swa.page_index, target_swa.page_index),
+    }
+
+
+def test_job_prefill_falls_back_to_normal_ingest_when_custom_copy_plan_is_unavailable():
+    model_calls = []
+
+    class _FakeModel:
+        caps = {}
+
+        def prefill(self, input_ids, params):
+            model_calls.append({
+                "shape": tuple(input_ids.shape),
+                "cache_seqlens": tuple(params["cache_seqlens"].tolist()),
+            })
+
+    generator = SimpleNamespace(
+        max_chunk_size = PAGE_SIZE + 16,
+        num_draft_tokens = 0,
+        recurrent_cache = None,
+        draft_model = None,
+        draft_cache = None,
+        cache = SimpleNamespace(copy_page = lambda *args, **kwargs: None),
+        model = _FakeModel(),
+        recurrent_checkpoint_interval = PAGE_SIZE,
+        max_batch_size = 1,
+        max_total_tokens = PAGE_SIZE * 4,
+        padded_vocab_size = 128,
+    )
+    pagetable = _NoCopyPlanPageTable(generator, SimpleNamespace(max_num_tokens = PAGE_SIZE * 4))
+    generator.pagetable = pagetable
+
+    ids = torch.arange(PAGE_SIZE + 16, dtype = torch.long).unsqueeze(0)
+    job = Job(input_ids = ids, max_new_tokens = 8)
+    job.prepare_for_queue(generator, serial_number = 1)
+    job.allocate_pages()
+
+    match_page = pagetable.all_pages[-1]
+    match_page.prev_hash = None
+    match_page.kv_position = 8
+    match_page.sequence[:, :8].copy_(ids[:, :8])
+
+    results = []
+    job.prefill(results)
+
+    assert model_calls == [{
+        "shape": (1, PAGE_SIZE),
+        "cache_seqlens": (0,),
+    }]
+    assert job.cached_tokens == 0
+    assert job.sequences[0].kv_position == PAGE_SIZE
+    assert results and results[0]["stage"] == "prefill"
+
+
+def test_gemma4_pagetable_disables_full_reuse_without_matching_partial_source():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    ids = torch.arange(0, 288, dtype = torch.long).unsqueeze(0)
+    first_page = ids[:, :PAGE_SIZE]
+    first_hash = tensor_hash_checksum(first_page, None)
+
+    reusable_page = pagetable.full_arena.all_pages[1]
+    reusable_page.add_ref_clear(pagetable.full_arena.access_serial + 1, first_hash)
+    reusable_page.kv_position = PAGE_SIZE
+    reusable_page.sequence[:, :PAGE_SIZE].copy_(first_page)
+
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    pagetable.cached_full_to_swa_pages[(first_hash, False)] = cached_swa
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    assert seq.page_hashes[0] != first_hash
+    assert seq.kv_position == 0
+
+
+def test_gemma4_pagetable_scopes_cached_full_sources_by_prompt_mode():
+    pagetable = _make_gemma4_pagetable()
+    source_full = pagetable.full_arena.all_pages[0]
+    target_full = pagetable.full_arena.all_pages[1]
+    source_swa = pagetable.swa_arena.all_pages[0]
+    target_swa = pagetable.swa_arena.all_pages[1]
+
+    source_full.phash = b"f" * 16
+    pagetable.cached_full_to_swa_pages[pagetable._cached_full_page_key(source_full, True)] = source_swa
+    pagetable.active_full_to_swa_pages[id(target_full)] = target_swa
+
+    assert pagetable.build_cache_copy_plan(source_full, target_full, 17) is None
+
+
+def test_gemma4_pagetable_reuses_full_prefix_with_matching_mm_mode():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768, profile = "26b_a4b_moe")
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 768
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 768)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    ids = torch.full((1, PAGE_SIZE + 1), FIRST_MM_EMBEDDING_INDEX, dtype = torch.long)
+    first_page = ids[:, :PAGE_SIZE]
+    first_hash = tensor_hash_checksum(first_page, None)
+
+    reusable_page = pagetable.full_arena.all_pages[1]
+    reusable_page.add_ref_clear(pagetable.full_arena.access_serial + 1, first_hash)
+    reusable_page.kv_position = PAGE_SIZE
+    reusable_page.sequence[:, :PAGE_SIZE].copy_(first_page)
+
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    cached_swa.kv_position = PAGE_SIZE
+    pagetable.cached_full_to_swa_pages[(first_hash, True)] = cached_swa
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    assert seq.page_hashes[0] == first_hash
+    assert seq.kv_position == PAGE_SIZE
+
+
+def test_gemma4_pagetable_26b_fresh_text_prefers_low_index_swa_pages():
+    pagetable = _make_gemma4_pagetable(
+        sliding_window = 256,
+        swa_max_num_tokens = 1024,
+        profile = "26b_a4b_moe",
+    )
+
+    # Make the highest-index SWA page look oldest so the generic LRU order would
+    # pick it first. The 26B fresh-text path should override that and keep the
+    # local window on the lowest page indices instead.
+    for page_idx, page in enumerate(pagetable.swa_arena.all_pages):
+        page.access_serial = 100 + page_idx
+    pagetable.swa_arena.all_pages[3].access_serial = 0
+
+    ids = torch.arange(0, 21, dtype = torch.long).unsqueeze(0)
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    swa_pages = _get_seq_pages(pagetable, seq, role = "swa")
+    assert [page.page_index for page in swa_pages] == [0]
+    assert seq.kv_position == 0
+
+
+def test_gemma4_pagetable_non_26b_text_keeps_lru_swa_allocation_order():
+    pagetable = _make_gemma4_pagetable(
+        sliding_window = 256,
+        swa_max_num_tokens = 1024,
+        profile = "generic",
+    )
+
+    for page_idx, page in enumerate(pagetable.swa_arena.all_pages):
+        page.access_serial = 100 + page_idx
+    pagetable.swa_arena.all_pages[3].access_serial = 0
+
+    ids = torch.arange(0, 21, dtype = torch.long).unsqueeze(0)
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    swa_pages = _get_seq_pages(pagetable, seq, role = "swa")
+    assert [page.page_index for page in swa_pages] == [3]
+
+
+def test_gemma4_pagetable_26b_mm_keeps_lru_swa_allocation_order():
+    pagetable = _make_gemma4_pagetable(
+        sliding_window = 256,
+        swa_max_num_tokens = 1024,
+        profile = "26b_a4b_moe",
+    )
+
+    for page_idx, page in enumerate(pagetable.swa_arena.all_pages):
+        page.access_serial = 100 + page_idx
+    pagetable.swa_arena.all_pages[3].access_serial = 0
+
+    ids = torch.full((1, 21), FIRST_MM_EMBEDDING_INDEX, dtype = torch.long)
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    swa_pages = _get_seq_pages(pagetable, seq, role = "swa")
+    assert [page.page_index for page in swa_pages] == [3]
+
+
+def test_gemma4_pagetable_26b_reused_text_prefix_prefers_low_index_full_tail_page():
+    pagetable = _make_gemma4_pagetable(
+        sliding_window = 256,
+        swa_max_num_tokens = 1024,
+        profile = "26b_a4b_moe",
+    )
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 1024
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    for page_idx, page in enumerate(pagetable.full_arena.all_pages):
+        page.access_serial = 100 + page_idx
+    pagetable.full_arena.all_pages[3].access_serial = 0
+
+    ids = torch.arange(0, PAGE_SIZE + 21, dtype = torch.long).unsqueeze(0)
+    first_page = ids[:, :PAGE_SIZE]
+    first_hash = tensor_hash_checksum(first_page, None)
+
+    reusable_page = pagetable.full_arena.all_pages[1]
+    reusable_page.add_ref_clear(pagetable.full_arena.access_serial + 1, first_hash)
+    reusable_page.kv_position = PAGE_SIZE
+    reusable_page.sequence[:, :PAGE_SIZE].copy_(first_page)
+
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    cached_swa.kv_position = PAGE_SIZE
+    pagetable.cached_full_to_swa_pages[(first_hash, False)] = cached_swa
+    partial_ids = ids[:, PAGE_SIZE:PAGE_SIZE + 20]
+    partial_key = pagetable._cached_partial_page_key(first_hash, partial_ids, False)
+    partial_swa = pagetable.swa_arena.all_pages[1]
+    partial_swa.add_ref_unique(pagetable.swa_arena.access_serial + 2)
+    partial_swa.kv_position = 20
+    pagetable.cached_partial_to_swa_pages[partial_key] = partial_swa
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    full_pages = _get_seq_pages(pagetable, seq, role = "full")
+    assert [page.page_index for page in full_pages] == [1, 0]
+    assert seq.kv_position == PAGE_SIZE
+
+
+def test_gemma4_pagetable_non_26b_reused_text_prefix_keeps_lru_full_tail_page():
+    pagetable = _make_gemma4_pagetable(
+        sliding_window = 256,
+        swa_max_num_tokens = 1024,
+        profile = "generic",
+    )
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 1024
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    for page_idx, page in enumerate(pagetable.full_arena.all_pages):
+        page.access_serial = 100 + page_idx
+    pagetable.full_arena.all_pages[3].access_serial = 0
+
+    ids = torch.arange(0, PAGE_SIZE + 21, dtype = torch.long).unsqueeze(0)
+    first_page = ids[:, :PAGE_SIZE]
+    first_hash = tensor_hash_checksum(first_page, None)
+
+    reusable_page = pagetable.full_arena.all_pages[1]
+    reusable_page.add_ref_clear(pagetable.full_arena.access_serial + 1, first_hash)
+    reusable_page.kv_position = PAGE_SIZE
+    reusable_page.sequence[:, :PAGE_SIZE].copy_(first_page)
+
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    cached_swa.kv_position = PAGE_SIZE
+    pagetable.cached_full_to_swa_pages[(first_hash, False)] = cached_swa
+    partial_ids = ids[:, PAGE_SIZE:PAGE_SIZE + 20]
+    partial_key = pagetable._cached_partial_page_key(first_hash, partial_ids, False)
+    partial_swa = pagetable.swa_arena.all_pages[1]
+    partial_swa.add_ref_unique(pagetable.swa_arena.access_serial + 2)
+    partial_swa.kv_position = 20
+    pagetable.cached_partial_to_swa_pages[partial_key] = partial_swa
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    full_pages = _get_seq_pages(pagetable, seq, role = "full")
+    assert [page.page_index for page in full_pages] == [1, 3]
+
+
+def test_gemma4_pagetable_26b_mm_reused_prefix_keeps_lru_full_tail_page():
+    pagetable = _make_gemma4_pagetable(
+        sliding_window = 256,
+        swa_max_num_tokens = 1024,
+        profile = "26b_a4b_moe",
+    )
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 1024
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    for page_idx, page in enumerate(pagetable.full_arena.all_pages):
+        page.access_serial = 100 + page_idx
+    pagetable.full_arena.all_pages[3].access_serial = 0
+
+    ids = torch.full((1, PAGE_SIZE + 21), FIRST_MM_EMBEDDING_INDEX, dtype = torch.long)
+    first_page = ids[:, :PAGE_SIZE]
+    first_hash = tensor_hash_checksum(first_page, None)
+
+    reusable_page = pagetable.full_arena.all_pages[1]
+    reusable_page.add_ref_clear(pagetable.full_arena.access_serial + 1, first_hash)
+    reusable_page.kv_position = PAGE_SIZE
+    reusable_page.sequence[:, :PAGE_SIZE].copy_(first_page)
+
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    cached_swa.kv_position = PAGE_SIZE
+    pagetable.cached_full_to_swa_pages[(first_hash, True)] = cached_swa
+    partial_ids = ids[:, PAGE_SIZE:PAGE_SIZE + 20]
+    partial_key = pagetable._cached_partial_page_key(first_hash, partial_ids, True)
+    partial_swa = pagetable.swa_arena.all_pages[1]
+    partial_swa.add_ref_unique(pagetable.swa_arena.access_serial + 2)
+    partial_swa.kv_position = 20
+    pagetable.cached_partial_to_swa_pages[partial_key] = partial_swa
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    full_pages = _get_seq_pages(pagetable, seq, role = "full")
+    assert [page.page_index for page in full_pages] == [1, 3]
+
+
+def test_gemma4_pagetable_reuses_text_full_prefix_before_first_mm_request():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768, profile = "26b_a4b_moe")
+    swa_layer = _DummyLayer("swa")
+    swa_layer.max_num_tokens = 768
+    full_layer = SimpleNamespace(cache_role = "full", max_num_tokens = 1024)
+    pagetable.cache.layers = {0: full_layer, 1: swa_layer}
+
+    ids = torch.arange(0, PAGE_SIZE + 1, dtype = torch.long).unsqueeze(0)
+    first_page = ids[:, :PAGE_SIZE]
+    first_hash = tensor_hash_checksum(first_page, None)
+
+    reusable_page = pagetable.full_arena.all_pages[1]
+    reusable_page.add_ref_clear(pagetable.full_arena.access_serial + 1, first_hash)
+    reusable_page.kv_position = PAGE_SIZE
+    reusable_page.sequence[:, :PAGE_SIZE].copy_(first_page)
+
+    cached_swa = pagetable.swa_arena.all_pages[0]
+    cached_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    cached_swa.kv_position = PAGE_SIZE
+    pagetable.cached_full_to_swa_pages[(first_hash, False)] = cached_swa
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+    pagetable.allocate_sequence(seq, None)
+
+    assert seq.page_hashes[0] == first_hash
+    assert seq.kv_position == PAGE_SIZE
+
+
+def test_gemma4_pagetable_scopes_cached_partial_sources_by_prompt_mode():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    source_page = pagetable.full_arena.all_pages[0]
+    source_page.add_ref_unique(pagetable.full_arena.access_serial + 1)
+    source_page.kv_position = 20
+    source_page.prev_hash = b"prev"
+    source_page.sequence[:, :20].copy_(torch.arange(PAGE_SIZE, PAGE_SIZE + 20, dtype = torch.long).unsqueeze(0))
+
+    target_page = pagetable.full_arena.all_pages[1]
+    target_page.add_ref_unique(pagetable.full_arena.access_serial + 2)
+
+    target_swa = pagetable.swa_arena.all_pages[0]
+    target_swa.add_ref_unique(pagetable.swa_arena.access_serial + 1)
+    pagetable.active_full_to_swa_pages[id(target_page)] = target_swa
+
+    partial_key = pagetable._cached_partial_page_key(source_page.prev_hash, source_page.sequence[:, :20], True)
+    source_swa = pagetable.swa_arena.all_pages[1]
+    source_swa.add_ref_unique(pagetable.swa_arena.access_serial + 2)
+    pagetable.cached_partial_to_swa_pages[partial_key] = source_swa
+
+    assert pagetable.build_cache_copy_plan(source_page, target_page, 20) is None
+
+
+def test_gemma4_pagetable_keeps_full_page_hashes_when_no_reuse_candidate_exists():
+    pagetable = _make_gemma4_pagetable(sliding_window = 256, swa_max_num_tokens = 768)
+
+    ids = torch.arange(0, 288, dtype = torch.long).unsqueeze(0)
+    first_page = ids[:, :PAGE_SIZE]
+    first_hash = tensor_hash_checksum(first_page, None)
+
+    seq = Sequence(ids, ids.clone())
+    pagetable.prepare_sequence(seq, False, 0, allow_page_reuse = True)
+
+    assert seq.page_hashes[0] == first_hash
+
+
+def test_cache_copy_page_uses_role_specific_page_plan_and_default_fallback():
+    src_cache = object.__new__(Cache)
+    dst_cache = object.__new__(Cache)
+    src_cache.model = SimpleNamespace(loaded_tp = False)
+    dst_cache.model = SimpleNamespace(loaded_tp = False)
+    src_cache.num_layers = dst_cache.num_layers = 2
+    src_cache.layers = {0: _DummyLayer("full"), 1: _DummyLayer("swa")}
+    dst_cache.layers = {0: _DummyLayer("full"), 1: _DummyLayer("swa")}
+
+    Cache.copy_page(
+        src_cache,
+        dst_cache,
+        1,
+        2,
+        5,
+        page_plan = {
+            "full": (10, 20),
+            "swa": (11, 21),
+        },
+    )
+    assert dst_cache.layers[0].calls == [("full", 10, 20, 5)]
+    assert dst_cache.layers[1].calls == [("swa", 11, 21, 5)]
+
+    src_cache_2 = object.__new__(Cache)
+    dst_cache_2 = object.__new__(Cache)
+    src_cache_2.model = SimpleNamespace(loaded_tp = False)
+    dst_cache_2.model = SimpleNamespace(loaded_tp = False)
+    src_cache_2.num_layers = dst_cache_2.num_layers = 2
+    src_cache_2.layers = {0: _DummyLayer("full"), 1: _DummyLayer("swa")}
+    dst_cache_2.layers = {0: _DummyLayer("full"), 1: _DummyLayer("swa")}
+
+    Cache.copy_page(
+        src_cache_2,
+        dst_cache_2,
+        1,
+        2,
+        5,
+        page_plan = {"default": (7, 8)},
+    )
+    assert dst_cache_2.layers[0].calls == [("full", 7, 8, 5)]
+    assert dst_cache_2.layers[1].calls == [("swa", 7, 8, 5)]
+
+
+def test_gemma4_prepare_inputs_drops_mm_state_for_plain_text_decode():
+    embeddings = [
+        SimpleNamespace(first_index = 1000, last_index = 1016),
+        SimpleNamespace(first_index = 2000, last_index = 2016),
+    ]
+    input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype = torch.long)
+    params = {"indexed_embeddings": embeddings.copy()}
+
+    _filter_gemma4_indexed_embeddings(input_ids, params)
+
+    assert "indexed_embeddings" not in params
+
+
+def test_gemma4_prepare_inputs_keeps_only_current_mm_ranges():
+    embeddings = [
+        SimpleNamespace(first_index = 1000, last_index = 1016),
+        SimpleNamespace(first_index = 2000, last_index = 2016),
+    ]
+    input_ids = torch.tensor([[1, 1002, 3], [4, 2005, 6]], dtype = torch.long)
+    params = {"indexed_embeddings": embeddings.copy()}
+
+    _filter_gemma4_indexed_embeddings(input_ids, params)
+
+    assert params["indexed_embeddings"] == embeddings
+
+    params_single = {"indexed_embeddings": embeddings.copy()}
+    _filter_gemma4_indexed_embeddings(torch.tensor([[1, 1003, 4]], dtype = torch.long), params_single)
+    assert params_single["indexed_embeddings"] == [embeddings[0]]
+
+
+def test_gemma4_26b_mm_request_keeps_temp_reconstruct_even_after_decode_tokens():
+    params = {
+        "indexed_embeddings": [SimpleNamespace(first_index = 1000, last_index = 1016)],
+    }
+    input_ids = torch.tensor([[1, 2, 3]], dtype = torch.long)
+
+    has_mm_request = bool(params.get("indexed_embeddings"))
+    _filter_gemma4_indexed_embeddings(input_ids, params)
+    assert "indexed_embeddings" not in params
+
+    _update_gemma4_reconstruct_mode(params, "26b_a4b_moe", has_mm_request = has_mm_request)
+
+    assert params["reconstruct"] is True
+    assert params["_gemma4_temp_reconstruct"] is True
+
+
+def test_gemma4_26b_text_request_clears_temp_reconstruct_when_mm_request_ends():
+    params = {
+        "reconstruct": True,
+        "_gemma4_temp_reconstruct": True,
+    }
+
+    _update_gemma4_reconstruct_mode(params, "26b_a4b_moe", has_mm_request = False)
+
+    assert "reconstruct" not in params
+    assert "_gemma4_temp_reconstruct" not in params
+
+
+def test_gemma4_26b_mm_request_preserves_explicit_reconstruct_flag():
+    params = {
+        "indexed_embeddings": [SimpleNamespace(first_index = 1000, last_index = 1016)],
+        "reconstruct": True,
+    }
+
+    _update_gemma4_reconstruct_mode(params, "26b_a4b_moe", has_mm_request = True)
+
+    assert params["reconstruct"] is True
+    assert "_gemma4_temp_reconstruct" not in params
+
+
+def test_full_gemma4_mm_only_keeps_bsz1_graph_enabled_by_default_and_supports_force_disable():
+    block = object.__new__(Gemma4TransformerBlock)
+    block.mlp = object()
+
+    full_attn = object.__new__(Gemma4Attention)
+    full_attn.sliding_window = -1
+    full_attn.device = torch.device("cpu")
+    block.attn = full_attn
+
+    assert block._should_disable_bsz1_graph({"indexed_embeddings": [object()]}) is False
+    assert block._should_disable_bsz1_graph({}) is False
+    assert block._should_disable_bsz1_graph({
+        "indexed_embeddings": [object()],
+        "_force_disable_bsz1_graph": True,
+    }) is True
+
+    sliding_attn = object.__new__(Gemma4Attention)
+    sliding_attn.sliding_window = 1024
+    sliding_attn.device = torch.device("cpu")
+    block.attn = sliding_attn
+
+    assert block._should_disable_bsz1_graph({
+        "indexed_embeddings": [object()],
+        "_force_disable_bsz1_graph": True,
+    }) is False
+
+
+@pytest.mark.parametrize("sliding_window", [-1, 256])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("with_groups", [False, True])
+def test_gemma4_mm_mask_vectorized_matches_reference(sliding_window: int, causal: bool, with_groups: bool):
+    attn = object.__new__(Gemma4Attention)
+    attn.sliding_window = sliding_window
+
+    bsz = 2
+    seqlen = 4
+    device = torch.device("cpu")
+    total_lens = torch.tensor([7, 6], dtype = torch.int32)
+    cache_seqlens = torch.tensor([3, 2], dtype = torch.int32)
+    vision_group_ids = None
+    if with_groups:
+        vision_group_ids = torch.tensor(
+            [
+                [0, 0, -1, -1],
+                [-1, 1, 1, -1],
+            ],
+            dtype = torch.int32,
+        )
+
+    expected = _build_mm_mask_reference(
+        sliding_window = sliding_window,
+        bsz = bsz,
+        seqlen = seqlen,
+        total_lens = total_lens,
+        cache_seqlens = cache_seqlens,
+        vision_group_ids = vision_group_ids,
+        q_dtype = torch.float16,
+        device = device,
+        causal = causal,
+    )
+    actual = attn._build_mm_mask(
+        bsz = bsz,
+        seqlen = seqlen,
+        total_lens = total_lens,
+        cache_seqlens = cache_seqlens,
+        vision_group_ids = vision_group_ids,
+        q_dtype = torch.float16,
+        device = device,
+        causal = causal,
+    )
+
+    assert torch.equal(actual, expected.eq(0))
+
+
+def test_gemma4_mm_mask_cache_reuses_same_forward_params_and_separates_roles():
+    params = {}
+    total_lens = torch.tensor([7], dtype = torch.int32)
+    cache_seqlens = torch.tensor([3], dtype = torch.int32)
+    vision_group_ids = torch.tensor([[0, 0, -1, -1]], dtype = torch.int32)
+
+    full_attn = object.__new__(Gemma4Attention)
+    full_attn.sliding_window = -1
+    full_mask_1 = full_attn._get_mm_mask_cached(
+        params,
+        1,
+        4,
+        total_lens,
+        cache_seqlens,
+        vision_group_ids,
+        torch.float16,
+        torch.device("cpu"),
+        True,
+    )
+    full_mask_2 = full_attn._get_mm_mask_cached(
+        params,
+        1,
+        4,
+        total_lens,
+        cache_seqlens,
+        vision_group_ids,
+        torch.float16,
+        torch.device("cpu"),
+        True,
+    )
+    assert full_mask_1 is full_mask_2
+
+    swa_attn = object.__new__(Gemma4Attention)
+    swa_attn.sliding_window = 256
+    swa_mask = swa_attn._get_mm_mask_cached(
+        params,
+        1,
+        4,
+        total_lens,
+        cache_seqlens,
+        vision_group_ids,
+        torch.float16,
+        torch.device("cpu"),
+        True,
+    )
+    assert swa_mask is not full_mask_1
+
+
+def test_gemma4_mm_visible_positions_cache_reuses_and_reduces_mask():
+    attn = object.__new__(Gemma4Attention)
+    attn.sliding_window = 1
+
+    params = {}
+    total_lens = torch.tensor([5], dtype = torch.int32)
+    cache_seqlens = torch.tensor([3], dtype = torch.int32)
+    vision_group_ids = torch.tensor([[-1, -1]], dtype = torch.int32)
+
+    mask = attn._get_mm_mask_cached(
+        params,
+        1,
+        2,
+        total_lens,
+        cache_seqlens,
+        vision_group_ids,
+        torch.float16,
+        torch.device("cpu"),
+        True,
+    )
+    selected_1, counts_1, reduced_1 = attn._get_mm_visible_positions_cached(
+        params,
+        mask,
+        total_lens,
+        torch.device("cpu"),
+    )
+    selected_2, counts_2, reduced_2 = attn._get_mm_visible_positions_cached(
+        params,
+        mask,
+        total_lens,
+        torch.device("cpu"),
+    )
+
+    assert selected_1 is selected_2
+    assert counts_1 is counts_2
+    assert reduced_1 is reduced_2
+    assert counts_1.tolist() == [3]
+    assert selected_1[0, :3].tolist() == [2, 3, 4]
+    assert torch.equal(reduced_1[0, 0, :, :3], mask[0, 0, :, selected_1[0, :3]])
+
+
+def test_gemma4_mm_visible_positions_vectorized_handles_ragged_batches():
+    attn = object.__new__(Gemma4Attention)
+    attn.sliding_window = 1
+
+    params = {}
+    total_lens = torch.tensor([5, 3], dtype = torch.int32)
+    cache_seqlens = torch.tensor([3, 1], dtype = torch.int32)
+    vision_group_ids = torch.tensor(
+        [
+            [-1, -1],
+            [0, -1],
+        ],
+        dtype = torch.int32,
+    )
+
+    mask = attn._get_mm_mask_cached(
+        params,
+        2,
+        2,
+        total_lens,
+        cache_seqlens,
+        vision_group_ids,
+        torch.float16,
+        torch.device("cpu"),
+        True,
+    )
+    selected, counts, reduced = attn._get_mm_visible_positions_cached(
+        params,
+        mask,
+        total_lens,
+        torch.device("cpu"),
+    )
+
+    assert counts.tolist() == [3, 3]
+    assert selected[0, :3].tolist() == [2, 3, 4]
+    assert selected[1, :3].tolist() == [0, 1, 2]
+    assert torch.equal(reduced[0, 0, :, :3], mask[0, 0, :, selected[0, :3]])
+    assert torch.equal(reduced[1, 0, :, :3], mask[1, 0, :, selected[1, :3]])
+
+
+def test_gemma4_mm_visible_positions_handles_empty_selection():
+    attn = object.__new__(Gemma4Attention)
+    attn.sliding_window = 1
+    params = {}
+    mask = torch.zeros((2, 1, 3, 4), dtype = torch.bool)
+    total_lens = torch.tensor([0, 0], dtype = torch.int32)
+
+    selected, counts, reduced = attn._get_mm_visible_positions_cached(
+        params,
+        mask,
+        total_lens,
+        torch.device("cpu"),
+    )
+
+    assert selected.shape == (2, 0)
+    assert reduced.shape == (2, 1, 3, 0)
+    assert counts.tolist() == [0, 0]
+
+
+def test_full_text_only_single_quant_cache_uses_compact_path():
+    attn = object.__new__(Gemma4Attention)
+    attn.sliding_window = -1
+    attn.force_quantized_fallback = False
+
+    cache_layer = object.__new__(Gemma4SingleQuantCacheLayer)
+
+    allow_full_compact_cache = (
+        attn.sliding_window < 0 and
+        isinstance(cache_layer, Gemma4SingleQuantCacheLayer)
+    )
+    use_shadow_cache = (
+        isinstance(cache_layer, Gemma4QuantCacheLayer) and
+        attn.sliding_window < 0 and
+        not allow_full_compact_cache
+    )
+    use_compact_cache = (
+        isinstance(cache_layer, Gemma4SingleQuantCacheLayer) and
+        not use_shadow_cache and
+        (
+            allow_full_compact_cache or
+            attn.force_quantized_fallback or
+            False or
+            False
+        )
+    )
+
+    assert allow_full_compact_cache is True
+    assert use_shadow_cache is False
+    assert use_compact_cache is True
+
+
+def test_full_mm_without_vision_groups_does_not_force_mm_fallback():
+    attn = object.__new__(Gemma4Attention)
+    attn.sliding_window = -1
+    attn.force_quantized_fallback = False
+    attn.head_dim = 256
+    attn.device = torch.device("cpu")
+    attn._get_cache_layer = lambda cache: object()
+
+    params = {"indexed_embeddings": [object()]}
+    has_mm_embeddings = bool(params.get("indexed_embeddings"))
+    vision_group_ids = attn._get_vision_group_ids(params)
+    if attn.sliding_window < 0:
+        vision_group_ids = None
+    needs_custom_mm_mask = vision_group_ids is not None
+    force_quantized_fallback = (
+        attn.force_quantized_fallback and
+        False and
+        False and
+        isinstance(attn._get_cache_layer(None), Gemma4QuantCacheLayer)
+    )
+
+    assert has_mm_embeddings is True
+    assert needs_custom_mm_mask is False
+    assert force_quantized_fallback is False
+    assert (attn.head_dim > 256 or needs_custom_mm_mask or force_quantized_fallback) is False
+
+
+def test_gemma4_kv_workspace_reuses_same_forward_params():
+    attn = object.__new__(Gemma4Attention)
+    attn.num_kv_heads = 2
+    attn.head_dim = 4
+
+    params = {}
+    k1, v1 = attn._get_kv_workspace(params, 1, 8, torch.half, torch.device("cpu"))
+    k2, v2 = attn._get_kv_workspace(params, 1, 8, torch.half, torch.device("cpu"))
+    assert k1 is k2
+    assert v1 is v2
+
+    k3, v3 = attn._get_kv_workspace(params, 1, 16, torch.half, torch.device("cpu"))
+    assert k3 is not k1
+    assert v3 is not v1
+
+    hk1, hv1 = attn._get_kv_workspace(params, 1, 8, torch.half, torch.device("cpu"), heads_first = True)
+    hk2, hv2 = attn._get_kv_workspace(params, 1, 8, torch.half, torch.device("cpu"), heads_first = True)
+    assert hk1 is hk2
+    assert hv1 is hv2
+    assert hk1.shape == (1, 2, 8, 4)
+    assert hv1.shape == (1, 2, 8, 4)
+    assert hk1 is not k1
+    assert hv1 is not v1
+
+
+def test_gemma4_gather_cache_pages_supports_heads_first_workspace():
+    attn = object.__new__(Gemma4Attention)
+    attn.num_kv_heads = 2
+    attn.head_dim = 4
+
+    cache_tensor = torch.arange(3 * 256 * 2 * 4, dtype = torch.float32).reshape(3, 256, 2, 4)
+    block_table = torch.tensor([[2, 1], [0, 2]], dtype = torch.int32)
+    total_lens = torch.tensor([6, 3], dtype = torch.int32)
+
+    gathered_time = attn._gather_cache_pages(cache_tensor, block_table, total_lens)
+    gathered_heads = attn._gather_cache_pages(
+        cache_tensor,
+        block_table,
+        total_lens,
+        gathered = torch.zeros((2, 2, 6, 4), dtype = cache_tensor.dtype),
+    )
+    for batch_idx, total in enumerate(total_lens.tolist()):
+        assert torch.equal(gathered_heads[batch_idx, :, :total], gathered_time[batch_idx, :total].transpose(0, 1))
+
+
+def test_gemma4_gather_selected_cache_pages_matches_full_gather_subset():
+    attn = object.__new__(Gemma4Attention)
+    attn.num_kv_heads = 2
+    attn.head_dim = 4
+
+    cache_tensor = torch.arange(3 * 256 * 2 * 4, dtype = torch.float32).reshape(3, 256, 2, 4)
+    block_table = torch.tensor([[2, 1], [0, 2]], dtype = torch.int32)
+    total_lens = torch.tensor([6, 3], dtype = torch.int32)
+    selected_positions = torch.tensor([[1, 4, 5], [0, 2, 0]], dtype = torch.long)
+    selected_counts = torch.tensor([3, 2], dtype = torch.int32)
+
+    full_gather = attn._gather_cache_pages(cache_tensor, block_table, total_lens)
+    subset_heads = attn._gather_selected_cache_pages(
+        cache_tensor,
+        block_table,
+        selected_positions,
+        selected_counts,
+        torch.zeros((2, 2, 3, 4), dtype = cache_tensor.dtype),
+    )
+
+    assert torch.equal(subset_heads[0, :, :3], full_gather[0, selected_positions[0, :3]].transpose(0, 1))
+    assert torch.equal(subset_heads[1, :, :2], full_gather[1, selected_positions[1, :2]].transpose(0, 1))
+
+
+def test_gemma4_mm_attention_softcap_gqa_matches_repeat_reference():
+    attn = object.__new__(Gemma4Attention)
+    attn.sm_scale = None
+    attn.head_dim = 4
+    attn.logit_softcapping = 30.0
+    attn.gqa = True
+
+    q = torch.arange(2 * 4 * 3 * 4, dtype = torch.float32).reshape(2, 4, 3, 4) / 17.0
+    k = torch.arange(2 * 2 * 5 * 4, dtype = torch.float32).reshape(2, 2, 5, 4) / 19.0
+    v = torch.arange(2 * 2 * 5 * 4, dtype = torch.float32).reshape(2, 2, 5, 4) / 23.0
+    mask = torch.ones((2, 1, 3, 5), dtype = torch.bool)
+    mask[:, :, :, -1] = False
+
+    repeat = q.shape[1] // k.shape[1]
+    k_ref = k.repeat_interleave(repeat, dim = 1)
+    v_ref = v.repeat_interleave(repeat, dim = 1)
+    scale = attn.head_dim ** -0.5
+    scores = torch.matmul(q.float(), k_ref.transpose(-1, -2).float()) * scale
+    scores = torch.tanh(scores / attn.logit_softcapping) * attn.logit_softcapping
+    scores.masked_fill_(mask.logical_not(), torch.finfo(scores.dtype).min)
+    probs = torch.softmax(scores, dim = -1, dtype = torch.float32)
+    expected = torch.matmul(probs, v_ref.float()).to(q.dtype)
+
+    actual = attn._mm_attention(q, k, v, mask)
+    assert torch.allclose(actual, expected, atol = 1e-5, rtol = 1e-5)

--- a/tests/test_gemma4_turboquant.py
+++ b/tests/test_gemma4_turboquant.py
@@ -19,6 +19,7 @@ from exllamav3.cache.gemma4 import (
 )
 from exllamav3.cache.quant import CacheLayer_quant
 from exllamav3.constants import PAGE_SIZE
+from exllamav3.generator.generator import Generator
 from exllamav3.generator.gemma4_pagetable import Gemma4PageTable
 from exllamav3.generator.job import Job
 from exllamav3.generator.pagetable import PageTable, Sequence, tensor_hash_checksum
@@ -240,6 +241,191 @@ def test_select_gemma4_cache_layer_applies_auto_swa_default_only_when_unspecifie
         },
     )
     assert explicit_swa["max_num_tokens"] == 1536
+
+
+def test_pagetable_advance_draft_decode_params_keeps_default_path_and_extends_gemma_roles():
+    default_pagetable = PageTable(
+        SimpleNamespace(),
+        SimpleNamespace(max_num_tokens = PAGE_SIZE * 4),
+    )
+    default_params = {
+        "cache_seqlens": torch.tensor([3, 7], dtype = torch.int32),
+    }
+    default_pagetable.advance_draft_decode_params(default_params, step = 2)
+    assert default_params["cache_seqlens"].tolist() == [5, 9]
+
+    gemma4_pagetable = _make_gemma4_pagetable()
+    gemma4_params = {
+        "cache_seqlens": torch.tensor([1], dtype = torch.int32),
+        "cache_seqlens_full": torch.tensor([4], dtype = torch.int32),
+        "cache_seqlens_swa": torch.tensor([6], dtype = torch.int32),
+    }
+    gemma4_pagetable.advance_draft_decode_params(gemma4_params, step = 2)
+    assert gemma4_params["cache_seqlens"].tolist() == [3]
+    assert gemma4_params["cache_seqlens_full"].tolist() == [6]
+    assert gemma4_params["cache_seqlens_swa"].tolist() == [8]
+
+
+def test_generator_iterate_draftmodel_gen_advances_custom_draft_cache_seqlens():
+    observed_forward = []
+    observed_prefill = []
+
+    class _FakePageTable:
+
+        def __init__(self):
+            self.advance_calls = 0
+
+        def build_draft_decode_params(self, active_jobs, max_seq_len):
+            return {
+                "block_table": torch.zeros((1, 1), dtype = torch.int32),
+                "cache_seqlens": torch.tensor([3], dtype = torch.int32),
+                "block_table_full": torch.zeros((1, 1), dtype = torch.int32),
+                "cache_seqlens_full": torch.tensor([5], dtype = torch.int32),
+                "block_table_swa": torch.zeros((1, 1), dtype = torch.int32),
+                "cache_seqlens_swa": torch.tensor([7], dtype = torch.int32),
+            }
+
+        def advance_draft_decode_params(self, params, step = 1):
+            self.advance_calls += 1
+            params["cache_seqlens"] += step
+            params["cache_seqlens_full"] += step
+            params["cache_seqlens_swa"] += step
+
+    class _FakeDraftModel:
+
+        def forward(self, input_ids, params):
+            observed_forward.append({
+                "cache_seqlens": params["cache_seqlens"].clone(),
+                "cache_seqlens_full": params["cache_seqlens_full"].clone(),
+                "cache_seqlens_swa": params["cache_seqlens_swa"].clone(),
+            })
+            logits = torch.zeros((1, 1, 4), dtype = torch.float32)
+            logits[:, :, 1] = 1.0
+            return logits
+
+        def prefill(self, input_ids, params):
+            observed_prefill.append({
+                "cache_seqlens": params["cache_seqlens"].clone(),
+                "cache_seqlens_full": params["cache_seqlens_full"].clone(),
+                "cache_seqlens_swa": params["cache_seqlens_swa"].clone(),
+            })
+
+    fake_job = SimpleNamespace(
+        embeddings = [],
+        time_first_token = 0.0,
+        is_prefill_done = lambda: True,
+        get_max_seq_len = lambda: 1,
+        get_input_ids_list = lambda: [torch.tensor([[11]], dtype = torch.long)],
+    )
+    fake_self = SimpleNamespace(
+        active_jobs = [fake_job],
+        num_draft_tokens = 2,
+        pagetable = _FakePageTable(),
+        draft_model = _FakeDraftModel(),
+        draft_cache = object(),
+        draft_input_ids_pinned = torch.zeros((1, 1), dtype = torch.long),
+        draft_ids_pinned = torch.zeros((1, 2), dtype = torch.long),
+    )
+
+    Generator.iterate_draftmodel_gen(fake_self, results = [])
+
+    assert fake_self.pagetable.advance_calls == 2
+    assert [entry["cache_seqlens"].item() for entry in observed_forward] == [3, 4]
+    assert [entry["cache_seqlens_full"].item() for entry in observed_forward] == [5, 6]
+    assert [entry["cache_seqlens_swa"].item() for entry in observed_forward] == [7, 8]
+    assert observed_prefill[-1]["cache_seqlens"].item() == 5
+    assert observed_prefill[-1]["cache_seqlens_full"].item() == 7
+    assert observed_prefill[-1]["cache_seqlens_swa"].item() == 9
+
+
+def test_generator_iterate_gen_rolls_back_rejected_draft_tokens_for_each_sequence():
+    page_a = SimpleNamespace(kv_position = 1)
+    page_b = SimpleNamespace(kv_position = 1)
+    seq_a = SimpleNamespace(kv_position = 1, allocated_pages = [page_a])
+    seq_b = SimpleNamespace(kv_position = 1, allocated_pages = [page_b])
+    sync_calls = []
+
+    class _FakeModel:
+        caps = {}
+
+        def forward(self, input_ids, params):
+            return torch.zeros((2, 2, 4), dtype = torch.float32)
+
+    class _FakePageTable:
+
+        def build_decode_params(self, active_jobs, max_seq_len, use_offsets = False):
+            return {
+                "block_table": torch.zeros((2, 1), dtype = torch.int32),
+                "cache_seqlens": torch.tensor([1, 1], dtype = torch.int32),
+            }
+
+        def sync_sequence_views(self, seq):
+            sync_calls.append(seq)
+
+        def defrag(self):
+            return None
+
+    class _FakeJob:
+
+        def __init__(self):
+            self.sequences = [seq_a, seq_b]
+            self.embeddings = []
+            self.time_first_token = 0.0
+            self.new_tokens = 0
+            self.filters = []
+            self.filter_futures = []
+            self.logit_masks = []
+            self.accepted_draft_tokens = 0
+            self.rejected_draft_tokens = 0
+
+        def is_prefill_done(self):
+            return True
+
+        def get_max_seq_len(self):
+            return 1
+
+        def get_input_ids_list(self, draft_tokens = None, batch_offset = 0, add_to_cache = False):
+            return [
+                torch.tensor([[1]], dtype = torch.long),
+                torch.tensor([[2]], dtype = torch.long),
+            ]
+
+        def prepare_logit_mask(self):
+            return None
+
+        def prepare_sampling_past_ids(self):
+            return None
+
+        def receive_logits(self, token_logits):
+            return torch.tensor(0), None, None, 1.0
+
+        def receive_sample(self, token_logits, next_token, next_k_tokens, next_k_probs, next_prob, results):
+            return False, torch.tensor(1), False
+
+        def deallocate_pages(self):
+            return None
+
+        def free_recurrent_state(self):
+            return None
+
+    fake_job = _FakeJob()
+    fake_self = SimpleNamespace(
+        active_jobs = [fake_job],
+        num_draft_tokens = 0,
+        model = _FakeModel(),
+        pagetable = _FakePageTable(),
+        recurrent_cache = None,
+        filter_pool = None,
+        cache = object(),
+        num_remaining_jobs = lambda: 1,
+    )
+
+    Generator.iterate_gen(fake_self, results = [], draft_tokens = torch.zeros((1, 1), dtype = torch.long))
+
+    assert fake_job.rejected_draft_tokens == 1
+    assert page_a.kv_position == 0
+    assert page_b.kv_position == 0
+    assert sync_calls == [seq_a, seq_b]
 
 
 def test_gemma4_pagetable_reports_min_safe_swa_window_and_atomic_prefill_guard():


### PR DESCRIPTION
> Note: because upstream PR #185 is still based on the fork branch `lesj0610:feat/gemma4-support`, GitHub cannot show a truly stacked upstream PR on top of that branch.

> This upstream draft therefore targets `dev` for visibility, but the intended logical review target is the turboquant delta on top of PR #185. A clean stacked draft against `feat/gemma4-support` also exists in the fork: https://github.com/lesj0610/exllamav3/pull/5

# PR Draft: Gemma4 turboquant KV cache with reduced SWA and Gemma4-local soak fixes

## Summary

This PR adds a Gemma4-specific turboquant KV-cache path with reduced SWA
capacity, role-aware page-table handling, and Gemma4-local stability fixes for
mixed text/MM serving.

This is intentionally **not** the cumulative Gemma4 support PR. `PR #185`
should contain the squashed first-stage Gemma4 support work:

- initial Gemma4 architecture support
- multimodal / vision support
- support-side Gemma4/MM fixes

This turboquant PR is the follow-up stacked on top of that support PR. It only
covers the Gemma4 cache, page-table, and runtime changes that are needed to
make the turboquant path work correctly and efficiently once Gemma4 support
exists.

## Reference snapshots used for comparison

The implementation comparisons in this PR were made against the following local
repository snapshots:

- `exllamav3`: `84004e6` (`v0.0.28-4-g84004e6`)
- `vLLM`: `1a2c17634` (`v0.19.1rc0-102-g1a2c17634`)
- `llama.cpp`: `d9a12c82f` (`b8708-9-gd9a12c82f`)

These are local working snapshots rather than release tags, so the comparison
should be read as “what was implemented in those codebases at the time this PR
was prepared,” not as a claim about all earlier or later revisions.

## Relation to other runtimes

Gemma4 already requires architecture-specific handling in other inference
engines.

- **vLLM** does not keep Gemma4 on a generic path. It has a dedicated Gemma4
  implementation and, when `kv_sharing_fast_prefill` is enabled, splits
  prefill into `Gemma4SelfDecoderLayers` and `Gemma4CrossDecoderLayers` around
  `num_kv_shared_layers`. The main optimization there is fast prefill rather
  than a reduced local KV-cache design.

- **llama.cpp** also treats Gemma4 as a dedicated ISWA model. It maintains
  separate base and SWA KV caches, builds separate `k_idxs / v_idxs / kq_mask`
  inputs for those caches, and sizes the SWA cache independently from the full
  cache. Conceptually, this is the closest external design to the one used
  here.

This PR follows the same overall direction: Gemma4 is handled through
architecture-specific hooks instead of forcing it through the generic KV-cache
assumptions. In exllamav3, that takes the form of:

- Gemma4-specific quantized KV cache layers
- Gemma4-specific reduced-SWA sizing
- Gemma4-specific role-aware page-table handling for `full` and `swa`
- Gemma4-specific compact KV fast paths
- Gemma4-local mixed text/MM stability fixes

So this PR is not introducing a special case in isolation; it brings exllamav3
in line with the fact that Gemma4 already needs dedicated cache/runtime
treatment in other mature runtimes as well.

## Why this should live upstream

Gemma4 does not fit the generic EXL3 KV-cache assumptions cleanly:

- Gemma4 mixes full/global attention with sliding-window attention.
- The sliding-window view needs a smaller local cache budget than the full
  cache budget.
- Mixed text/MM traffic needs role-aware cache-copy handling between the full
  and SWA views.
- The generic one-cache page model is not enough to preserve correctness for
  Gemma4 prompt reuse and local-window restores.

Without these changes, the Gemma4 turboquant path either wastes a large amount
of KV memory or becomes unstable under mixed text/MM churn.

## Scope

This PR adds:

- Gemma4-specific quantized KV cache layers
- Gemma4-specific reduced-SWA sizing
- Gemma4-specific role-aware page-table handling for `full` and `swa`
- Gemma4-specific compact KV fast paths
- Gemma4-specific stability fixes for mixed text/MM serving

This PR does **not** add:

- generic EXL3 serving bugfixes for unrelated models
- Gemma4 MM architecture split or vision-model support
- TP enablement for `26B-A4B`

## Non-Gemma impact

The shared changes that remain in this PR are limited to generic extension
hooks that stay on the original default path for non-Gemma models.

### What non-Gemma models do **not** do

Non-Gemma models do not opt into any of the Gemma4-specific runtime classes:

- `model.caps["page_table_cls"]` is unset
- `model.caps["cache_layer_selector"]` is unset
- `model.caps["quantized_kv_cache_layer"]` is unset

So non-Gemma models continue to use:

- the default `PageTable`
- the default `CacheLayer_quant`
- the original single-cache block-table path

### What was actually checked

I re-ran short quantized-cache generation probes on two non-Gemma models using
the default `Cache`, `Generator`, and `Job` APIs:

- `EXAONE-4.0.1-32B-EXL3-4.00bpw`
- `Magistral-Small-2509-EXL3-4.0bpw`

Observed results after the latest shared-surface cleanup:

- `page_table_cls = null`
- `cache_layer_selector = false`
- `quantized_kv_cache_layer = null`
- instantiated cache layers were plain `CacheLayer_quant`
- both models completed short quantized-cache generation successfully

Example probe outputs:

```json
{"model": "exaone", "page_table_cls": null, "cache_layer_selector": false, "quantized_kv_cache_layer": null, "cache_layer_types": ["CacheLayer_quant"], "output": "\\n\\nAnswer: Yes"}
{"model": "magistral", "page_table_cls": null, "cache_layer_selector": false, "quantized_kv_cache_layer": null, "cache_layer_types": ["CacheLayer_quant"], "output": " What is the name of"}
```

The exact text is not important here; the point of the probe is that both
non-Gemma models stay on the default quantized-cache path and complete actual
generation without opting into any Gemma4-specific classes.

I also re-ran the shared `model_init.init(...)` path on a non-Gemma model with
`cache_quant="4"` and verified that it still resolves to:

```json
{"page_table_cls": null, "cache_layer_selector": false, "quantized_kv_cache_layer": null, "cache_layer_types": ["CacheLayer_quant"]}
```

So the remaining `model_init` change is still a default-preserving constructor
hook rather than a non-Gemma runtime behavior change.

### Why the remaining shared hooks are acceptable

The remaining shared changes are:

- constructor-time cache-layer selection in `Cache`
- constructor-time page-table selection in `Generator`
- generic `PageTable` extension points used by custom pagetables

For non-Gemma models these hooks stay on the default implementation and do not
perform any Gemma4-specific tensor work, SWA bookkeeping, or extra cache
allocations.

In particular:

- `Generator` now chooses the pagetable class once at construction time.
  Non-Gemma models still instantiate the default `PageTable`.
- `Job` only talks to the generic `PageTable` interface and no longer branches
  on Gemma4-specific runtime types.
- `Cache.copy_page(..., page_plan=...)` keeps the original path unless a custom
  pagetable explicitly passes a role-aware copy plan. Non-Gemma models never do.

To keep the shared surface small, this PR intentionally does **not** add a
global `model_init --swa_cache_size` knob. Reduced-SWA configuration stays on
the Gemma4 cache path itself.

## Turboquant vs support-only baseline

To make the tradeoff concrete, I added a dedicated Gemma4 comparison harness:

- `tests/bench_gemma4_compare.py`

This compares the current turboquant branch against the support-only Gemma4
branch in isolated subprocesses so both trees can be measured with the same
workload.

The comparison below was run on the `31B` EXL3 model with:

```bash
python tests/bench_gemma4_compare.py \
  --baseline_repo_root /tmp/exllamav3_support_split \
  --current_repo_root . \
  --model_dir /ssd512g/models/gemma-4-31B-it-exl3-4bpw \
  --cache_bits 4 \
  --cache_size 4096 \
  --swa_cache_size 1024 \
  --text_repeats 2 \
  --mm_repeats 2
```

Observed result:

```json
{
  "baseline": {
    "cache_footprint_mib": 3520.0,
    "text_repeat_times_s": [1.518, 0.1036],
    "dup_same_times_s": [6.0431, 0.5146],
    "pair_animal_s": 3.2601
  },
  "current": {
    "cache_footprint_mib": 315.86,
    "text_repeat_times_s": [0.9159, 0.8855],
    "dup_same_times_s": [0.8121, 0.7562],
    "pair_animal_s": 0.7508
  },
  "comparison": {
    "cache_ratio_baseline_over_current": 11.1442,
    "cache_reduction_pct": 91.03,
    "text_first_speedup": 1.6574,
    "text_second_speedup": 0.117,
    "dup_same_first_speedup": 7.4413,
    "dup_same_second_speedup": 0.6805,
    "pair_animal_speedup": 4.3422
  }
}
```

The main takeaway is:

- turboquant reduces Gemma4 KV-cache footprint by about `91%` in this setup
- turboquant materially improves cold MM latency in the mixed-image workloads
  above
- the support-only full-cache baseline can still win on fully warmed text/MM
  reuse, which is expected because it avoids quantized-KV overhead and keeps a
  much larger cache resident

So the value of this PR is not “turboquant beats the full-cache path at every
microbenchmark.” The value is that Gemma4 gets a much smaller cache footprint,
better first-run MM behavior, and stable mixed text/MM serving without pushing
those costs onto non-Gemma models.

## Validation

### Regression tests

```bash
python -m pytest -q \
  tests/test_gemma4_turboquant.py \
  tests/test_gemma4_kv_ext.py
```

Current result:

- `63 passed, 14 warnings`
- all warnings came from the same upstream Torch deprecation:
  `torch.jit.script_method`

### Latest follow-up on the current PR head

After the initial draft was opened, the current head also addressed two
speculative generator correctness issues raised during review:

- rejected speculative tokens now roll back KV positions per sequence again
- Gemma4 draft decode now advances `cache_seqlens_full` and
  `cache_seqlens_swa` together with the default `cache_seqlens`

### Gemma4 focused repros

`26B-A4B` previously had a remaining mixed text/MM corruption where a fresh
plain-text prefill could collapse to `<pad>...` after earlier MM churn.

That path is now covered by focused runtime repros:

- fresh text forced onto later full-cache pages now returns `Inquisitive`
- `pair -> drop snapshots -> fruit -> text` now returns:
  - `pair -> First`
  - `fruit -> Strawberry`
  - `text -> Inquisitive`

### Gemma4 smoke / soak

- `31B` MM smoke: pass
- `31B` mixed soak, `seed=20260407`, `nreq=256`: `{"status":"OK","nreq":256}`
- `26B` mixed soak, `seed=20260407`, `nreq=256`: `{"status":"OK","nreq":256}`
- `26B` mixed soak, `seed=20260407`, `nreq=512`: `{"status":"OK","nreq":512}`
- earlier hard soak coverage also includes:
  - `swa=768`
  - `swa=1024`
  - dynamic prefix-churn / text-MM mode flips
  - `max_num_tokens = 262144`

## Notes on the final 26B fix

The final remaining `26B` corruption bug was fixed inside
`Gemma4PageTable.allocate_pages()`.

The bug turned out to be Gemma4-local: a fresh full-prefill could break if it
started on later full-cache page indices after prior churn. The fix keeps fresh
Gemma4 full-prefill on the stable low-index full pages, without changing the
non-Gemma page-table path.

## Known limitations

- `26B-A4B` multimodal duplicate-reasoning quality is still a weight-side model
  issue. That is separate from the fixed runtime corruption bug.
- `26B-A4B` TP semantics are still not ready to expose.
