### PR TITLE
Quality: Bare `except:` swallows all exceptions and masks broken installs

### DIFF
--- a/eval/compare_q_llamacpp.py
+++ b/eval/compare_q_llamacpp.py
@@ -3,7 +3,7 @@ try:
     import gguf
     from gguf import GGUFReader
     from llama_cpp import Llama
-except:
+except ModuleNotFoundError:
     pass
 import torch
 from functools import lru_cache


### PR DESCRIPTION
## Problem

The bare `except:` clause catches every exception type (including SyntaxError, ImportError with a real message, AttributeError from a partially-initialized module, etc.). If llama_cpp is installed but broken (e.g., missing native library, version mismatch), the real error is silently swallowed. All downstream functions that use `llama_cpp`, `Llama`, `GGUFReader`, etc. will then fail with a confusing `NameError` with no indication of the original cause. The sibling files `compare_q_exllamav2.py` and `compare_q_exllamav3.py` correctly use `except ModuleNotFoundError:`, which only catches the intended case of a missing package.


**Severity**: `high`
**File**: `eval/compare_q_llamacpp.py`

## Solution

try:
    import llama_cpp
    import gguf
    from gguf import GGUFReader
    from llama_cpp import Llama
except ModuleNotFoundError:
    pass


## Changes

- `eval/compare_q_llamacpp.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
