### PR TITLE
Quality: Undefined variable `cache_size` causes NameError at runtime

### DIFF
--- a/eval/compare_q_exllamav2.py
+++ b/eval/compare_q_exllamav2.py
@@ -30,7 +30,7 @@ def get_storage_info(model):
 def load_exllamav2(model_dir: str | list, size: int = 2048):
     config = ExLlamaV2Config(model_dir)
     model = ExLlamaV2(config)
-    cache = ExLlamaV2Cache(model, batch_size = 1, max_seq_len = cache_size)  # Cache isn't used but reqd by autosplit
+    cache = ExLlamaV2Cache(model, batch_size = 1, max_seq_len = size)  # Cache isn't used but reqd by autosplit
     model.load_autosplit(cache, reserve_vram = 1024**3)
     bpw_layer, bpw_head, vram_bits = get_storage_info(model)
     return model, bpw_layer, bpw_head, vram_bits


### PR DESCRIPTION
## Problem

The function parameter is named `size` (line 25), but the body references the undefined variable `cache_size` (line 28). This will raise a NameError every time `load_exllamav2` is called. This is not caught by any guard because it's not an import-time error.


**Severity**: `critical`
**File**: `eval/compare_q_exllamav2.py`

## Solution

def load_exllamav2(model_dir: str | list, size: int = 2048):
    config = ExLlamaV2Config(model_dir)
    model = ExLlamaV2(config)
    cache = ExLlamaV2Cache(model, batch_size = 1, max_seq_len = size)  # Cache isn't used but reqd by autosplit
    model.load_autosplit(cache, reserve_vram = 1024**3)


## Changes

- `eval/compare_q_exllamav2.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
