### PR TITLE
Update pydantic version constraint in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pillow
 pyyaml
 marisa_trie
 kbnf>=0.4.2
-pydantic
+pydantic<=2.11.10
 formatron>=0.5.0
 xformers
 flash-linear-attention>=0.5.0


### PR DESCRIPTION
Pydantic 2.12.0 adds `pydantic.typing` which conflicts with formatron's use.

formatron has an open ticket about exactly this issue that's been open since October 2025