### PR TITLE
Fix MTP draft lm_head with tensor parallel

### DIFF
--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -522,10 +522,14 @@ class Generator:
                 "cache_seqlens": cache_seqlens,
             }
             batch_state = self.draft_model.forward(batch_ids, params)
-            lm_head = self.model.modules[self.model.logit_layer_idx]
-            batch_state = lm_head.prepare_for_device(batch_state, params)
-            batch_logits = lm_head.forward(batch_state, params)
-            new_ids = torch.argmax(batch_logits, dim = -1)
+            if self.model.loaded_tp:
+                shared_state = self.model.tp_producer.send(batch_state)
+                new_ids = self.model.tp_dispatch_lm_head_argmax((shared_state, {}))
+            else:
+                lm_head = self.model.modules[self.model.logit_layer_idx]
+                batch_state = lm_head.prepare_for_device(batch_state, params)
+                batch_logits = lm_head.forward(batch_state, params)
+                new_ids = torch.argmax(batch_logits, dim = -1)
             self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
             batch_ids.copy_(new_ids)
             cache_seqlens += 1


### PR DESCRIPTION
## Summary

Fix Qwen3.5/3.6 MTP drafting when the target model is loaded with tensor parallelism.

The MTP draft path was directly calling the parent-process target `lm_head`. With TP loading, that module is sharded/unloaded in the parent process, so `lm_head.inner` is `None` and generation fails with:

```text
AttributeError: 'NoneType' object has no attribute 'forward'
```

This patch uses the existing TP lm_head argmax dispatch path when `self.model.loaded_tp` is true, matching the approach used by DFlash. The non-TP path is unchanged.

## Testing

- `python -m py_compile exllamav3/generator/generator.py`
- Live-tested locally with MTP draft + tensor parallel on Rio/Qwen3.5 MoE model
