### PR TITLE
fix: pad tensors in TPBackendNative.broadcast for NCCL 16-byte alignment

### DIFF
--- a/exllamav3/model/model_tp_backend.py
+++ b/exllamav3/model/model_tp_backend.py
@@ -338,7 +338,47 @@ class TPBackendNative:
 
 
     def broadcast(self, tensor: torch.Tensor, src_device: int):
-        if tensor.numel() * tensor.element_size() <= 2048:
+        nelem = tensor.numel()
+        esize = tensor.element_size()
+        data_size = nelem * esize
+
+        # NCCL requires data_size to be a multiple of 16 bytes.
+        # Pad the tensor if necessary (e.g. MoE routing_weights with
+        # num_experts_per_tok=10 gives (bsz*10*2) bytes, which misaligns
+        # when bsz is not a multiple of 4).
+        if data_size % 16 != 0:
+            pad_bytes = 16 - (data_size % 16)
+            pad_elements = pad_bytes // esize
+            shape = tensor.shape
+            padded = torch.cat([tensor.reshape(-1),
+                                torch.zeros(pad_elements, dtype = tensor.dtype, device = tensor.device)])
+            padded_nelem = padded.numel()
+            if padded_nelem * esize <= 2048:
+                ext.pg_broadcast_ll(
+                    self.ptr_g,
+                    self.active_devices,
+                    self.device,
+                    src_device,
+                    padded,
+                    self.ptr_s,
+                    SHBUF_SIZE_S,
+                    self.abort_flag
+                )
+            else:
+                ext.pg_broadcast(
+                    self.ptr_g,
+                    self.active_devices,
+                    self.device,
+                    src_device,
+                    padded,
+                    self.ptr_b,
+                    self.shbuf_size,
+                    self.abort_flag
+                )
+            tensor.copy_(padded[:nelem].view(shape))
+            return
+
+        if data_size <= 2048:
             ext.pg_broadcast_ll(
                 self.ptr_g,
                 self.active_devices,


### PR DESCRIPTION
## Problem

NCCL broadcast requires `data_size` to be a multiple of 16 bytes.  
`TPBackendNative.broadcast()` passes tensors directly to `ext.pg_broadcast` / `ext.pg_broadcast_ll` without ensuring alignment.

This breaks with MoE models where `num_experts_per_tok` is not a multiple of 8.  
For example, **Qwen3.5-MoE** (Nex-N2-Pro) has `num_experts_per_tok=10`, giving routing_weights shape `(bsz, 10)` in float16 → `bsz * 20` bytes.  
When `bsz` is not a multiple of 4, the broadcast fails with:

```
RuntimeError: data_size must be multiple of 16
```

Stack trace points to `block_sparse_mlp.py` → `broadcast(routing_weights)` → `ext.pg_broadcast`.

## Fix

Detect unaligned tensors in `broadcast()`, pad with zeros to the next 16-byte boundary, broadcast the padded tensor, then copy the valid portion back to the original tensor.

The padding is transparent to callers — zeros are discarded immediately after the broadcast.

## Impact

- **No-op for already-aligned tensors** (the common case: `num_experts_per_tok=8` always aligns; most other broadcasts use shapes that align naturally).
- **Fixes crashes on models with unusual `num_experts_per_tok`** (e.g. 10, 6, or any non-multiple-of-8) in tensor-parallel mode.

Disclaimer: This PR was created with DeepSeek v4 pro. I tested and confirm the code working with Qwen 3.5 397B