### PR TITLE
Fix streaming buffer in AsyncGenerator

### DIFF
--- a/exllamav3/generator/async_generator.py
+++ b/exllamav3/generator/async_generator.py
@@ -69,7 +69,7 @@ class AsyncJob:
     def __init__(self, generator: AsyncGenerator, *args: object, **kwargs: object):
         self.generator = generator
         self.job = Job(*args, **kwargs)
-        self.queue = asyncio.Queue()
+        self.queue = asyncio.Queue(maxsize=16)
         self.generator.enqueue(self)
         self.cancelled = False
 

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -685,7 +685,7 @@ class Generator:
 
                         # Rewind recurrent states
                         if rejected and states:
-                            for layer, state in states[idx].items():
+                            for layer, state in states[j].items():
                                 assert len(job.sequences) == 1
                                 state.rewind(rejected)
 


### PR DESCRIPTION
The `AsyncGenerator._run_iteration()` blocks the event loop during forward passes (`self.generator.iterate()`), causing generated tokens to accumulate and "burst" all at once at the end of the request.

The fix is to add a maxsize on the queue. This causes `await async_job.put_result(result)` to yield to the event loop and allow the consumer to pop results before another long forward pass blocks the loop again.

After applying the fix, another bug surfaced:

`IndexError` during recurrent state rewinding in `iterate_gen`. When using speculative decoding, the code attempts to rewind recurrent states using an index (`idx`) derived from `active_jobs`. However, the `states` list is built from `batch_jobs`. If any jobs are skipped (e.g., prefill incomplete), these indices diverge, leading to an `IndexError`.

Fix: Use the batch-relative counter `j` to index into `states`, ensuring alignment with the current batched workload.