### PR TITLE
Fix recurrent state desync after atomic MM prefill

### DIFF
--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -1149,6 +1149,13 @@ class Job:
                         }
                     )
 
+                # Atomic MM prefill may have extended the forward pass past prefill_end, advancing any
+                # recurrent state beyond the chunk boundary. The extension is processed again by the
+                # next chunk, so rewind to keep the state position in sync with kv_position. Re-fed
+                # tokens map to the same state slots with the same values, leaving state content intact.
+                if self.recurrent_state is not None and self.recurrent_state.position > prefill_end:
+                    self.recurrent_state.rewind(self.recurrent_state.position - prefill_end)
+
                 seq.kv_position = prefill_end
 
                 p2 = min(p1 + 1, len(seq.allocated_pages))


### PR DESCRIPTION
## Summary

Fixes #228 (AssertionError in `sliding_attn.py` `unstash()` after vision input with Gemma4).

`atomic_mm_prefill` extends a prefill chunk's forward pass past `prefill_end` when the chunk boundary lands inside an image token span. The extended tail is intentionally processed again by the next chunk (idempotent for the paged K/V cache), but `advance_recurrent_states()` advances recurrent states by the full forwarded length each time, so the overlap is counted twice and the SWA state position runs permanently ahead of `kv_position`.

Checkpoints stashed at page boundaries then record the desynced position. When a follow-up request revives such a checkpoint, `new_from_stashed()` passes `position = cached_pages * PAGE_SIZE`, and `assert self.position == stashed["position"]` in `SWAState.unstash()` fires. (The commented-out assert at the top of `Job.prefill()` — "Atomic prefill is not supported for recurrent models" — marks this conflict.)

## Fix

Rewind the recurrent state to `prefill_end` after each chunk, the same idiom used for draft-token rejection in speculative decoding. The re-fed overlap tokens map to the same state slots with the same values, so state content is unaffected; only the position bookkeeping is corrected. States no longer advance past `kv_position`, so stashed checkpoints are valid again.

## Reproduction and validation

Deterministic repro on a Gemma-4-31B derivative ([caipiralink/Gemma-4-Gembrain-31B-it-uncensored-heretic-EXL3-6.0bpw](https://huggingface.co/caipiralink/Gemma-4-Gembrain-31B-it-uncensored-heretic-EXL3-6.0bpw)), dev @ 2f297e4, H200, torch 2.9.1+cu130:

1. Build a prompt with one image such that the last-page boundary `(len - 1) // 256 * 256` falls inside the image token span, making the `recurrent_last_page` chunk collide with the atomic MM extension.
2. Run the job to completion (works), then submit a follow-up request extending the same conversation with the same `MMEmbedding` objects (as TabbyAPI does via its embedding cache). Page hashes match, `allocate_pages()` revives the stashed checkpoint, and unstash asserts with the exact traceback from #228.
3. With this fix, the follow-up completes, and the revived state produces correct grounded output (the model accurately answers questions about the image content after checkpoint revival).