### PR TITLE
MiMo: Support MTP drafting

### DIFF
--- a/exllamav3/architecture/mimo.py
+++ b/exllamav3/architecture/mimo.py
@@ -1,7 +1,9 @@
 from typing_extensions import override
 from .llama import LlamaConfig, LlamaModel
+from .mimo_mtp import MiMoMTPModel
 
-# Identical to Llama except for MTP layers, ignored for now
+# Llama with an MTP layer, loadable as a separate draft model for
+# self-speculative decoding (component = "mtp")
 
 class MiMoConfig(LlamaConfig):
     arch_string = "MiMoForCausalLM"
@@ -13,9 +15,14 @@ class MiMoConfig(LlamaConfig):
     ):
         super().__init__(
             directory,
-            derived_model = {"text": MiMoModel},
+            derived_model = {"text": MiMoModel, "mtp": MiMoMTPModel},
             **kwargs
         )
+
+        # MTP (multi-token prediction) head — informational; head loaded as separate draft model
+        self.num_nextn_predict_layers = self.read_cfg(int, "num_nextn_predict_layers", 0)
+        if self.num_nextn_predict_layers == 0:
+            del self.model_classes["mtp"]
 
 
 class MiMoModel(LlamaModel):

--- a/exllamav3/architecture/mimo_mtp.py
+++ b/exllamav3/architecture/mimo_mtp.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+from typing_extensions import override
+import torch
+import weakref
+
+from ..model.config import Config
+from ..model.model import Model
+from ..modules import RMSNorm, Embedding, TransformerBlock, Attention, GatedMLP, Linear
+from ..modules.arch_specific.mimo_mtp import MiMoMTPInputLayer
+from ..modules.attn import prepare_for_attn
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .mimo import MiMoConfig
+
+
+class MiMoMTPModel(Model):
+
+    def __init__(
+        self,
+        config: MiMoConfig,
+        **kwargs
+    ):
+        super().__init__(config, **kwargs)
+
+        num_layers = config.num_nextn_predict_layers
+
+        # Module list: token/hidden norms + input_proj, then MTP TransformerBlock(s), then final norm
+        # module key must differ from the block's: the convert stage saves
+        # per-module tensor files named by key, and identical keys clobber
+        self.input_layer = MiMoMTPInputLayer(
+            config = config,
+            key = "model.mtp_layers.0.mtp_in",
+            key_norm_hidden = "model.mtp_layers.0.hidden_layernorm",
+            key_norm_embedding = "model.mtp_layers.0.token_layernorm",
+            key_proj = "model.mtp_layers.0.input_proj",
+            hidden_size = config.hidden_size,
+            rms_norm_eps = config.rms_norm_eps,
+            native_draft_len = 1,
+            out_dtype = torch.float,
+            qbits_key = "mtp_bits",
+        )
+
+        self.modules = [self.input_layer]
+
+        self.first_block_idx = len(self.modules)
+        self.attn_modules = []
+
+        for idx in range(num_layers):
+            attn = Attention(
+                config = config,
+                key = f"model.mtp_layers.{idx}.self_attn",
+                layer_idx = idx,
+                hidden_size = config.hidden_size,
+                head_dim = config.head_dim,
+                num_q_heads = config.num_q_heads,
+                num_kv_heads = config.num_kv_heads,
+                rope_settings = config.rope_settings,
+                sm_scale = None,
+                key_q = "q_proj",
+                key_k = "k_proj",
+                key_v = "v_proj",
+                key_o = "o_proj",
+                qmap = "block.attn",
+                out_dtype = torch.float,
+                qbits_key = "mtp_bits",
+            )
+            self.attn_modules.append(attn)
+
+            self.modules.append(
+                TransformerBlock(
+                    config = config,
+                    key = f"model.mtp_layers.{idx}",
+                    layer_idx = idx,
+                    attn_norm = RMSNorm(
+                        config = config,
+                        key = f"model.mtp_layers.{idx}.input_layernorm",
+                        rms_norm_eps = config.rms_norm_eps,
+                    ),
+                    attn = attn,
+                    mlp_norm = RMSNorm(
+                        config = config,
+                        key = f"model.mtp_layers.{idx}.post_attention_layernorm",
+                        rms_norm_eps = config.rms_norm_eps,
+                    ),
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"model.mtp_layers.{idx}.mlp",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.intermediate_size,
+                        key_up = "up_proj",
+                        key_gate = "gate_proj",
+                        key_down = "down_proj",
+                        qmap = "block.mlp",
+                        interm_dtype = torch.float,
+                        out_dtype = torch.float,
+                        qbits_key = "mtp_bits",
+                    ),
+                )
+            )
+
+        self.last_kv_module_idx = len(self.modules) - 1
+
+        # Final norm. Kept out of the forward chain: the drafting loop feeds this
+        # model's output back as the next step's target_hidden, and MiMo chains
+        # the pre-norm block output (the norm only feeds the head). Applied in
+        # sample_from_state instead.
+        self.final_norm = RMSNorm(
+            config = config,
+            key = f"model.mtp_layers.{num_layers - 1}.final_layernorm",
+            rms_norm_eps = config.rms_norm_eps,
+            out_dtype = torch.half,
+        )
+        self.norm_module_idx = len(self.modules)
+        self.modules.append(self.final_norm)
+
+        self.caps.update({
+            "supports_tp": False,
+            "attach_target": True,
+            "mtp_draft": True,
+            "default_draft_size": 1,  # single depth-1 head; chained drafts decay hard
+            "autosplit_load_fwd": False,
+        })
+
+        # Cross-references populated by attach_to()
+        self.target_embed = None
+        self.target_lm_head = None
+        self.attached_model = None
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        return prepare_for_attn(input_ids, params)
+
+
+    @override
+    def forward(self, input_ids: torch.Tensor, params: dict | None = None):
+        # Chain state stays pre-norm, see above
+        if params is None:
+            params = {}
+        x = self.prepare_inputs(input_ids, params)
+        for module in self.modules[: self.norm_module_idx]:
+            params["layer_instance"] = 0
+            x = module.prepare_for_device(x, params)
+            x = module.forward(x, params)
+        return x
+
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        raise NotImplementedError("MTP draft model does not have its own chat template")
+
+
+    def attach_to(self, target):
+        """
+        Bind to target model: borrow embed_tokens / lm_head and tell target to export hidden state.
+
+        MiMo's MTP layer consumes the trunk's pre-norm residual stream (DeepSeek-style), so the
+        export hooks the last decoder block rather than the final norm.
+        """
+        self.input_layer.attached_model = weakref.ref(target)
+        self.attached_model = weakref.ref(target)
+
+        target_embed = None
+        for m in target.modules:
+            if isinstance(m, Embedding):
+                target_embed = m
+                break
+        assert target_embed is not None, "Could not locate target's Embedding module"
+        self.target_embed = weakref.ref(target_embed)
+
+        assert isinstance(target.modules[-1], Linear), "Expected Linear lm_head as last target module"
+        self.target_lm_head = weakref.ref(target.modules[-1])
+
+        self.draft_verifier_params.update({
+            "export_state_layers": {self.config.num_hidden_layers - 1},
+        })
+
+
+    def default_load_shape_dtype(self, chunk_size):
+        return (1, 1), torch.long
+
+
+    def default_load_params(self, max_chunk_size):
+        return {}
+
+
+    def sample_from_state(
+        self,
+        state: torch.Tensor,
+        params: dict
+    ) -> torch.Tensor:
+        state = self.final_norm.forward(state.to(self.final_norm.device), params, out_dtype = torch.half)
+        if not self.attached_model().loaded_tp:
+            ll = self.attached_model().logit_layer_idx
+            lm = self.attached_model().modules[ll]
+            logits = lm.prepare_for_device(state, params)
+            logits = lm.forward(logits, params)
+            return torch.argmax(logits, dim = -1)
+        else:
+            state = self.attached_model().tp_producer.send(state)
+            argmax = self.attached_model().tp_dispatch_lm_head_argmax((state, {}))
+            return argmax

