### PR TITLE
Fix non-contiguous attn output crash and formatron import guard

### DIFF
--- a/exllamav3/generator/filter/formatron.py
+++ b/exllamav3/generator/filter/formatron.py
@@ -13,6 +13,15 @@ except ModuleNotFoundError:
     formatron_available = False
 except ImportError:
     formatron_available = False
+except Exception:
+    formatron_available = False
+    try:
+        import kbnf
+    except Exception:
+        kbnf = None
+    FormatterBuilder = None
+    EngineGenerationConfig = None
+    get_original_characters = default_mask_logits_fn = get_bit_mask = None
 
 
 @lru_cache(10)

--- a/exllamav3/modules/attn.py
+++ b/exllamav3/modules/attn.py
@@ -683,7 +683,7 @@ class Attention(Module):
         )
 
         if self.headwise_gate: ext.mul_sigmoid_broadcast_(o, g)
-        o = o.view((bsz, seqlen, self.num_q_heads * self.head_dim))
+        o = o.reshape((bsz, seqlen, self.num_q_heads * self.head_dim))
         if self.full_gate or self.interleaved_gate: ext.mul_sigmoid_(o, g)
 
         o = self.project_o(o, bsz, seqlen, params)
@@ -757,7 +757,7 @@ class Attention(Module):
         )
 
         if self.headwise_gate: ext.mul_sigmoid_broadcast_(o, g)
-        o = o.view((bsz, seqlen, self.num_q_heads * self.head_dim))
+        o = o.reshape((bsz, seqlen, self.num_q_heads * self.head_dim))
         if self.full_gate or self.interleaved_gate: ext.mul_sigmoid_(o, g)
 
         o = self.project_o(o, bsz, seqlen, params)


### PR DESCRIPTION
## Summary

Two small fixes for issues hit while quantizing and serving a Gemma 4 31B derivative:

1. **`modules/attn.py`: use `reshape()` instead of `view()` on attention output.** Gemma 4's global-attention layers (head_dim 512) fall through to the torch SDPA fallback when flash-attn (head_dim <= 256) and xformers are unavailable. SDPA can return a non-contiguous (transposed-view) output, so `o.view(...)` raises `RuntimeError`. `reshape()` is a no-op for contiguous outputs and copies only when required. Hit reproducibly during `convert.py` on a Gemma-4-31B model, crashing in the forward pass at the first global-attention layer.

2. **`generator/filter/formatron.py`: treat any import-time failure as formatron-unavailable.** The guard only catches `ModuleNotFoundError` / `ImportError`, but formatron/kbnf can raise other exceptions at import time (e.g. dependency version conflicts), which makes the entire `exllamav3` package unimportable. Broaden the guard, keep `kbnf` importable separately (it is referenced in annotations), and stub the formatron names.

## Validation

- Converted bf16 -> EXL3 6.0 bpw on a Gemma-4-31B derivative ([caipiralink/Gemma-4-Gembrain-31B-it-uncensored-heretic-EXL3-6.0bpw](https://huggingface.co/caipiralink/Gemma-4-Gembrain-31B-it-uncensored-heretic-EXL3-6.0bpw)) with these patches; without (1) the conversion crashes at the first global-attention layer.
- Text generation verified against dev @ 2f297e4 on H200, torch 2.9.1+cu130, flash-attn 2.8.3.