### PR TITLE
Fixed key_fused_qkvz and key_fused_ba being overwritten with None

### DIFF
--- a/exllamav3/modules/gated_delta_net.py
+++ b/exllamav3/modules/gated_delta_net.py
@@ -319,12 +319,7 @@ class GatedDeltaNet(Module):
             self.qkv_proj = None
             self.z_proj = None
             self.register_submodule(self.qkvz_proj)
-        else:
-            self.qkvz_proj = None
-            self.qkv_proj = None
-            self.z_proj = None
-
-        if qkv_proj:
+        elif qkv_proj:
             self.qkv_proj = qkv_proj
             self.z_proj = z_proj
             self.qkvz_proj = None
@@ -365,12 +360,7 @@ class GatedDeltaNet(Module):
             self.b_proj = None
             self.a_proj = None
             self.register_submodule(self.ba_proj)
-        else:
-            self.b_proj = None
-            self.a_proj = None
-            self.ba_proj = None
-
-        if b_proj:
+        elif b_proj:
             self.b_proj = b_proj
             self.a_proj = a_proj
             self.ba_proj = None


### PR DESCRIPTION
Merged the top conditionals for key_fused_qkvz and key_fused_ba into the set of conditionals that follow them, so their values don't get clobbered.

What we had was:
```
if thing:
  set a = thing
  set b = None

if other_thing:
  set a = None
  set b = other_thing
else:
  set a = None
  set b = None
```

The problem is that the `else` overwrites the true condition of the preceding condition.