--- a/exllamav3/modules/arch_specific/mimo_mtp.py
+++ b/exllamav3/modules/arch_specific/mimo_mtp.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+import torch
+from ...model.config import Config
+from ...model.model_tp_fn import mp_model_forward_embedding
+from ...modules import Module, Linear, RMSNorm
+from ...util.tensor import get_for_device, to2
+
+class MiMoMTPInputLayer(Module):
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        key_norm_hidden: str,
+        key_norm_embedding: str,
+        key_proj: str,
+        hidden_size: int,
+        rms_norm_eps: float,
+        native_draft_len: int,
+        out_dtype: torch.dtype | None = torch.float,
+        qmap: str | None = None,
+        qbits_key = "mtp_bits",
+    ):
+        super().__init__(config, key, None)
+        self.module_name = "MiMoMTPInputLayer"
+        self.qmap = qmap
+        self.key = key
+        self.hidden_size = hidden_size
+        self.out_dtype = out_dtype
+        self.native_draft_len = native_draft_len
+        self.key_norm_hidden = key_norm_hidden
+        self.key_norm_embedding = key_norm_embedding
+        self.key_proj = key_proj
+
+        # Norms applied to incoming hidden state and embeddings before they get concatenated
+        self.norm_hidden = RMSNorm(
+            config = config,
+            key = f"{key_norm_hidden}",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.half,
+        )
+        self.norm_embedding = RMSNorm(
+            config = config,
+            key = f"{key_norm_embedding}",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.half,
+        )
+
+        # 2H -> H projection. MiMo concatenates (hidden, embedding), the reverse of Qwen3.5
+        self.proj = Linear(
+            config = config,
+            key = f"{key_proj}",
+            in_features = hidden_size * 2,
+            out_features = hidden_size,
+            qmap = "block.mtp.proj",
+            out_dtype = out_dtype,
+            pad_to = 1,
+            qbits_key = qbits_key,
+        )
+
+        self.register_submodule(self.norm_hidden)
+        self.register_submodule(self.norm_embedding)
+        self.register_submodule(self.proj)
+
+        # Populated by attach_to()
+        self.attached_model = None
+
+        self.caps.update({"x_cpu": True})
+
+
+    def optimizer_targets(self):
+        raise NotImplementedError()
+
+
+    def prepare_for_device(self, x: torch.Tensor, params: dict) -> torch.Tensor:
+        return x
+
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ):
+        # Norm for input state
+        target_hidden = params.get("target_hidden")
+        assert target_hidden is not None, "MiMo MTP requires target_hidden"
+        assert target_hidden.shape[:-1] == x.shape, \
+            f"MiMo MTP token/state shape mismatch: {tuple(x.shape)} vs {tuple(target_hidden.shape)}"
+        y = get_for_device(params, "target_hidden", self.device)
+        y = self.norm_hidden.forward(y, params)
+
+        # Token embedding
+        if not self.attached_model().loaded_tp:
+            x = self.attached_model().modules[0].forward(x, params, out_dtype = torch.half)
+        else:
+            x = self.attached_model().tp_producer.send(x)
+            x = self.attached_model().tp_dispatch_master(mp_model_forward_embedding, (x, params))
+            x = x.half()
+        x = self.norm_embedding.forward(x.to(self.device), params)
+
+        # Project
+        x = torch.cat((y, x.to(y.device)), dim = -1)
+        x = self.proj.forward(x, params)
+        return to2(x, out_dtype, self.out_dtype)
+
+
+    def get_compile_sizes(self, stc):
+        return (
+            stc.get_tensor_sizes(self.key_norm_hidden) +
+            stc.get_tensor_sizes(self.key_norm_embedding) +
+            stc.get_tensor_sizes(self.key_proj)
+        )
+
+    def get_compile_tensors(self, stc):
+        r = {}
+        r.update(stc.get_tensors(self.key_norm_hidden, allow_bf16 = True))
+        r.update(stc.get_tensors(self.key_norm_embedding, allow_bf16 = True))
+        r.update(stc.get_tensors(self.key_proj, allow_bf16 = True))
+        return r


### PR DESCRIPTION
mimo.py has said "MTP layers, ignored for now" for a while. This wires MiMo's MTP layer into the existing MTP draft machinery, same component pattern as qwen3_5_mtp (loads with `component="mtp"` / `--mtp`).

MiMo's head is DeepSeek-style rather than Qwen3.5-style, which comes down to three differences:
- it consumes the pre-norm residual from the last block, so `attach_to()` exports via `export_state_layers` instead of `export_state_norm_keys`
- `input_proj` concatenates (hidden, embedding), the reverse of Qwen3.5's fc
- the chained draft state has to stay pre-norm: `final_layernorm` only feeds the head, so the model's forward stops before it and `sample_from_state` applies it

`default_draft_size` is 1: the released checkpoint has a single depth-1 head and acceptance falls off hard past the first drafted token (~30% aggregate at 3). At 1, acceptance on MiMo-7B-RL is ~88% on code prompts, ~50-70% on prose, and greedy output matches the non-draft path token for token, up to the usual near-tie flips from the q_len=2 verify batch.
