### PR TITLE
Disable parallel quantization for mul1 codebook

### DIFF
--- a/exllamav3/conversion/convert_model.py
+++ b/exllamav3/conversion/convert_model.py
@@ -189,6 +189,10 @@ def prepare(args) -> (dict, dict, bool, str):
     in_args["verbose"] = args.verbose
     in_args["apply_out_scales"] = {"always": True, "never": False, "auto": None}[args.out_scales]
 
+    if in_args["codebook"] == "mul1" and in_args["parallel_mode"]:
+        print(" !! Warning: --parallel_mode is currently unsafe with --codebook mul1; disabling parallel mode")
+        in_args["parallel_mode"] = False
+
     if args.resume:
         job_state = load_dict("ckpt/job.json", in_args)
         print(f" -- Resuming existing job")


### PR DESCRIPTION
## Summary

`convert.py --parallel_mode` is currently unsafe with `--codebook mul1`. In a full GLM-5.2 MUL1 quant run it corrupts layer-0 EXL3 scale metadata (`.suh` tensors containing NaN/Inf), which then poisons layer-1 calibration Hessians and causes Cholesky failure.

This PR disables `parallel_mode` automatically when the selected codebook is `mul1`, with a warning, while leaving the existing parallel path unchanged for the default MCG codebook.

## Validation

- Syntax check: `python -m py_compile exllamav3/conversion/convert_model.py`
- Reproduced failure with `--codebook mul1 --parallel_mode`: layer 0 produced NaN/Inf `.suh`; layer 1 Hessians became all-NaN and Cholesky failed.
- Retested GLM-5.2 full 3.0bpw MUL1 quant with serial mode: cleanly passed layers 0, 1, and 2 and reached loading layer 3. Layer-0 saved tensors had no NaN/Inf floating tensors.

## Notes

This is a conservative correctness guard. It avoids the known-bad combination without changing quantization kernels or the parallel path for other codebooks.
