### PR TITLE
MTP speculative decoding for Qwen3.5 / Qwen3.6

### DIFF
--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -35,6 +35,7 @@ from .qwen2 import Qwen2Model
 from .qwen2_5_vl import Qwen2_5VLModel
 from .qwen3 import Qwen3Model
 from .qwen3_5 import Qwen3_5Model, Qwen3_5MoeModel, Qwen3_5VLModel, Qwen3_5VLMoeModel
+from .qwen3_5_mtp import Qwen3_5MTPDraftModel
 from .qwen3_moe import Qwen3MoeModel
 from .qwen3_next import Qwen3NextModel
 from .qwen3_vl import Qwen3VLModel
@@ -91,6 +92,7 @@ ARCHITECTURES = {
         Qwen3_5MoeModel,
         Qwen3_5VLModel,
         Qwen3_5VLMoeModel,
+        Qwen3_5MTPDraftModel,
         Qwen3MoeModel,
         Qwen3NextModel,
         Qwen3VLModel,

--- a/exllamav3/architecture/qwen3_5.py
+++ b/exllamav3/architecture/qwen3_5.py
@@ -96,6 +96,10 @@ class Qwen3_5VLBaseConfig(Config):
             self.full_attention_interval,
         )
 
+        # MTP (multi-token prediction) head — informational; head loaded as separate draft model
+        self.mtp_num_hidden_layers = self.read_cfg(int, pfx("mtp_num_hidden_layers"), 0)
+        self.mtp_use_dedicated_embeddings = self.read_cfg(bool, pfx("mtp_use_dedicated_embeddings"), False)
+
         # RoPE
         self.rope_settings = self.read_rope_settings_default(
             RopeStyle.NEOX,
@@ -212,6 +216,10 @@ class Qwen3_5VLMoeBaseConfig(Config):
             self.num_hidden_layers,
             self.full_attention_interval,
         )
