### PR TITLE
Fix TP gather self-copy offset

### DIFF
--- a/exllamav3/exllamav3_ext/parallel/gather.cu
+++ b/exllamav3/exllamav3_ext/parallel/gather.cu
@@ -121,7 +121,7 @@ void pg_gather_kernel
                 {
                     size_t row = copy_t / ldim;
                     size_t col = copy_t % ldim;
-                    size_t out_t = row * stride + col;
+                    size_t out_t = row * stride + col + dst_offset;
                     *((uint4*) (out_data_ptr + out_t)) = src[t];
                 }
             }


### PR DESCRIPTION
## Summary
- Apply dst_offset in the native TP gather self-copy path
- Fixes output-device shards being written at column offset 0 when the output device is not the first gather shard

## Notes
- Clean branch from origin/master (c5d9c65)
- Contains only the one-line gather kernel fix for #233; no MiniMax-M3 work included

## Testing
- git diff --check origin/master..HEAD