### PR TITLE
set xformers dep to 0.0.32.post2 for torch 2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,7 +320,7 @@ jobs:
 
           switch -Regex ($torchVersion) {
             '^2\.7\.'  { $xformersSpec = '==0.0.30'; break }
-            '^2\.8\.'  { $xformersSpec = '==0.0.32'; break }
+            '^2\.8\.'  { $xformersSpec = '==0.0.32.post2'; break }
             '^2\.9\.'  { $xformersSpec = '==0.0.33'; break }
             '^2\.10\.' { $xformersSpec = '>=0.0.34,<0.0.36'; break }
             '^2\.11\.' { $xformersSpec = '>=0.0.34,<0.0.36'; break }


### PR DESCRIPTION
0.0.32 is not longer available causing installation of cuda 2.8 versions to fail

```
INFO: pip is looking at multiple versions of exllamav3 to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement xformers==0.0.32 (from exllamav3) (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 0.0.9, 0.0.10, 0.0.11, 0.0.12, 0.0.13, 0.0.16rc424, 0.0.16rc425, 0.0.16, 0.0.20, 0.0.21, 0.0.22, 0.0.22.post7, 0.0.23, 0.0.23.post1, 0.0.24, 0.0.25, 0.0.25.post1, 0.0.26.post1, 0.0.27, 0.0.27.post1, 0.0.27.post2, 0.0.28, 0.0.28.post1, 0.0.28.post2, 0.0.28.post3, 0.0.29, 0.0.29.post1, 0.0.29.post2, 0.0.29.post3, 0.0.30, 0.0.31, 0.0.31.post1, 0.0.32.post1, 0.0.32.post2, 0.0.33, 0.0.33.post1, 0.0.33.post2, 0.0.34.dev1095, 0.0.34.dev1096, 0.0.34.dev1097, 0.0.34.dev1098, 0.0.34.dev1100, 0.0.34.dev1102, 0.0.34.dev1116, 0.0.34, 0.0.35.dev1117, 0.0.35.dev1118, 0.0.35.dev1119, 0.0.35.dev1120, 0.0.35.dev1121, 0.0.35.dev1122, 0.0.35.dev1123, 0.0.35.dev1124, 0.0.35.dev1125, 0.0.35.dev1126, 0.0.35.dev1127, 0.0.35.dev1128, 0.0.35.dev1129, 0.0.35.dev1130, 0.0.35)
ERROR: No matching distribution found for xformers==0.0.32
```