+
+        # MTP (multi-token prediction) head — informational; head loaded as separate draft model
+        self.mtp_num_hidden_layers = self.read_cfg(int, pfx("mtp_num_hidden_layers"), 0)
+        self.mtp_use_dedicated_embeddings = self.read_cfg(bool, pfx("mtp_use_dedicated_embeddings"), False)
 
         # RoPE
         self.rope_settings = self.read_rope_settings_default(

--- a/exllamav3/architecture/qwen3_5_mtp.py
+++ b/exllamav3/architecture/qwen3_5_mtp.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+from typing_extensions import override
+import torch
+import weakref
+
+from ..cache import Cache
+from ..ext import exllamav3_ext as ext
+from ..model.config import Config, no_default
+from ..model.model import Model
+from ..util.rope import RopeStyle
+from ..modules import RMSNorm, Embedding, TransformerBlock, Attention, GatedMLP, Linear
+from ..modules.attn import prepare_for_attn
+from ..modules.module import no_p2p_copy
+from ..util.tensor import get_for_device
+
+
+# Synthetic architecture for the MTP head shipped alongside Qwen3.5/3.6 checkpoints.
+#
+# The MTP weights live inside the original (BF16) parent checkpoint under the "mtp." prefix
+# and are *not* part of the main exl3 quant produced by convert.py today. To use this draft:
+#
+#   - Load the target model normally (e.g. an exl3 quant of Qwen3.6-27B with MTP tensors stripped)
+#   - Load this draft model from the original BF16 directory using arch_override
+#     ("Qwen3_5MTPDraftModel") so only the mtp.* tensors are picked up
+#   - Pass the draft model to Generator(..., draft_model=draft, draft_cache=draft_cache)
+
+
+class Qwen3_5MTPDraftConfig(Config):
+    arch_string = "Qwen3_5MTPDraftModel"
+
+    def __init__(
+        self,
+        directory: str,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            {"text": Qwen3_5MTPDraftModel},
+            **kwargs
+        )
+
+        # The parent config keeps the MTP fields under text_config (LM/VL flat — try both)
+        text_cfg_dict = self.read_cfg(dict, "text_config", None)
+        text_cfg = "text_config" if text_cfg_dict is not None else None
+
+        def pfx(key):
+            return key if text_cfg is None else f"{text_cfg}->{key}"
+
+        # Attention params (same as Qwen3_5)
+        self.head_dim = self.read_cfg(int, pfx("head_dim"), None)
+        self.hidden_size = self.read_cfg(int, pfx("hidden_size"), no_default)
+        self.num_q_heads = self.read_cfg(int, pfx("num_attention_heads"), no_default)
+        self.num_kv_heads = self.read_cfg(int, pfx("num_key_value_heads"), self.num_q_heads)
+
+        if not self.head_dim:
+            self.head_dim = self.hidden_size // self.num_q_heads
+
+        # Dense MLP params
+        self.intermediate_size = self.read_cfg(int, pfx("intermediate_size"), no_default)
+
+        # Norms
+        self.rms_norm_eps = self.read_cfg(float, pfx("rms_norm_eps"), no_default)
+
+        # MTP layer count + dedicated embeddings
+        self.num_hidden_layers = self.read_cfg(int, pfx("mtp_num_hidden_layers"), 1)
+        self.mtp_use_dedicated_embeddings = self.read_cfg(bool, pfx("mtp_use_dedicated_embeddings"), False)
+        assert self.num_hidden_layers >= 1, "Qwen3_5MTPDraftConfig: mtp_num_hidden_layers must be >= 1"
+
+        # RoPE — match parent (full_attention layers in Qwen3_5 use NEOX with partial rotary factor)
+        self.rope_settings = self.read_rope_settings_default(
+            RopeStyle.NEOX,
+            default_rope_theta = 10000000,
+            config_dict = self.read_cfg(dict, "text_config", no_default) if text_cfg else None,
+        )
+
+        # Vision placeholders (draft is text-only)
+        self.vision = None
+        self.vision_pp = None
+
+
+class Qwen3_5MTPDraftModel(Model):
+    config_class = Qwen3_5MTPDraftConfig
+
+    def __init__(
+        self,
+        config: Qwen3_5MTPDraftConfig,
+        **kwargs
+    ):
+        super().__init__(config, **kwargs)
+
+        # Pre-fc norms applied to incoming hidden state and embeddings before they get concatenated
+        self.pre_fc_norm_hidden = RMSNorm(
+            config = config,
+            key = "mtp.pre_fc_norm_hidden",
+            rms_norm_eps = config.rms_norm_eps,
+            constant_bias = 1.0,
+            out_dtype = torch.half,
+        )
+        self.pre_fc_norm_embedding = RMSNorm(
+            config = config,
+            key = "mtp.pre_fc_norm_embedding",
+            rms_norm_eps = config.rms_norm_eps,
+            constant_bias = 1.0,
+            out_dtype = torch.half,
+        )
+
+        # 2H -> H projection
+        self.fc = Linear(
+            config = config,
+            key = "mtp.fc",
+            in_features = config.hidden_size * 2,
+            out_features = config.hidden_size,
+            qmap = "block.mtp.fc",
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+
+        # Optional dedicated embedding (rare; default false for Qwen3.6)
+        self.dedicated_embedding = None
+        if config.mtp_use_dedicated_embeddings:
+            self.dedicated_embedding = Embedding(
+                config = config,
+                key = "mtp.embed_tokens",
+                vocab_size = config.vocab_size,
+                hidden_size = config.hidden_size,
+            )
+
+        # Module list: optional embed, then pre_fc norms + fc, then num_mtp_layers * TransformerBlock, then norm
+        # All modules are present here purely so the standard loader walks them and loads weights;
+        # forward iteration is bypassed (we call step() manually from the generator).
+        self.modules = []
+        if self.dedicated_embedding is not None:
+            self.modules.append(self.dedicated_embedding)
+        self.modules.append(self.pre_fc_norm_hidden)
+        self.modules.append(self.pre_fc_norm_embedding)
+        self.modules.append(self.fc)
+
+        self.first_block_idx = len(self.modules)
+        self.attn_modules = []
+
+        for idx in range(config.num_hidden_layers):
+            attn = Attention(
+                config = config,
+                key = f"mtp.layers.{idx}.self_attn",
+                layer_idx = idx,
+                hidden_size = config.hidden_size,
+                head_dim = config.head_dim,
+                num_q_heads = config.num_q_heads,
+                num_kv_heads = config.num_kv_heads,
+                rope_settings = config.rope_settings,
+                sm_scale = None,
+                key_q = "q_proj",
+                key_k = "k_proj",
+                key_v = "v_proj",
+                key_o = "o_proj",
+                qmap = "block.attn",
+                q_norm = RMSNorm(
+                    config = config,
+                    key = f"mtp.layers.{idx}.self_attn.q_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    constant_bias = 1.0,
+                ),
+                k_norm = RMSNorm(
+                    config = config,
+                    key = f"mtp.layers.{idx}.self_attn.k_norm",
+                    rms_norm_eps = config.rms_norm_eps,
+                    constant_bias = 1.0,
+                ),
+                out_dtype = torch.float,
+                interleaved_gate = True,
+            )
+            self.attn_modules.append(attn)
+
+            self.modules.append(
+                TransformerBlock(
+                    config = config,
+                    key = f"mtp.layers.{idx}",
+                    layer_idx = idx,
+                    attn_norm = RMSNorm(
+                        config = config,
+                        key = f"mtp.layers.{idx}.input_layernorm",
+                        rms_norm_eps = config.rms_norm_eps,
+                        constant_bias = 1.0,
+                    ),
+                    attn = attn,
+                    mlp_norm = RMSNorm(
+                        config = config,
+                        key = f"mtp.layers.{idx}.post_attention_layernorm",
+                        rms_norm_eps = config.rms_norm_eps,
+                        constant_bias = 1.0,
+                    ),
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"mtp.layers.{idx}.mlp",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.intermediate_size,
+                        key_up = "up_proj",
+                        key_gate = "gate_proj",
+                        key_down = "down_proj",
+                        qmap = "block.mlp",
+                        interm_dtype = torch.half,
+                        out_dtype = torch.float,
+                    ),
+                )
+            )
+
+        self.last_kv_module_idx = len(self.modules) - 1
+
+        # Final norm
+        self.final_norm = RMSNorm(
+            config = config,
+            key = "mtp.norm",
+            rms_norm_eps = config.rms_norm_eps,
+            out_dtype = torch.half,
+            constant_bias = 1.0,
+        )
+        self.modules.append(self.final_norm)
+
+        self.caps.update({
+            "supports_tp": False,
+            "attach_target": True,
+            "qwen3_5_mtp_draft": True,
+            "default_draft_size": 2,  # MTP-1 with 2-step recurrence
+            "autosplit_load_fwd": False,
+        })
+
+        # Cross-references populated by attach_to()
+        self.target_embed = None
+        self.target_lm_head = None
+
+    @property
+    def _emb_module(self):
+        """Embedding module to use: dedicated if present, else target's."""
+        return self.dedicated_embedding if self.dedicated_embedding is not None else self.target_embed()
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        # MTP doesn't take input_ids through Embedding here — embedding is handled in step()
+        # But prepare_for_attn still wires up flash-attn params
+        return prepare_for_attn(input_ids, params)
+
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        raise NotImplementedError("MTP draft model does not have its own chat template")
+
+
+    def attach_to(self, target):
+        """Bind to target model: borrow embed_tokens / lm_head and tell target to export hidden state.
+
+        We need the trunk's PRE-final-norm hidden state (residual stream after the last transformer
+        block, before output_norm). MTP's pre_fc_norm_hidden does its own normalization on top of
+        that — feeding post-norm here would double-normalize and hurt acceptance. See llama.cpp PR
+        ggml-org/llama.cpp#22673 (`t_h_pre_norm` capture in qwen35.cpp).
+        """
+        target_modules = target.modules
+
+        # Find the target's embedding (first module of class Embedding)
+        target_embed = None
+        for m in target_modules:
+            if isinstance(m, Embedding):
+                target_embed = m
+                break
+        assert target_embed is not None, "Could not locate target's Embedding module"
+        self.target_embed = weakref.ref(target_embed)
+
+        # lm_head is the last module
+        assert isinstance(target_modules[-1], Linear), "Expected Linear lm_head as last target module"
+        self.target_lm_head = weakref.ref(target_modules[-1])
+
+        # Find the last TransformerBlock and mark it to export its output residual stream
+        # (= pre-final-norm hidden). Iterate from the end since vision variants may have
+        # DeepstackEmbed/other modules between the last block and output_norm.
+        last_block = None
+        for m in reversed(target_modules):
+            if isinstance(m, TransformerBlock):
+                last_block = m
+                break
+        assert last_block is not None, "Could not locate a TransformerBlock in target to mark for export"
+        last_block.export_state = True
+        self.draft_verifier_params.update({
+            "export_state_layers": {last_block.layer_idx},
+        })
+
+
+    @override
+    def forward(self, input_ids: torch.Tensor, params: dict | None = None):
+        """
+        Convenience forward — caller provides:
+          input_ids:    (bsz, num_steps)  ids to embed at each draft step
+          params["target_hidden"]:  (bsz, 1, H)  starting hidden state — the trunk's residual stream
+            captured BEFORE its final norm (= TransformerBlock.export_state on target's last block).
+          params["block_table"], ["cache_seqlens"], ["cache"], ["attn_mode"="flash_attn"]
+
+        Returns logits stacked along seq dim: (bsz, num_steps, vocab_size).
+        Use generator's iterate_draftmodel_mtp_gen for the integrated drafting flow.
+        """
+        if params is None:
+            params = {}
+        target_hidden = params.get("target_hidden")
+        assert target_hidden is not None, "MTP draft forward requires params['target_hidden']"
+
+        bsz, num_steps = input_ids.shape
+        last_hidden = target_hidden
+        cache_seqlens = params.get("cache_seqlens")
+        all_logits = []
+
+        for step_idx in range(num_steps):
+            step_params = dict(params)
+            if cache_seqlens is not None:
+                step_params["cache_seqlens"] = cache_seqlens
+            ids_step = input_ids[:, step_idx:step_idx+1]
+            new_hidden, logits = self.step(ids_step, last_hidden, step_params, layer_step = step_idx)
+            all_logits.append(logits)
+            last_hidden = new_hidden
+            if cache_seqlens is not None:
+                cache_seqlens = cache_seqlens + 1
+
+        return torch.cat(all_logits, dim = 1)
+
+    def _to_dev(self, t: torch.Tensor, dst: torch.device) -> torch.Tensor:
+        """Move tensor to device, honoring EXLLAMA_NO_P2P_COPY (host bounce)."""
+        if t.device == dst:
+            return t
+        return t.cpu().to(dst) if no_p2p_copy else t.to(dst)
+
+
+    def step(
+        self,
+        last_token_ids: torch.Tensor,
+        last_hidden: torch.Tensor,
+        params: dict,
+        layer_step: int = 0,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Run one MTP step.
+
+          last_token_ids: (bsz, 1) — id of the previously sampled / verified token
+          last_hidden:    (bsz, 1, hidden_size) — PRE-final-norm hidden state (residual stream)
+                            — for k=0 this is target.last_block's residual; for k>=1 it's the
+                              previous step's returned new_hidden (MTP block's residual output).
+                              Matches llama.cpp's `t_h_pre_norm` / `t_mtp_out` convention.
+          params:         flash-attn params (cache, block_table, cache_seqlens, ...)
+          layer_step:     which MTP layer to use (mod num_hidden_layers)
+
+        Returns:
+          new_hidden:  (bsz, 1, hidden_size)  MTP block's residual output (pre-MTP-final-norm),
+                                              feed back as last_hidden on the next step.
+          logits:      (bsz, 1, vocab_size)   computed via final_norm + lm_head on a separate path.
+        """
+        # Embed last token — keep ids on the embedding's own device (target embed has prefer_cpu=True)
+        emb_module = self._emb_module
+        last_token_ids = self._to_dev(last_token_ids, emb_module.device)
+        embed = emb_module.forward(last_token_ids, params)
+
+        # Pre-fc norms — RMSNorm.forward doesn't auto-move x, so explicitly land x on each norm's device
+        # before running it, then bring outputs to fc.device for the cat. Honors EXLLAMA_NO_P2P_COPY.
+        embed_for_norm = self.pre_fc_norm_embedding.prepare_for_device(embed, params).half()
+        h_for_norm = self.pre_fc_norm_hidden.prepare_for_device(last_hidden, params).half()
+        embed_n = self.pre_fc_norm_embedding.forward(embed_for_norm, params, out_dtype = torch.half)
+        h_n = self.pre_fc_norm_hidden.forward(h_for_norm, params, out_dtype = torch.half)
+        embed_n = self.fc.prepare_for_device(embed_n, params)
+        h_n = self.fc.prepare_for_device(h_n, params)
+
+        # Concatenate and project: [embed | hidden] -> hidden
+        cat = torch.cat([embed_n, h_n], dim = -1)
+        x = self.fc.forward(cat, params, out_dtype = torch.half)
+
+        # Run MTP transformer block — TransformerBlock's submodules (attn_norm/attn/mlp_norm/mlp) assume
+        # x is already on the block's device, so move x explicitly. (Mirrors what Model.forward_ls does
+        # for top-level modules.)
+        layer_idx = layer_step % len(self.attn_modules)
+        block = self.modules[self.first_block_idx + layer_idx]
+        x = block.prepare_for_device(x, params)
+        x = block.forward(x, params)
+
+        # Block output is the residual stream (pre-final-norm). This is what the NEXT AR step
+        # consumes — pre_fc_norm_hidden expects pre-norm input. Matches llama.cpp's `t_mtp_out`
+        # lm_head needs post-norm so we norm a copy.
+        new_hidden = x
+
+        # Apply final norm + lm_head on a separate path (don't propagate post-norm to next step)
+        x_normed = self.final_norm.prepare_for_device(x, params)
+        x_normed = self.final_norm.forward(x_normed, params, out_dtype = torch.half)
+        lm_head = self.target_lm_head()
+        x_for_head = lm_head.prepare_for_device(x_normed, params)
+        logits = lm_head.forward(x_for_head, params)
+        return new_hidden, logits
+
+
+    def update_kv_from_target(
+        self,
+        shifted_tokens: torch.Tensor,
+        shifted_hiddens: torch.Tensor,
+        cache: Cache,
+        params: dict,
+    ) -> None:
+        """
+        Write MTP K/V at slots [start, start + n - 1] using already-aligned input pairs.
+
+        K/V convention: slot p = fc(concat[embed(token@(p+1)), hidden@p]).
+        Caller is responsible for the shift — pass:
+          shifted_tokens[k]  = token at position (start + k + 1)
+          shifted_hiddens[k] = hidden at position (start + k)
+          params["cache_seqlens"] = (bsz,) tensor of `start` per batch element
+
+        Both inputs have shape (bsz, n, ...).
+        """
+        assert len(self.attn_modules) == 1, \
+            "update_kv_from_target currently supports a single MTP layer (Qwen3.6 default)"
+        layer = self.attn_modules[0]
+
+        device = self.fc.device
+        bsz, n, hsz = shifted_hiddens.shape
+        assert shifted_tokens.shape == (bsz, n), \
+            f"shifted_tokens must be (bsz={bsz}, n={n}); got {tuple(shifted_tokens.shape)}"
+
+        # Embed token ids — Embedding may live on CPU (prefer_cpu); land ids on its device first.
+        ids_for_embed = self._to_dev(shifted_tokens, self._emb_module.device)
+        embeds = self._emb_module.forward(ids_for_embed, {})
+
+        # Pre-fc norms — RMSNorm.forward doesn't auto-move x, so land on each norm's device first.
+        embeds_for_norm = self._to_dev(embeds, self.pre_fc_norm_embedding.device).half()
+        hidden_for_norm = self._to_dev(shifted_hiddens, self.pre_fc_norm_hidden.device).half()
+        embeds_n = self.pre_fc_norm_embedding.forward(embeds_for_norm, {}, out_dtype = torch.half)
+        hidden_n = self.pre_fc_norm_hidden.forward(hidden_for_norm, {}, out_dtype = torch.half)
+        embeds_n = self._to_dev(embeds_n, device)
+        hidden_n = self._to_dev(hidden_n, device)
+
+        # fc projection
+        cat = torch.cat([embeds_n, hidden_n], dim = -1)
+        x = self.fc.forward(cat, {}, out_dtype = torch.half)
+
+        # Move to layer.device for k/v projections
+        x = self._to_dev(x, layer.device)
+
+        block_table = get_for_device(params, "block_table", layer.device)
+        cache_seqlens = get_for_device(params, "cache_seqlens", layer.device)
+
+        # k/v project + RoPE
+        k = layer.k_proj.forward(x, {})
+        v = layer.v_proj.forward(x, {})
+        k = k.view(bsz, n, layer.num_kv_heads, layer.head_dim)
+        v = v.view(bsz, n, layer.num_kv_heads, layer.head_dim)
+
+        if layer.rope:
+            k, _ = layer.rope.apply(
+                k, None,
+                0,
+                cache_seqlens,
+                None,
+                True,
+                layer.k_norm_tensor,
+                None,
+                layer.norm_eps,
+                layer.norm_constant_bias,
+                None,
+                False,
+            )
+
+        cache_k, cache_v = cache.get_layer(layer.layer_idx, cache_seqlens, block_table, -1, 0)
+        ext.paged_kv_cache_update(k, v, cache_k, cache_v, block_table, cache_seqlens)
+        cache.update_layer(layer.layer_idx, cache_seqlens, block_table, cache_k, cache_v, n, 0)
+
+
+    def default_load_shape_dtype(self, chunk_size):
+        return (1, 1), torch.long
+
+
+    def default_load_params(self, max_chunk_size):
+        return {}

--- a/exllamav3/generator/async_generator.py
+++ b/exllamav3/generator/async_generator.py
@@ -75,7 +75,8 @@ class AsyncGenerator:
     async def cancel(self, job: AsyncJob):
         # Remove the underlying Job from the synchronous generator first so no new tokens are produced, then drop
         # the async mapping so any late results from an in-flight iteration are ignored.
-        assert job.job in self.jobs
+        if job.job not in self.jobs:
+            return
         self.generator.cancel(job.job)
         del self.jobs[job.job]
 
@@ -113,5 +114,5 @@ class AsyncJob:
     async def cancel(self):
         # Delegate cancellation to the wrapper so it can update both the sync generator queue and the async job map,
         # then mark this iterator as closed for any current or future consumers.
-        await self.generator.cancel(self)
         self.cancelled = True
+        await self.generator.cancel(self)

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -190,6 +190,8 @@ class Generator:
         if draft_model is not None and draft_model.caps.get("attach_target"):
             draft_model.attach_to(model)
         self.dflash_draft = self.draft_model is not None and self.draft_model.caps.get("dflash_draft", False)
+        self.mtp_draft = self.draft_model is not None and self.draft_model.caps.get("qwen3_5_mtp_draft", False)
+        self.mtp_last_hidden = None  # per-job last_hidden dict, lazily created when mtp_draft
 
 
     def num_remaining_jobs(self):
@@ -352,6 +354,9 @@ class Generator:
             if self.dflash_draft:
                 draft_tokens = self.iterate_draftmodel_dflash_gen(results)
                 self.iterate_gen(results, draft_tokens)
+            elif self.mtp_draft:
+                draft_tokens = self.iterate_draftmodel_mtp_gen(results)
+                self.iterate_gen(results, draft_tokens)
             else:
                 draft_tokens = self.iterate_draftmodel_gen(results)
                 self.iterate_gen(results, draft_tokens)
@@ -459,6 +464,104 @@ class Generator:
                 "cache_seqlens": cache_seqlens
             }
         )
+
+        return self.draft_ids_pinned
+
+
+    def iterate_draftmodel_mtp_gen(self, results: list):
+        """
+        Recurrent MTP-1 drafting (Qwen3.5/3.6 NEXTN-style). Each step embeds the previous token,
+        concats with previous hidden state, runs the MTP block + lm_head, samples greedy.
+        Requires that the previous iterate_gen has populated self.mtp_last_hidden[job.serial_number].
+        """
+
+        # Get shape of active batch
+        batch_size = 0
+        max_seq_len = 0
+        for job in self.active_jobs:
+            if not job.is_prefill_done(): continue
+            max_seq_len = max(max_seq_len, job.get_max_seq_len() + self.num_draft_tokens + 1)
+            batch_size += 1
+        if batch_size == 0:
+            return None
+
+        # Lazy-init per-job hidden state dict
+        if self.mtp_last_hidden is None:
+            self.mtp_last_hidden = {}
+
+        # Seed mtp_last_hidden from prefill carry on the very first round (before iterate_gen has populated it)
+        for job in self.active_jobs:
+            if not job.is_prefill_done(): continue
+            if self.mtp_last_hidden.get(job.serial_number) is None:
+                seq0 = job.sequences[0]
+                if getattr(seq0, "mtp_carry_hidden", None) is not None:
+                    self.mtp_last_hidden[job.serial_number] = seq0.mtp_carry_hidden
+
+        # Skip drafting on jobs that still have no target_hidden (no prefill carry, no iterate yet)
+        all_have_hidden = all(
+            self.mtp_last_hidden.get(job.serial_number) is not None
+            for job in self.active_jobs if job.is_prefill_done()
+        )
+        if not all_have_hidden:
+            return None
+
+        # Block table + cache_seqlens for batch
+        # MTP convention: K/V at MTP slot p = (token@(p+1), hidden@p). To predict token@(K+1) where K
+        # = seq.kv_position, MTP step writes slot K-1. So cache_seqlens for the FIRST step = K-1.
+        max_pages_batch = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+        block_index = torch.zeros((batch_size, max_pages_batch), dtype = torch.int32)
+        cache_seqlens = torch.zeros((batch_size,), dtype = torch.int32)
+        batch = 0
+        for job in self.active_jobs:
+            if not job.is_prefill_done(): continue
+            for seq in job.sequences:
+                seq_block_index = seq.block_index_tensor[:, :max_pages_batch]
+                block_index[batch:batch+1, :seq_block_index.shape[-1]].copy_(seq_block_index)
+                cache_seqlens[batch] = seq.kv_position - 1
+                batch += 1
+
+        # MM embeddings not supported with MTP draft; multi-sequence jobs (CFG) also unsupported
+        # because mtp_last_hidden is tracked per-job, not per-sequence
+        for job in self.active_jobs:
+            if not job.is_prefill_done(): continue
+            assert not job.embeddings, "MM embeddings not supported with MTP draft model."
+            assert len(job.sequences) == 1, "Multi-sequence jobs (e.g. CFG) not supported with MTP draft."
+
+        # Collect last id and last_hidden for each batch element
+        input_ids_list = []
+        hidden_list = []
+        for job in self.active_jobs:
+            if not job.is_prefill_done(): continue
+            ids = job.get_input_ids_list()
+            input_ids_list += ids
+            hidden_list.append(self.mtp_last_hidden[job.serial_number])
+
+        batch_ids = self.draft_input_ids_pinned[:batch_size, :]
+        batch_ids.copy_(torch.cat(input_ids_list, dim = 0))
+        target_hidden = torch.cat(hidden_list, dim = 0)  # (bsz, 1, H)
+
+        # Drafting loop — one MTP step per draft token. Step k writes K/V at slot (kv_position - 1 + k)
+        # from input pair (last_id, last_hidden). Output predicts the (k+1)-th draft token.
+        last_ids = batch_ids
+        last_hidden = target_hidden
+        for idx in range(self.num_draft_tokens):
+            params = {
+                "attn_mode": "flash_attn",
+                "block_table": block_index,
+                "cache": self.draft_cache,
+                "cache_seqlens": cache_seqlens,
+            }
+            new_hidden, logits = self.draft_model.step(
+                last_token_ids = last_ids,
+                last_hidden = last_hidden,
+                params = params,
+                layer_step = idx,
+            )
+            new_ids = torch.argmax(logits, dim = -1)
+            self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
+            last_ids = new_ids
+            last_hidden = new_hidden
+            cache_seqlens.add_(1)
 
         return self.draft_ids_pinned
 
@@ -774,6 +877,63 @@ class Generator:
                     "cache_seqlens": p_cache_seqlens,
                 }
             )
+
+        # Capture target's last-position post-norm hidden state per job, for next MTP draft round.
+        # Also backfill MTP K/V cache for the just-verified positions, replacing step's drafter-K/V
+        # with target's actual K/V (MTP convention: slot p stores (token@(p+1), main_hidden@p)).
+        if self.mtp_draft:
+            export_states = p_export_states
+            if export_states:
+                target_hidden_full = export_states[-1]  # (batch_size, num_tokens_per_batch, H)
+                done_jobs = set(id(j) for j in completed_jobs) | set(id(j) for j in requeuing_jobs)
+                jb = 0
+                for idx, (job, a_idx, b_idx) in enumerate(zip(self.active_jobs, logit_mapping[:-1], logit_mapping[1:])):
+                    if a_idx == b_idx: continue
+                    if id(job) in done_jobs:
+                        jb += 1
+                        continue  # job is finishing this iter; no point seeding next-round state
+                    accepted_length = accepted_lengths[jb] if jb < len(accepted_lengths) else 1
+                    pos_idx = accepted_length - 1  # last accepted position relative to this iter's input span
+                    if target_hidden_full.dim() == 3:
+                        h = target_hidden_full[a_idx:a_idx+1, pos_idx:pos_idx+1, :].clone()
+                    else:
+                        flat_pos = a_idx * target_hidden_full.shape[0] // max(1, batch_size) + pos_idx
+                        h = target_hidden_full[flat_pos:flat_pos+1, :].unsqueeze(0).clone()
+                    self.mtp_last_hidden[job.serial_number] = h
+
+                    # Per-job MTP K/V backfill for accepted positions.
+                    # For acc >= 2: write (acc-1) entries at slots [K, K+acc-2] from
+                    #   shifted_tokens[k]  = sequence_ids[K+1+k]   (committed, drafted-and-accepted)
+                    #   shifted_hiddens[k] = main_hidden@(K+k)     (= target_hidden_full[a_idx, k])
+                    # for k in [0, acc-2].
+                    if accepted_length >= 2:
+                        seq0 = job.sequences[0]
+                        K = seq0.kv_position - accepted_length  # kv_position_pre for this iter
+                        n_back = accepted_length - 1
+                        if target_hidden_full.dim() == 3:
+                            shifted_hiddens = target_hidden_full[a_idx:a_idx+1, 0:n_back, :].clone()
+                        else:
+                            flat_a = a_idx * target_hidden_full.shape[0] // max(1, batch_size)
+                            shifted_hiddens = target_hidden_full[flat_a:flat_a+n_back, :].unsqueeze(0).clone()
+                        # Pull just-committed token ids from sequence_ids
+                        shifted_tokens = seq0.sequence_ids.torch_slice(K + 1, K + accepted_length)
+                        self.draft_model.update_kv_from_target(
+                            shifted_tokens = shifted_tokens,
+                            shifted_hiddens = shifted_hiddens,
+                            cache = self.draft_cache,
+                            params = {
+                                "block_table": seq0.block_index_tensor,
+                                "cache_seqlens": torch.tensor([K], dtype = torch.int32),
+                            },
+                        )
+                    jb += 1
+
+        # Drop MTP hidden state for completed/requeuing jobs
+        if self.mtp_draft and self.mtp_last_hidden is not None:
+            for job in completed_jobs + requeuing_jobs:
+                self.mtp_last_hidden.pop(job.serial_number, None)
+            if not self.mtp_last_hidden:
+                self.mtp_last_hidden = None
 
         # Release pages for completed jobs. Finished and requeued jobs no longer need their active page references.
         # Requeued recurrent jobs may stash the last checkpoint first so the next queued job can resume from cached

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -1106,6 +1106,49 @@ class Job:
                             "cache_seqlens": params["cache_seqlens"],
                         }
                     )
+                elif self.generator.mtp_draft:
+                    # MTP convention: cache slot p stores K/V from (token@(p+1), hidden@p).
+                    # For chunk covering positions [a, a+n-1] with target_hidden = [hidden@a, ..., hidden@(a+n-1)]
+                    # and prefill_ids = [token@a, ..., token@(a+n-1)], we can fill:
+                    #   - slot a-1 from (token@a, carry=hidden@(a-1))    -- only if a>=1 and carry is available
+                    #   - slots [a, a+n-2] from (token@(a+1+k), hidden@(a+k)) for k in [0, n-2]
+                    # The last slot in the chunk (a+n-1) stays empty until the NEXT chunk arrives
+                    # (or until job.prefill's iter-1 path picks up the held-back last prompt token).
+                    exports = params.get("export_states") or []
+                    if exports:
+                        target_hidden_seq = exports[-1]
+                        if target_hidden_seq.dim() == 2:
+                            target_hidden_seq = target_hidden_seq.unsqueeze(0)
+                        bsz, n, _ = target_hidden_seq.shape
+
+                        a = prefill_start  # absolute position of chunk start
+
+                        # Carry-fill at slot a-1
+                        if a >= 1 and seq.mtp_carry_hidden is not None:
+                            self.generator.draft_model.update_kv_from_target(
+                                shifted_tokens = prefill_ids[:, 0:1],
+                                shifted_hiddens = seq.mtp_carry_hidden,
+                                cache = self.generator.draft_cache,
+                                params = {
+                                    "block_table": seq.block_index_tensor,
+                                    "cache_seqlens": torch.tensor([a - 1] * bsz, dtype = torch.int32),
+                                },
+                            )
+
+                        # Chunk-local: write n-1 entries at slots [a, a+n-2]
+                        if n >= 2:
+                            self.generator.draft_model.update_kv_from_target(
+                                shifted_tokens = prefill_ids[:, 1:n],
+                                shifted_hiddens = target_hidden_seq[:, 0:n-1, :],
+                                cache = self.generator.draft_cache,
+                                params = {
+                                    "block_table": seq.block_index_tensor,
+                                    "cache_seqlens": torch.tensor([a] * bsz, dtype = torch.int32),
+                                },
+                            )
+
+                        # Update carry = last hidden of this chunk (for next chunk's slot (a+n-1))
+                        seq.mtp_carry_hidden = target_hidden_seq[:, -1:, :].clone().half()
                 elif self.generator.draft_model:
                     self.generator.draft_model.prefill(
                         input_ids = prefill_ids,

--- a/exllamav3/generator/pagetable.py
+++ b/exllamav3/generator/pagetable.py
@@ -193,6 +193,10 @@ class Sequence:
         # Multimodal token spans
         self.multimodal_mask = ids[0] >= FIRST_MM_EMBEDDING_INDEX
 
+        # MTP carry hidden — last hidden state of the previous prefill chunk, used to seed
+        # the prev_hidden shift in update_kv_from_target. None until first prefill chunk runs.
+        self.mtp_carry_hidden = None
+
 
     def prepare(self, has_prefix_token: bool, max_new_tokens: int):
         self.page_hashes = []

--- a/exllamav3/model/config.py
+++ b/exllamav3/model/config.py
@@ -15,6 +15,7 @@ class Config(ABC):
         directory: str,
         model_classes: dict,
         layer_map: list[int] | str | None = None,
+        arch_override: str | None = None,
         **kwargs,
     ):
         """
@@ -44,13 +45,18 @@ class Config(ABC):
         with open(self.config_filename, encoding = "utf8") as f:
             self.config_dict = json.load(f)
 
-        assert len(self.config_dict["architectures"]) == 1, \
-            f"Multiple architectures defined in {self.config_filename}"
+        if arch_override is None:
+            assert len(self.config_dict["architectures"]) == 1, \
+                f"Multiple architectures defined in {self.config_filename}"
 
-        arch = self.config_dict["architectures"][0]
-        assert arch == self.arch_string, \
-            f"Unexpected architecture {arch} in {self.config_filename}, should be {self.arch_string}."
-        self.architecture = arch
+            arch = self.config_dict["architectures"][0]
+            assert arch == self.arch_string, \
+                f"Unexpected architecture {arch} in {self.config_filename}, should be {self.arch_string}."
+            self.architecture = arch
+        else:
+            assert arch_override == self.arch_string, \
+                f"arch_override {arch_override} does not match config class arch_string {self.arch_string}"
+            self.architecture = arch_override
 
         # Collect all .safetensors files in directory
         self.stc = SafetensorsCollection(directory, load_method = kwargs.get("load_method"))
@@ -133,12 +139,16 @@ class Config(ABC):
 
 
     @staticmethod
-    def from_directory(directory: str, **kwargs) -> Config:
+    def from_directory(directory: str, arch_override: str | None = None, **kwargs) -> Config:
         """
         Create config from the specified directory if it contains a HF model of a supported architecture
 
         :param directory:
             Directory containing model files
+
+        :param arch_override:
+            If set, ignore the config.json's "architectures" entry and load this architecture instead.
+            Used e.g. to load a Qwen3.6 BF16 directory as a MTP-only draft model.
 
         :param kwargs:
             load_method:
@@ -155,15 +165,19 @@ class Config(ABC):
         with open(config_filename, encoding = "utf8") as f:
             config_dict = json.load(f)
 
-        assert "architectures" in config_dict, f"No architecture defined in {config_filename}"
-        archs = config_dict["architectures"]
-        assert len(archs) == 1, f"Multiple architectures defined in {config_filename}"
-        arch = archs[0]
-        assert arch in architectures, f"Unknown architecture {arch} in {config_filename}"
+        if arch_override is not None:
+            assert arch_override in architectures, f"Unknown arch_override {arch_override}"
+            arch = arch_override
+        else:
+            assert "architectures" in config_dict, f"No architecture defined in {config_filename}"
+            archs = config_dict["architectures"]
+            assert len(archs) == 1, f"Multiple architectures defined in {config_filename}"
+            arch = archs[0]
+            assert arch in architectures, f"Unknown architecture {arch} in {config_filename}"
 
         arch_def = architectures[arch]
         config_class = arch_def["config_class"]
-        config = config_class(directory, **kwargs)
+        config = config_class(directory, arch_override = arch_override, **kwargs)
         return config
 
 

--- a/exllamav3/model_init.py
+++ b/exllamav3/model_init.py
@@ -94,6 +94,11 @@ def add_args(
     if add_draft_model_args:
         parser.add_argument("-dm", "--draft_model_dir", type = str, help = "Path to draft model directory", default = None)
         parser.add_argument("-ndt", "--num_draft_tokens", type = int, help = "Number of draft tokens (default: draft model default, else 4)", default = None)
+        parser.add_argument(
+            "-dm_arch", "--draft_arch_override", type = str, default = None,
+            help = "Override the draft model's arch_string. Use 'Qwen3_5MTPDraftModel' to load only the "
+                   "MTP head from a Qwen3.5/3.6 BF16 directory."
+        )
 
 
 def get_arg_sampler(args):
@@ -167,11 +172,15 @@ def init(
 
     return_draft = "draft_model_dir" in args
     draft_model_dir = args.draft_model_dir if return_draft else None
+    draft_arch_override = getattr(args, "draft_arch_override", None) if return_draft else None
 
     # Config
     config = Config.from_directory(args.model_dir, layer_map = args.layer_map)
     if override_dynamic_seq_len: config.override_dynamic_seq_len(override_dynamic_seq_len)
-    draft_config = Config.from_directory(draft_model_dir) if draft_model_dir else None
+    draft_config = Config.from_directory(
+        draft_model_dir,
+        arch_override = draft_arch_override,
+    ) if draft_model_dir else None
 
     # Override tensors
     if args.override:


### PR DESCRIPTION
## Multi-Token Prediction (MTP) speculative decoding for Qwen3.5 / Qwen3.6

Adds integrated MTP draft model support for Qwen3.5/3.6 models, enabling speculative decoding via the native MTP head shipped alongside these models.

### Overview

Introduces `Qwen3_5MTPDraftModel`, a synthetic draft architecture that loads only the `mtp.*` tensors from the original BF16 checkpoint and borrows `embed_tokens` / `lm_head` from the target model via weakrefs. The MTP head is a single transformer block plus a 2H->H projection over `[embed(token), hidden]`, supporting recurrent multi-step drafting (NEXTN-style).

Unlike standard draft models, MTP requires the target's **pre-final-norm** hidden state (residual stream after the last transformer block, before `output_norm`). Feeding post-norm would double-normalize and hurt acceptance rates.

### Changes

**Architecture** (`qwen3_5_mtp.py`):
- `attach_to()` binds to target model, marks last `TransformerBlock` to export its pre-final-norm residual stream
- `step()` embeds token, RMSNorms both embedding and hidden, concatenates, projects through `fc`, runs MTP block, returns residual hidden + logits
- `update_kv_from_target()` backfills MTP K/V cache from target hidden states (slot p stores `(token@(p+1), hidden@p)`)

**Generator** (`generator.py`):
- `iterate_draftmodel_mtp_gen()` — recurrent drafting loop; one MTP step per draft token, writing K/V at correct cache slots (lagging target by 1)
- Post-verification: captures `export_states` to seed next round's `last_hidden`, backfills accepted-position K/V with target-actual values
- Fixes pre-existing `states[idx]` → `states[j]` indexing bug in recurrent state rewind (only affected models with `recurrent_cache`)

**Prefill** (`job.py`):
- After each prefill chunk, backfills MTP draft cache from exported hidden states
- Threads `seq.mtp_carry_hidden` across chunks for slot continuity

**Config** (`config.py`):
- `arch_override` parameter on `Config.from_directory()` allows loading a Qwen3.5/3.6 BF16 directory as `Qwen3_5MTPDraftModel`, picking up only `mtp.*` tensors despite `config.json` declaring `Qwen3_5ForConditionalGeneration`

**CLI** (`model_init.py`):
- New `-dm_arch` / `--draft_arch_override` flag

**Other**:
- Registers `mtp_num_hidden_layers` / `mtp_use_dedicated_embeddings` in Qwen3_5 config (informational; head loaded as separate draft model)
- Adds `mtp_carry_hidden` slot on `Sequence` for cross-chunk hidden threading
- `LinearEXL3`: removes unnecessary `rows <= 32` threshold check on fast path

### Limitations

- Multi-sequence jobs (CFG) not supported with MTP draft
- Multimodal embeddings not supported with MTP draft
- `update_kv_from_target()` currently supports a single MTP layer (Qwen3.6 default)
- MTP draft model loaded in BF16 (not yet supported by exl3 quant converter)

### AI Disclosure
Most of this was written by AI (a combination of Claude Opus and Qwen3.6 27B) under my guidance. I did steer them and read through it to ensure they weren't doing anything obviously stupid, but I don't have the math or ML background to verify their algorithm changes are correct. I can only verify that it works empirically.

I have tested this locally with tabbyAPI ([with some changes to pass the new arguments](https://github.com/theroyallab/tabbyAPI/pull/421)), and I get a more than 2x token generation speedup on my 5070ti + 3060ti. The output is coherent and indistinguishable to me from without MTP. Prompt processing does take a bit of a hit though (~33% slower).