### PR TITLE
update setup.py with current repository URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "exllamav3.loader",
         "exllamav3.util",
     ],
-    url="https://github.com/turboderp/exllamav3",
+    url="https://github.com/turboderp-org/exllamav3",
     license="MIT",
     author="turboderp",
     install_requires=[


### PR DESCRIPTION
I was on huggingface, opened an EXL3 quant, and when I clicked on the ExLlama3 link in the readme it brought me to the old repo URL which 404'd.

I assume this will fix it.

thanks