### PR TITLE
Fix illegal memory access on multi-GPU

### DIFF
--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -522,7 +522,8 @@ class Generator:
                 "cache_seqlens": cache_seqlens,
             }
             batch_state = self.draft_model.forward(batch_ids, params)
-            batch_logits = self.model.modules[self.model.logit_layer_idx].forward(batch_state, params)
+            lm_head = self.model.modules[self.model.logit_layer_idx]
+            batch_logits = lm_head.forward(lm_head.prepare_for_device(batch_state, params), params)
             new_ids = torch.argmax(batch_logits, dim = -1)
             self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
             batch_ids.copy_(new_ids)


### PR DESCRIPTION
Fixes an illegal memory access when running with MTP on multiple GPUs.

```
2026-06-12 18:02:34.190 ERROR:    FATAL ERROR with generation. Attempting to recreate the generator. If this fails, please 
restart the server.

2026-06-12 18:02:34.191 WARNING:  Immediately terminating all jobs. Clients will have their requests cancelled.

2026-06-12 18:02:34.192 ERROR:    Error during chat completion 
2026-06-12 18:02:34.192 ERROR:    CUDA error: an illegal memory access was encountered
2026-06-12 18:02:34.192 ERROR:    Search for `cudaErrorIllegalAddress' in 
https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
2026-06-12 18:02:34.192 ERROR:    CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace
below might be incorrect.
2026-06-12 18:02:34.192 ERROR:    For debugging consider passing CUDA_LAUNCH_BLOCKING=1
2026-06-12 18:02:34.192 ERROR:    Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
2026-06-12 18:02:34.194 ERROR:    Error Traceback (most recent call last):
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/tabbyAPI/endpoints/OAI/utils/chat_completion.py", line 572, in 
stream_generate_chat_completion
2026-06-12 18:02:34.194 ERROR:        raise generation
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/tabbyAPI/endpoints/OAI/utils/chat_completion.py", line 395, in 
_chat_stream_collector
2026-06-12 18:02:34.194 ERROR:        async for generation in new_generation:
2026-06-12 18:02:34.194 ERROR:        ...\<97 lines>...
2026-06-12 18:02:34.194 ERROR:                break
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/tabbyAPI/backends/exllamav3/model.py", line 824, in stream_generate
2026-06-12 18:02:34.194 ERROR:        async for generation_chunk in self.generate_gen(
2026-06-12 18:02:34.194 ERROR:        ...\<7 lines>...
2026-06-12 18:02:34.194 ERROR:            yield generation_chunk
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/tabbyAPI/backends/exllamav3/model.py", line 1176, in generate_gen
2026-06-12 18:02:34.194 ERROR:        raise ex
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/tabbyAPI/backends/exllamav3/model.py", line 1106, in generate_gen
2026-06-12 18:02:34.194 ERROR:        async for result in job:
2026-06-12 18:02:34.194 ERROR:        ...\<50 lines>...
2026-06-12 18:02:34.194 ERROR:                break
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/exllamav3/exllamav3/generator/async_generator.py", line 109, in 
__aiter__
2026-06-12 18:02:34.194 ERROR:        raise result
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/exllamav3/exllamav3/generator/async_generator.py", line 27, in 
_run_iteration
2026-06-12 18:02:34.194 ERROR:        results = self.generator.iterate()
2026-06-12 18:02:34.194 ERROR:      File 
"/home/alex/git/tabbyAPI/.venv/lib/python3.13/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
2026-06-12 18:02:34.194 ERROR:        return func(*args, **kwargs)
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/exllamav3/exllamav3/generator/generator.py", line 357, in iterate
2026-06-12 18:02:34.194 ERROR:        draft_tokens = self.iterate_draftmodel_mtp_gen(results)
2026-06-12 18:02:34.194 ERROR:      File "/home/alex/git/exllamav3/exllamav3/generator/generator.py", line 526, in 
iterate_draftmodel_mtp_gen
2026-06-12 18:02:34.194 ERROR:        new_ids = torch.argmax(batch_logits, dim = -1)
2026-06-12 18:02:34.194 ERROR:    torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```