### PR TITLE
Add MLA attention and DeepseekV3ForCausalLM support

### DIFF
--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -4,6 +4,7 @@ from .apertus import ApertusModel
 from .cohere import CohereModel
 from .cohere2 import Cohere2Model
 from .decilm import DeciLMModel
+from .deepseek_v3 import DeepseekV3Model
 from .dflash import DFlashModel
 from .dots1 import Dots1Model
 from .ernie4_5 import Ernie4_5Model
@@ -57,6 +58,7 @@ ARCHITECTURES = {
         CohereModel,
         Cohere2Model,
         DeciLMModel,
+        DeepseekV3Model,
         DFlashModel,
         Dots1Model,
         Ernie4_5Model,

--- a/exllamav3/architecture/deepseek_v3.py
+++ b/exllamav3/architecture/deepseek_v3.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+from typing_extensions import override
+import torch
+from ..model.config import Config, no_default
+from ..model.model import Model
+from ..modules import RMSNorm, Embedding, TransformerBlock, GatedMLP, BlockSparseMLP, Linear
+from ..modules.mla_attn import MLAAttention
+from ..modules.attn import prepare_for_attn
+
+
+class DeepseekV3Config(Config):
+    arch_string = "DeepseekV3ForCausalLM"
+
+    def __init__(
+        self,
+        directory: str,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            {"text": DeepseekV3Model},
+            **kwargs
+        )
+
+        self.hidden_size = self.read_cfg(int, "hidden_size", no_default)
+        self.num_q_heads = self.read_cfg(int, "num_attention_heads", no_default)
+
+        # MLA
+        self.q_lora_rank = self.read_cfg(int, "q_lora_rank", None)
+        self.kv_lora_rank = self.read_cfg(int, "kv_lora_rank", no_default)
+        self.qk_nope_head_dim = self.read_cfg(int, "qk_nope_head_dim", no_default)
+        self.qk_rope_head_dim = self.read_cfg(int, "qk_rope_head_dim", no_default)
+        self.v_head_dim = self.read_cfg(int, "v_head_dim", no_default)
+        self.rope_theta = self.read_cfg(float, "rope_theta", 10000.0)
+
+        # MLP / MoE
+        self.assert_cfg(str, "hidden_act", "silu", True)
+        self.intermediate_size = self.read_cfg(int, "intermediate_size", no_default)
+        self.moe_intermediate_size = self.read_cfg(int, "moe_intermediate_size", no_default)
+        self.num_shared_experts = self.read_cfg(int, "n_shared_experts", 1)
+        self.num_experts = self.read_cfg(int, "n_routed_experts", no_default)
+        self.num_experts_per_tok = self.read_cfg(int, "num_experts_per_tok", no_default)
+        self.first_k_dense_replace = self.read_cfg(int, "first_k_dense_replace", 0)
+        self.routed_scaling_factor = self.read_cfg(float, "routed_scaling_factor", 1.0)
+        self.n_group = self.read_cfg(int, "n_group", 1)
+        self.topk_group = self.read_cfg(int, "topk_group", 1)
+
+        # Norms / layers
+        self.rms_norm_eps = self.read_cfg(float, "rms_norm_eps", no_default)
+        self.num_hidden_layers = self.read_cfg(int, "num_hidden_layers", no_default)
+        self.tie_word_embeddings = self.read_cfg(bool, "tie_word_embeddings", False)
+
+
+class DeepseekV3Model(Model):
+    config_class = DeepseekV3Config
+
+    def __init__(
+        self,
+        config: DeepseekV3Config,
+        **kwargs
+    ):
+        super().__init__(config, **kwargs)
+        self.caps.update({"supports_tp": False})
+
+        self.modules += [
+            Embedding(
+                config = config,
+                key = "model.embed_tokens",
+                vocab_size = config.vocab_size,
+                hidden_size = config.hidden_size,
+            )
+        ]
+
+        self.first_block_idx = len(self.modules)
+
+        self.modules += [
+            TransformerBlock(
+                config = config,
+                key = f"model.layers.{idx}",
+                layer_idx = idx,
+                attn_norm = RMSNorm(
+                    config = config,
+                    key = f"model.layers.{idx}.input_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                attn = MLAAttention(
+                    config = config,
+                    key = f"model.layers.{idx}.self_attn",
+                    layer_idx = idx,
+                    hidden_size = config.hidden_size,
+                    num_heads = config.num_q_heads,
+                    q_lora_rank = config.q_lora_rank,
+                    kv_lora_rank = config.kv_lora_rank,
+                    qk_nope_head_dim = config.qk_nope_head_dim,
+                    qk_rope_head_dim = config.qk_rope_head_dim,
+                    v_head_dim = config.v_head_dim,
+                    rope_theta = config.rope_theta,
+                    rms_norm_eps = config.rms_norm_eps,
+                    qmap = "block.attn",
+                    rope_interleave_pairs = True,
+                ),
+                mlp_norm = RMSNorm(
+                    config = config,
+                    key = f"model.layers.{idx}.post_attention_layernorm",
+                    rms_norm_eps = config.rms_norm_eps,
+                ),
+                mlp = (
+                    GatedMLP(
+                        config = config,
+                        key = f"model.layers.{idx}.mlp",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.intermediate_size,
+                        key_up = "up_proj",
+                        key_gate = "gate_proj",
+                        key_down = "down_proj",
+                        qmap = "block.mlp",
+                        interm_dtype = torch.half,
+                        out_dtype = torch.float,
+                    )
+                    if idx < config.first_k_dense_replace else
+                    BlockSparseMLP(
+                        config = config,
+                        key = f"model.layers.{idx}.mlp",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.moe_intermediate_size,
+                        num_experts = config.num_experts,
+                        num_experts_per_tok = config.num_experts_per_tok,
+                        key_up = "experts.{expert_idx}.up_proj",
+                        key_gate = "experts.{expert_idx}.gate_proj",
+                        key_down = "experts.{expert_idx}.down_proj",
+                        key_routing_gate = "gate",
+                        qmap = "block.mlp",
+                        interm_dtype = torch.half,
+                        out_dtype = torch.float,
+                        router_type = "ds3",
+                        routed_scaling_factor = config.routed_scaling_factor,
+                        n_group = config.n_group,
+                        topk_group = config.topk_group,
+                        shared_experts = GatedMLP(
+                            config = config,
+                            key = f"model.layers.{idx}.mlp.shared_experts",
+                            hidden_size = config.hidden_size,
+                            intermediate_size = config.moe_intermediate_size * config.num_shared_experts,
+                            key_up = "up_proj",
+                            key_gate = "gate_proj",
+                            key_down = "down_proj",
+                            qmap = "block.mlp",
+                            interm_dtype = torch.half,
+                            out_dtype = torch.float,
+                        ),
+                    )
+                )
+            )
+            for idx in range(config.num_hidden_layers)
+        ]
+
+        self.last_kv_module_idx = len(self.modules) - 1
+
+        head_alt_key = None
+        if config.tie_word_embeddings and not self.config.stc.has_tensor("lm_head"):
+            head_alt_key = "model.embed_tokens"
+
+        self.modules += [
+            RMSNorm(
+                config = config,
+                key = "model.norm",
+                rms_norm_eps = config.rms_norm_eps,
+                out_dtype = torch.half,
+            ),
+            Linear(
+                config = config,
+                key = "lm_head",
+                qbits_key = "head_bits",
+                alt_key = head_alt_key,
+                in_features = config.hidden_size,
+                out_features = config.vocab_size,
+                qmap = "block",
+                caps = {"logits_output": True}
+            )
+        ]
+
+        self.logit_layer_idx = len(self.modules) - 1
+
+        # Activate all experts during H capture pass in quantization
+        self.calibration_all_experts = True
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        input_ids = prepare_for_attn(input_ids, params)
+        return input_ids
+
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        p = "<|begin_of_sentence|>"
+        if system_prompt:
+            p += f"{system_prompt}\n\n"
+        p += f"<|User|>{prompt}<|Assistant|>"
+        return p

--- a/exllamav3/modules/mla_attn.py
+++ b/exllamav3/modules/mla_attn.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+from typing_extensions import override
+import torch
+import torch.nn.functional as F
+from .module import Module
+from .linear import Linear
+from .attention_fn import attn_dispatch
+from ..util.tensor import get_for_device
+
+# Multi-head latent attention (DeepSeek-V2/V3 family). Low-rank q (optional) and
+# kv projections with decoupled rope; QK head dim may differ from V head dim.
+# With a paged cache, K/V are up-projected and cached at qk_head_dim (V padded)
+# so the standard cache layout and flash-attn path apply. Without a cache, two
+# full-sequence batch-1 paths: naive (up-project K/V, dtype scores) and absorbed
+# (score in latent space, fp32). The absorbed path reads kv_b's raw fp16 weight,
+# which is why kv_b stays unquantized.
+#
+# Model-specific behavior hooks in by subclassing: hook_q_lora / hook_kv_latent /
+# hook_attn_out (identity here) and extra_kv (extra always-visible latent/rope
+# positions, e.g. learned sinks; None here).
+
+
+def _rms_std(x, w, eps):
+    dtype = x.dtype
+    y = x.float()
+    y = y * torch.rsqrt(y.pow(2).mean(dim = -1, keepdim = True) + eps)
+    return (y * w.float()).to(dtype)
+
+
+def _rms_kvc(x, w, eps):
+    # variant: weight multiplied in dtype after the fp32 normalize
+    dtype = x.dtype
+    y = x.float()
+    y = y * torch.rsqrt(y.pow(2).mean(dim = -1, keepdim = True) + eps)
+    return y.to(dtype) * w.to(dtype)
+
+
+def _rotate_half(x):
+    x1, x2 = x.chunk(2, dim = -1)
+    return torch.cat((-x2, x1), dim = -1)
+
+
+def _apply_rotary(x, cos, sin):
+    dtype = x.dtype
+    x = x.float()
+    while cos.dim() < x.dim():
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+    return ((x * cos.float()) + (_rotate_half(x) * sin.float())).to(dtype)
+
+
+def _apply_rotary_dtype(x, cos, sin):
+    cos = cos.to(device = x.device, dtype = x.dtype)
+    sin = sin.to(device = x.device, dtype = x.dtype)
+    while cos.dim() < x.dim():
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+    return (x * cos) + (_rotate_half(x) * sin)
+
+
+def _interleave_pairs(x):
+    # DeepSeek rope layout: [x0 x1 x2 x3 ...] -> [x0 x2 ... | x1 x3 ...]
+    s = x.shape
+    return x.view(*s[:-1], s[-1] // 2, 2).transpose(-1, -2).reshape(s)
+
+
+class MLAAttention(Module):
+
+    def __init__(
+        self,
+        config,
+        key,
+        layer_idx,
+        hidden_size,
+        num_heads,
+        q_lora_rank,          # None -> direct q_proj
+        kv_lora_rank,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        v_head_dim,
+        rope_theta,
+        rms_norm_eps,
+        qmap = None,
+        sliding_window = None,
+        absorbed = False,
+        rope_interleave_pairs = False,
+        kv_norm_dtype_mul = False,
+        key_q_a = "q_a_proj",
+        key_q_a_norm = "q_a_layernorm",
+        key_q_b = "q_b_proj",
+        key_q = "q_proj",
+        key_kv_a = "kv_a_proj_with_mqa",
+        key_kv_a_norm = "kv_a_layernorm",
+        key_kv_b = "kv_b_proj",
+        key_o = "o_proj",
+        sm_scale = None,
+    ):
+        super().__init__(config, key, None)
+        self.module_name = "MLAAttention"
+        self.layer_idx = layer_idx
+        self.num_heads = num_heads
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.rope_theta = rope_theta
+        self.rms_norm_eps = rms_norm_eps
+        self.sliding_window = sliding_window
+        self.absorbed = absorbed
+        self.rope_interleave_pairs = rope_interleave_pairs
+        self.kv_norm_dtype_mul = kv_norm_dtype_mul
+        self.scaling = sm_scale or self.qk_head_dim ** -0.5
+        self.key_q_a_norm = key_q_a_norm
+        self.key_kv_a_norm = key_kv_a_norm
+
+        # Paged cache stores up-projected K/V at qk_head_dim, V zero-padded from
+        # v_head_dim, so the standard cache layout and flash-attn path apply
+        self.num_kv_heads = num_heads
+        self.head_dim = self.qk_head_dim
+        self.cache_layers = []
+        self.caps.update({"kv_cache": True})
+
+        if q_lora_rank:
+            self.q_a_proj = Linear(config, f"{key}.{key_q_a}", hidden_size, q_lora_rank, qmap = None)
+            self.q_b_proj = Linear(config, f"{key}.{key_q_b}", q_lora_rank,
+                                   num_heads * self.qk_head_dim, qmap = qmap + ".qb" if qmap else None)
+            self.q_proj = None
+            self.register_submodule(self.q_a_proj)
+            self.register_submodule(self.q_b_proj)
+        else:
+            self.q_a_proj = None
+            self.q_b_proj = None
+            self.q_proj = Linear(config, f"{key}.{key_q}", hidden_size,
+                                 num_heads * self.qk_head_dim, qmap = qmap + ".qb" if qmap else None)
+            self.register_submodule(self.q_proj)
+        self.kv_a_proj = Linear(config, f"{key}.{key_kv_a}", hidden_size,
+                                kv_lora_rank + qk_rope_head_dim, qmap = None)
+        self.kv_b_proj = Linear(config, f"{key}.{key_kv_b}", kv_lora_rank,
+                                num_heads * (qk_nope_head_dim + v_head_dim), qmap = None)
+        self.o_proj = Linear(config, f"{key}.{key_o}", num_heads * v_head_dim, hidden_size,
+                             qmap = qmap + ".o" if qmap else None)
+        for m in (self.kv_a_proj, self.kv_b_proj, self.o_proj):
+            self.register_submodule(m)
+
+        self.q_a_norm_w = None
+        self.kv_a_norm_w = None
+        self._cos = None
+        self._sin = None
+
+    # Subclass hooks, identity/None here
+    def hook_q_lora(self, q_lora):
+        return q_lora
+
+    def hook_kv_latent(self, k_latent):
+        return k_latent
+
+    def hook_attn_out(self, attn):
+        return attn
+
+    def extra_kv(self):
+        return None
+
+    def load_extra(self, device, get):
+        pass
+
+    @override
+    def load(self, device, **kwargs):
+        super().load(device, **kwargs)
+        for cl in self.cache_layers:
+            cl.alloc(device)
+        # no_defer: deferred placeholders only materialize after load, and these
+        # tensors are consumed/transformed before that
+        get = lambda k, **kw: self.config.stc.get_tensor(f"{self.key}.{k}", device,
+                                                         float2half = True, no_defer = True, **kw)
+        if self.q_lora_rank:
+            self.q_a_norm_w = get(f"{self.key_q_a_norm}.weight")
+        self.kv_a_norm_w = get(f"{self.key_kv_a_norm}.weight")
+        self.load_extra(device, get)
+
+    @override
+    def unload(self):
+        super().unload()
+        for cl in self.cache_layers:
+            cl.free()
+        self.q_a_norm_w = self.kv_a_norm_w = None
+        self._cos = self._sin = None
+
+    def optimizer_targets(self):
+        q = (self.q_b_proj or self.q_proj).optimizer_targets()
+        return [[q, self.o_proj.optimizer_targets()]]
+
+    def get_tensors(self):
+        # raw (non-Linear) tensors, re-emitted by the convert compile step
+        if self.device is None:
+            return {}
+        t = {}
+        if self.q_a_norm_w is not None:
+            t[f"{self.key}.{self.key_q_a_norm}.weight"] = self.q_a_norm_w
+        t[f"{self.key}.{self.key_kv_a_norm}.weight"] = self.kv_a_norm_w
+        t.update(self.get_tensors_extra())
+        return t
+
+    def get_tensors_extra(self):
+        return {}
+
+    def _cos_sin(self, seq_len, device, dtype):
+        if self._cos is None or self._cos.shape[0] < seq_len or self._cos.device != device:
+            half_dim = self.qk_rope_head_dim // 2
+            inv_freq = 1.0 / (self.rope_theta ** (
+                torch.arange(0, half_dim, device = device, dtype = torch.float32) / half_dim))
+            positions = torch.arange(seq_len, device = device, dtype = torch.float32)
+            freqs = torch.outer(positions, inv_freq)
+            emb = torch.cat((freqs, freqs), dim = -1)
+            self._cos = emb.cos().to(dtype)
+            self._sin = emb.sin().to(dtype)
+        return self._cos[:seq_len], self._sin[:seq_len]
+
+    def _kv_b_weight(self):
+        w = self.kv_b_proj.inner.weight  # stored [in, out]
+        w = w.transpose(0, 1).view(self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank)
+        return w
+
+    def _mask(self, seq_len, device):
+        q_pos = torch.arange(seq_len, device = device).unsqueeze(1)
+        k_pos = torch.arange(seq_len, device = device).unsqueeze(0)
+        mask = k_pos <= q_pos
+        if self.sliding_window is not None:
+            mask = mask & (k_pos >= q_pos - self.sliding_window + 1)
+        return mask
+
+    def forward(self, x, params, out_dtype = None):
+        if params.get("cache") is not None:
+            return self._fwd_paged(x, params)
+        # No cache: [seq, hidden] or [1, seq, hidden], batch size 1
+        orig_shape = x.shape
+        x = x.reshape(-1, orig_shape[-1])
+        seq_len = x.shape[0]
+        if self.q_lora_rank:
+            q_lora = self.q_a_proj.forward(x, params)[..., : self.q_lora_rank]
+            q_lora = self.hook_q_lora(q_lora)
+            q_lora = _rms_std(q_lora, self.q_a_norm_w, self.rms_norm_eps)
+            q = self.q_b_proj.forward(q_lora, params)[..., : self.num_heads * self.qk_head_dim]
+        else:
+            q = self.q_proj.forward(x, params)[..., : self.num_heads * self.qk_head_dim]
+        q = q.view(seq_len, self.num_heads, self.qk_head_dim)
+        q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim = -1)
+
+        kv = self.kv_a_proj.forward(x, params)[..., : self.kv_lora_rank + self.qk_rope_head_dim]
+        k_latent, k_pe = torch.split(kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim = -1)
+        k_latent = self.hook_kv_latent(k_latent)
+
+        if self.rope_interleave_pairs:
+            q_pe = _interleave_pairs(q_pe)
+            k_pe = _interleave_pairs(k_pe)
+
+        if self.absorbed:
+            attn = self._fwd_absorbed(x, q_nope, q_pe, k_latent, k_pe)
+        else:
+            attn = self._fwd_naive(x, q_nope, q_pe, k_latent, k_pe)
+        attn = self.hook_attn_out(attn)
+        out = self.o_proj.forward(attn, params)[..., : x.shape[-1]]
+        return out.reshape(orig_shape)
+
+    def _fwd_paged(self, x, params):
+        # [bsz, q_len, hidden] against the paged cache. K/V are up-projected and
+        # cached at qk_head_dim (V zero-padded), giving the standard cache layout
+        # and attention path. Rope positions come from cache_seqlens.
+        assert self.extra_kv() is None, "extra_kv not supported on the paged path"
+        bsz, q_len, hidden = x.shape
+        nope, rope_d, v_dim = self.qk_nope_head_dim, self.qk_rope_head_dim, self.v_head_dim
+
+        if self.q_lora_rank:
+            q_lora = self.q_a_proj.forward(x, params)[..., : self.q_lora_rank]
+            q_lora = self.hook_q_lora(q_lora)
+            q_lora = _rms_std(q_lora, self.q_a_norm_w, self.rms_norm_eps)
+            q = self.q_b_proj.forward(q_lora, params)[..., : self.num_heads * self.qk_head_dim]
+        else:
+            q = self.q_proj.forward(x, params)[..., : self.num_heads * self.qk_head_dim]
+        q = q.view(bsz, q_len, self.num_heads, self.qk_head_dim)
+        q_nope, q_pe = torch.split(q, [nope, rope_d], dim = -1)
+
+        kv = self.kv_a_proj.forward(x, params)[..., : self.kv_lora_rank + rope_d]
+        k_latent, k_pe = torch.split(kv, [self.kv_lora_rank, rope_d], dim = -1)
+        k_latent = self.hook_kv_latent(k_latent)
+        norm = _rms_kvc if self.kv_norm_dtype_mul else _rms_std
+        k_lat_n = norm(k_latent, self.kv_a_norm_w, self.rms_norm_eps)
+        kv_up = self.kv_b_proj.forward(k_lat_n, {})[..., : self.num_heads * (nope + v_dim)]
+        kv_up = kv_up.view(bsz, q_len, self.num_heads, nope + v_dim)
+        k_nope, v = torch.split(kv_up, [nope, v_dim], dim = -1)
+
+        if self.rope_interleave_pairs:
+            q_pe = _interleave_pairs(q_pe)
+            k_pe = _interleave_pairs(k_pe)
+
+        cache_seqlens = get_for_device(params, "cache_seqlens", x.device)
+        block_table = get_for_device(params, "block_table", x.device)
+        max_pos = int(cache_seqlens.max().item()) + q_len
+        cos, sin = self._cos_sin(max_pos, x.device, q_pe.dtype)
+        pos = cache_seqlens.long().unsqueeze(1) + torch.arange(q_len, device = x.device).unsqueeze(0)
+        cos_q = cos[pos].unsqueeze(2)
+        sin_q = sin[pos].unsqueeze(2)
+        q_pe = ((q_pe.float() * cos_q.float()) + (_rotate_half(q_pe.float()) * sin_q.float())).to(q.dtype)
+        cos_k = cos[pos].to(k_pe.dtype)
+        sin_k = sin[pos].to(k_pe.dtype)
+        k_pe = (k_pe * cos_k) + (_rotate_half(k_pe) * sin_k)
+
+        q = torch.cat((q_nope, q_pe), dim = -1)
+        k = torch.cat((k_nope, k_pe.unsqueeze(2).expand(-1, -1, self.num_heads, -1)), dim = -1)
+        v = F.pad(v, (0, self.qk_head_dim - v_dim))
+
+        o = attn_dispatch(
+            q = q.contiguous(),
+            k = k.contiguous(),
+            v = v.contiguous(),
+            cache = params.get("cache"),
+            cache_idx = self.layer_idx,
+            cache_instance = params.get("layer_instance"),
+            block_table = block_table,
+            cache_seqlens = cache_seqlens,
+            causal = True,
+            sm_scale = self.scaling,
+            window_size = self.sliding_window,
+        )
+        o = o[..., : v_dim].reshape(bsz, q_len, self.num_heads * v_dim)
+        o = self.hook_attn_out(o)
+        return self.o_proj.forward(o, params)[..., : hidden]
+
+    def _fwd_naive(self, x, q_nope, q_pe, k_latent, k_pe):
+        seq_len = x.shape[0]
+        nope, v_dim = self.qk_nope_head_dim, self.v_head_dim
+        norm = _rms_kvc if self.kv_norm_dtype_mul else _rms_std
+        k_lat_n = norm(k_latent, self.kv_a_norm_w, self.rms_norm_eps)
+        kv_up = self.kv_b_proj.forward(k_lat_n, {})[..., : self.num_heads * (nope + v_dim)]
+        kv_up = kv_up.view(seq_len, self.num_heads, nope + v_dim)
+        k_nope, v = torch.split(kv_up, [nope, v_dim], dim = -1)
+
+        cos, sin = self._cos_sin(seq_len, x.device, q_pe.dtype)
+        q_pe = _apply_rotary(q_pe, cos, sin)
+        k_pe = _apply_rotary_dtype(k_pe, cos, sin).unsqueeze(1).expand(-1, self.num_heads, -1)
+
+        n_extra = 0
+        extra = self.extra_kv()
+        if extra is not None:
+            x_lat, x_kpe = extra
+            x_kv = self.kv_b_proj.forward(x_lat, {})[..., : self.num_heads * (nope + v_dim)]
+            x_kv = x_kv.view(-1, self.num_heads, nope + v_dim)
+            x_k_nope, x_v = torch.split(x_kv, [nope, v_dim], dim = -1)
+            x_kpe = x_kpe.view(-1, 1, self.qk_rope_head_dim).expand(-1, self.num_heads, -1)
+            k_nope = torch.cat([x_k_nope.to(k_nope.dtype), k_nope], dim = 0)
+            k_pe = torch.cat([x_kpe.to(k_pe.dtype), k_pe], dim = 0)
+            v = torch.cat([x_v.to(v.dtype), v], dim = 0)
+            n_extra = k_nope.shape[0] - seq_len
+
+        scores = torch.einsum("thd,shd->hts", q_nope, k_nope)
+        scores = scores + torch.einsum("thr,shr->hts", q_pe, k_pe)
+        scores = scores * self.scaling
+        mask = self._mask(seq_len, x.device)
+        if n_extra > 0:
+            mask = torch.cat([torch.ones(seq_len, n_extra, dtype = torch.bool, device = x.device), mask], dim = -1)
+        mask = mask.unsqueeze(0)
+        scores = scores.masked_fill(~mask, torch.finfo(scores.dtype).min)
+        probs = torch.softmax(scores.float(), dim = -1).to(dtype = q_nope.dtype)
+        probs = torch.where(mask, probs, torch.zeros_like(probs))
+        return torch.einsum("hts,shv->thv", probs, v).reshape(seq_len, -1)
+
+    def _fwd_absorbed(self, x, q_nope, q_pe, k_latent, k_pe):
+        seq_len = x.shape[0]
+        cos, sin = self._cos_sin(seq_len, x.device, q_pe.dtype)
+        q_pe = _apply_rotary(q_pe, cos, sin)
+        k_pe = _apply_rotary(k_pe, cos, sin)
+        w = self._kv_b_weight()
+        w_uk_t = w[:, : self.qk_nope_head_dim, :]
+        w_uv = w[:, self.qk_nope_head_dim :, :].transpose(1, 2)
+        q_lat = torch.einsum("thd,hdr->thr", q_nope.float(), w_uk_t.float()).to(q_nope.dtype)
+        k_lat = _rms_std(k_latent, self.kv_a_norm_w, self.rms_norm_eps)
+
+        n_extra = 0
+        extra = self.extra_kv()
+        if extra is not None:
+            x_lat, x_kpe = extra
+            k_lat = torch.cat([x_lat.to(q_lat.dtype), k_lat], dim = 0)
+            k_pe = torch.cat([x_kpe.to(q_pe.dtype), k_pe], dim = 0)
+            n_extra = k_lat.shape[0] - seq_len
+
+        scores = torch.einsum("qhr,kr->qhk", q_lat.float(), k_lat.float())
+        scores = scores + torch.einsum("qhr,kr->qhk", q_pe.float(), k_pe.float())
+        scores = scores * self.scaling
+        mask = self._mask(seq_len, x.device)
+        if n_extra > 0:
+            mask = torch.cat([torch.ones(seq_len, n_extra, dtype = torch.bool, device = x.device), mask], dim = -1)
+        scores = scores.masked_fill(~mask.unsqueeze(1), float("-inf"))
+        probs = torch.softmax(scores, dim = -1)
+        probs = torch.where(mask.unsqueeze(1), probs, torch.zeros_like(probs))
+        attn_lat = torch.einsum("qhk,kr->qhr", probs, k_lat.float()).to(q_lat.dtype)
+        attn = torch.einsum("thr,hrv->thv", attn_lat.float(), w_uv.float())
+        return attn.to(x.dtype).reshape(seq_len, -1)

--- a/tests/smoke_deepseek_v3_arch.py
+++ b/tests/smoke_deepseek_v3_arch.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Lightweight smoke checks for DeepseekV3 architecture integration.
+
+Checks:
+1) Synthesize a tiny random-weight DeepseekV3ForCausalLM checkpoint (--gen)
+2) Config/architecture resolution and model graph construction
+3) Full forward over the synthetic model
+4) Optional: per-layer + logits diff against HF transformers (--hf_check)
+
+Covers both q projection variants (--q_lora_rank 0 for direct q_proj), the
+interleaved-pair rope layout, and grouped noaux_tc MoE routing.
+"""
+
+import argparse
+import json
+import os
+import sys
+import torch
+
+from exllamav3 import Config, Model
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def make_cfg(q_lora):
+    return {
+        "architectures": ["DeepseekV3ForCausalLM"],
+        "model_type": "deepseek_v3",
+        "hidden_size": 128,
+        "num_hidden_layers": 3,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "q_lora_rank": q_lora if q_lora else None,
+        "kv_lora_rank": 128,
+        "qk_nope_head_dim": 64,
+        "qk_rope_head_dim": 16,
+        "qk_head_dim": 80,
+        "v_head_dim": 64,
+        "head_dim": 16,
+        "intermediate_size": 256,
+        "moe_intermediate_size": 128,
+        "n_routed_experts": 8,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 2,
+        "n_group": 2,
+        "topk_group": 1,
+        "norm_topk_prob": True,
+        "routed_scaling_factor": 2.5,
+        "scoring_func": "sigmoid",
+        "topk_method": "noaux_tc",
+        "moe_layer_freq": 1,
+        "first_k_dense_replace": 1,
+        "hidden_act": "silu",
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "rope_scaling": None,
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "vocab_size": 512,
+        "max_position_embeddings": 2048,
+        "tie_word_embeddings": False,
+        "torch_dtype": "float16",
+        "bos_token_id": 0,
+        "eos_token_id": 1,
+    }
+
+
+def gen_checkpoint(model_dir, q_lora):
+    from safetensors.torch import save_file
+    torch.manual_seed(17)
+    os.makedirs(model_dir, exist_ok = True)
+    cfg = make_cfg(q_lora)
+    H = cfg["hidden_size"]
+    heads = cfg["num_attention_heads"]
+    qkh = cfg["qk_nope_head_dim"] + cfg["qk_rope_head_dim"]
+    t = {}
+
+    def lin(key, out_f, in_f, std = 0.02):
+        t[key] = (torch.randn(out_f, in_f) * std).half()
+
+    def vec(key, n):
+        t[key] = (1.0 + torch.randn(n) * 0.1).half()
+
+    t["model.embed_tokens.weight"] = (torch.randn(cfg["vocab_size"], H) * 0.02).half()
+    vec("model.norm.weight", H)
+    lin("lm_head.weight", cfg["vocab_size"], H)
+    for i in range(cfg["num_hidden_layers"]):
+        p = f"model.layers.{i}"
+        vec(f"{p}.input_layernorm.weight", H)
+        vec(f"{p}.post_attention_layernorm.weight", H)
+        if q_lora:
+            lin(f"{p}.self_attn.q_a_proj.weight", q_lora, H)
+            vec(f"{p}.self_attn.q_a_layernorm.weight", q_lora)
+            lin(f"{p}.self_attn.q_b_proj.weight", heads * qkh, q_lora)
+        else:
+            lin(f"{p}.self_attn.q_proj.weight", heads * qkh, H)
+        lin(f"{p}.self_attn.kv_a_proj_with_mqa.weight", cfg["kv_lora_rank"] + cfg["qk_rope_head_dim"], H)
+        vec(f"{p}.self_attn.kv_a_layernorm.weight", cfg["kv_lora_rank"])
+        lin(f"{p}.self_attn.kv_b_proj.weight", heads * (cfg["qk_nope_head_dim"] + cfg["v_head_dim"]), cfg["kv_lora_rank"])
+        lin(f"{p}.self_attn.o_proj.weight", H, heads * cfg["v_head_dim"])
+        if i < cfg["first_k_dense_replace"]:
+            for sk, io in (("gate_proj", (cfg["intermediate_size"], H)), ("up_proj", (cfg["intermediate_size"], H)),
+                           ("down_proj", (H, cfg["intermediate_size"]))):
+                lin(f"{p}.mlp.{sk}.weight", *io)
+        else:
+            lin(f"{p}.mlp.gate.weight", cfg["n_routed_experts"], H)
+            t[f"{p}.mlp.gate.e_score_correction_bias"] = (torch.randn(cfg["n_routed_experts"]) * 0.01).float()
+            for sk in ("gate_proj", "up_proj", "down_proj"):
+                io = (H, cfg["moe_intermediate_size"]) if sk == "down_proj" else (cfg["moe_intermediate_size"], H)
+                lin(f"{p}.mlp.shared_experts.{sk}.weight", *io)
+            for e in range(cfg["n_routed_experts"]):
+                for sk in ("gate_proj", "up_proj", "down_proj"):
+                    io = (H, cfg["moe_intermediate_size"]) if sk == "down_proj" else (cfg["moe_intermediate_size"], H)
+                    lin(f"{p}.mlp.experts.{e}.{sk}.weight", *io)
+
+    save_file(t, os.path.join(model_dir, "model.safetensors"))
+    index = {"metadata": {"total_size": sum(v.numel() * v.element_size() for v in t.values())},
+             "weight_map": {k: "model.safetensors" for k in t}}
+    with open(os.path.join(model_dir, "model.safetensors.index.json"), "w") as f:
+        json.dump(index, f)
+    with open(os.path.join(model_dir, "config.json"), "w") as f:
+        json.dump(cfg, f, indent = 2)
+    print(f"[INFO] generated {len(t)} tensors -> {model_dir} (q_lora={q_lora})")
+
+
+@torch.inference_mode()
+def run(model_dir, hf_check):
+    cfg = Config.from_directory(model_dir)
+    print("[INFO] architecture:", cfg.architecture)
+    if cfg.architecture != "DeepseekV3ForCausalLM":
+        fail(f"Unexpected architecture: {cfg.architecture}")
+
+    model = Model.from_config(cfg)
+    print("[INFO] model graph ok")
+    if not torch.cuda.is_available():
+        fail("CUDA is required for this smoke check")
+    model.load()
+
+    T = 24
+    torch.manual_seed(23)
+    ids = torch.randint(0, 512, (1, T))
+    x = model.modules[0].forward(ids, {}).to("cuda:0")
+    hiddens = []
+    for m in model.modules[1:]:
+        if x.dtype != torch.half:
+            x = x.half()
+        x = m.forward(x, {})
+        hiddens.append(x)
+    logits = x
+    if logits.shape != (1, T, 512):
+        fail(f"Unexpected logits shape {tuple(logits.shape)}")
+    if not torch.isfinite(logits.float()).all():
+        fail("Non-finite logits")
+    print("[INFO] forward ok")
+
+    if hf_check:
+        from transformers import AutoModelForCausalLM
+        ref = AutoModelForCausalLM.from_pretrained(
+            model_dir, dtype = torch.float16, attn_implementation = "eager").to("cuda:0").eval()
+        r = ref(input_ids = ids.to("cuda:0"), output_hidden_states = True, use_cache = False)
+        a, b = logits.float().reshape(-1).cpu(), r.logits.float().reshape(-1).cpu()
+        rel = (a - b).abs().max().item() / (b.abs().max().item() or 1.0)
+        cos = torch.nn.functional.cosine_similarity(a, b, dim = 0).item()
+        print(f"[INFO] HF logits diff: rel {rel:.6f} cos {cos:.6f}")
+        if rel > 3e-2:
+            fail("Logits diverge from HF reference")
+
+    print("[PASS] all checks ok")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_dir", default = "/tmp/ds3_smoke")
+    ap.add_argument("--q_lora_rank", type = int, default = 128)
+    ap.add_argument("--gen", action = "store_true")
+    ap.add_argument("--hf_check", action = "store_true")
+    args = ap.parse_args()
+    if args.gen:
+        gen_checkpoint(args.model_dir, args.q_lora_rank)
+    run(args.model_dir, args.hf_check)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
DeepSeek-V3 style models (MLA + noaux_tc MoE) don't load currently, since there's no MLA anywhere in the tree. This adds a standalone MLAAttention module and wires up DeepseekV3ForCausalLM on top of it.

MLA bits that differ from regular attention:
- low-rank q (optional, `q_lora_rank` can be null, falls back to plain q_proj) and kv projections with decoupled rope
- QK head dim != V head dim (192/128 on the real checkpoints)
- rope applies to interleaved pairs, same layout as the HF modeling code
- with a paged cache, K/V are up-projected and cached at qk_head_dim with V zero-padded, so the standard cache layout and flash-attn path apply (costs some KV memory vs a native latent cache, still much smaller than an equivalent dense model)
- without a cache there are two full-sequence paths: naive up-projected, and absorbed scoring in the kv_lora latent space. The absorbed path reads kv_b's fp16 weight directly, which is why kv_b stays unquantized (q_a/kv_a too)

Tested against HF transformers on small synthetic checkpoints (both q variants, logits match to ~1e-3) and on Moonlight-16B-A3B, where fp16 logits match HF fp16 closer than HF's own fp16-vs-bf16 spread, with 100% argmax agreement. Converted Moonlight at 4 bpw, and the quant generates through the standard Generator at ~52 tok/s on an L40S, with teacher-forced logits from the paged path matching the cacheless forward at 100% argmax agreement across all positions. Smoke test in tests/.
