### PR TITLE
Fix double '.' issue with Mistral Medium 3.5

### DIFF
--- a/exllamav3/architecture/mistral3.py
+++ b/exllamav3/architecture/mistral3.py
@@ -142,11 +142,11 @@ class Mistral3Model(Model):
         # Auto-detect key naming convention
         if config.new_key_style:
             # New keys: model.language_model.{name}
-            lm = "model.language_model."
+            lm = "model.language_model"
             head = "lm_head"
         else:
             # Original keys: language_model.model.{name}
-            lm = key_prefix + "model."
+            lm = key_prefix + "model"
             head = key_prefix + "lm_head"
 
         self.modules += [


### PR DESCRIPTION
Getting this error trying to quant Mistral Large 3.5:

```
Traceback (most recent call last):
  File "/home/[REDACTED]/exllamav3/convert.py", line 11, in <module>
    main(_in_args, _job_state)
  File "/home/[REDACTED]/exllamav3/exl3venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/[REDACTED]/exllamav3/exllamav3/conversion/convert_model.py", line 351, in main
    module.load(
  File "/home/[REDACTED]/exllamav3/exllamav3/modules/embedding.py", line 47, in load
    weight = self.config.stc.get_tensor(self.key + ".weight", self.device, float2half = True, allow_bf16 = True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/[REDACTED]/exllamav3/exllamav3/loader/safetensors.py", line 299, in get_tensor
    raise ValueError(f"Required tensor {key} not found in any *.safetensors file in {self.directory}")
ValueError: Required tensor model.language_model..embed_tokens.weight not found in any *.safetensors file in /ai/text-generation/models/mistralai_Mistral-Medium-3.5-128B
```

This change seems to fix the issue, but I'm wary of causing a regression with other Mistral 3-based models if this was working for others...