### PR TITLE
[kernel] Persistent route-packed (route_block x n_tile) schedule for exl3 fused MoE (sm120)

### DIFF
--- a/exllamav3/exllamav3_ext/bindings.cpp
+++ b/exllamav3/exllamav3_ext/bindings.cpp
@@ -95,6 +95,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("pack_signs", &pack_signs, "pack_signs");
     m.def("reconstruct", &reconstruct, "reconstruct");
     m.def("reconstruct_slice", &reconstruct_slice, "reconstruct_slice");
+    m.def("reconstruct_fp8dg_nt", &reconstruct_fp8dg_nt, "reconstruct_fp8dg_nt");
     m.def("had_r_128", &had_r_128, "had_r_128");
     m.def("exl3_gemm", &exl3_gemm, "exl3_gemm");
     m.def("exl3_gemv", &exl3_gemv, "exl3_gemv");
@@ -146,6 +147,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("blocksparse_mlp_routing", &blocksparse_mlp_routing, "blocksparse_mlp_routing");
     m.def("exl3_moe_max_concurrency", &exl3_moe_max_concurrency, "exl3_moe_max_concurrency");
     m.def("exl3_moe", &exl3_moe, "exl3_moe");
+    m.def("exl3_moe_fused", &exl3_moe_fused, "exl3_moe_fused");
+    m.def("exl3_moe_fused_retile", &exl3_moe_fused_retile, "exl3_moe_fused_retile");
 
     m.def("bighead_attn", &bighead_attn, "bighead_attn");
     m.def("bighead_attn_paged", &bighead_attn_paged, "bighead_attn_paged");

--- a/exllamav3/exllamav3_ext/hgemm.cu
+++ b/exllamav3/exllamav3_ext/hgemm.cu
@@ -59,18 +59,23 @@ static void hgemm_gemmex_impl
     void* ws = DevCtx::instance().get_ws(device);
     cublasSetWorkspace(cublas_handle, ws, WORKSPACE_SIZE);
 
-    float alpha_ = 1.0f;
-    float beta_ = 0.0f;
     cudaDataType_t c_type = output_fp32 ? CUDA_R_32F : CUDA_R_16F;
+    float alpha_f = 1.0f;
+    float beta_f = 0.0f;
+    half alpha_h = __float2half(1.0f);
+    half beta_h = __float2half(0.0f);
+    const void* alpha = output_fp16 ? (const void*) &alpha_h : (const void*) &alpha_f;
+    const void* beta = output_fp16 ? (const void*) &beta_h : (const void*) &beta_f;
+    auto compute_type = output_fp16 ? CUBLAS_COMPUTE_16F : CUBLAS_COMPUTE_32F;
     auto r = cublasGemmEx
     (
         cublas_handle,
         CUBLAS_OP_N, CUBLAS_OP_N,
         size_n, size_m, size_k,
-        &alpha_, b_ptr, CUDA_R_16F, size_n,
-                 a_ptr, CUDA_R_16F, size_k,
-        &beta_,  c.data_ptr(), c_type, (int) c_stride_m,
-        CUBLAS_COMPUTE_32F,
+        alpha, b_ptr, CUDA_R_16F, size_n,
+               a_ptr, CUDA_R_16F, size_k,
+        beta,  c.data_ptr(), c_type, (int) c_stride_m,
+        compute_type,
         CUBLAS_GEMM_DEFAULT_TENSOR_OP
     );
     cublas_check(r);

--- a/exllamav3/exllamav3_ext/quant/comp_units/exl3_moe_inst_3.cu
+++ b/exllamav3/exllamav3_ext/quant/comp_units/exl3_moe_inst_3.cu
@@ -3,3 +3,6 @@
 
 fp_exl3_moe_kernel exl3_moe_kernel_k3_n128() { return exl3_moe_kernel<3, 128>; }
 fp_exl3_moe_kernel exl3_moe_kernel_k3_n256() { return exl3_moe_kernel<3, 256>; }
+
+fp_exl3_moe_kernel exl3_moe_retile_kernel_k3_n128() { return exl3_moe_kernel<3, 128, true>; }
+fp_exl3_moe_kernel exl3_moe_retile_kernel_k3_n256() { return exl3_moe_kernel<3, 256, true>; }

--- a/exllamav3/exllamav3_ext/quant/comp_units/exl3_moe_instances.cuh
+++ b/exllamav3/exllamav3_ext/quant/comp_units/exl3_moe_instances.cuh
@@ -20,4 +20,10 @@ EXL3_MOE_DECLARE_GETTERS(8);
 
 #undef EXL3_MOE_DECLARE_GETTERS
 
+// Accuracy-first A1 specialization for the fixed GLM-5.2 TR3 bitrate. The
+// legacy instance table above remains unchanged for the default entrypoints.
+fp_exl3_moe_kernel exl3_moe_retile_kernel_k3_n128();
+fp_exl3_moe_kernel exl3_moe_retile_kernel_k3_n256();
+
 extern fp_exl3_moe_kernel exl3_moe_kernel_instances[];
+extern fp_exl3_moe_kernel exl3_moe_retile_kernel_instances[];

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
@@ -62,7 +62,7 @@ int* DevCtx::get_locks(int device)
     if (!locks[device])
     {
         cudaSetDevice(device);
-        size_t size = (MAX_TILES_C + MAX_BARRIERS * 2) * sizeof(int);
+        size_t size = (MAX_TILES_C + MAX_BARRIERS * 2 + MOE_SCHED_INTS) * sizeof(int);
         cudaMalloc(&locks[device], size);
         cudaMemset(locks[device], 0, size);
     }

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
@@ -8,6 +8,13 @@
 #define MAX_BARRIERS 1024
 #define BARRIER_LOCKS_OFFSET MAX_TILES_C
 
+// MoE expert scheduler state, after the barrier counters: [0] next ticket,
+// [1] retired groups, [2 + group] ticket published to group. The state is
+// self-resetting and is zero-initialized with the rest of the lock buffer.
+#define MOE_MAX_GROUPS 64
+#define MOE_SCHED_OFFSET (MAX_TILES_C + 2 * MAX_BARRIERS)
+#define MOE_SCHED_INTS (2 + MOE_MAX_GROUPS)
+
 // Workspace size
 #define WORKSPACE_SIZE (16*1024*1024)
 

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
@@ -4,9 +4,25 @@
 
 // Constants
 #define EXL3_GEMM_BASE_THREADS 256
-#define SMEM_MAX (90 * 1024)  // max shared memory on compute capability 8.6
+#ifndef EXL3_SMEM_MAX_BYTES
+#define EXL3_SMEM_MAX_BYTES (90 * 1024)
+#endif
+#ifndef SMEM_MAX
+#define SMEM_MAX EXL3_SMEM_MAX_BYTES
+#endif
 
 #include "exl3_dq.cuh"
+
+// On GA10x and sm_120 consumer silicon, fp32-accumulating HMMA runs at
+// half rate. Accumulate each k-slice in fp16 and fold it into the persistent
+// fp32 accumulators before reduction. This changes numerical accumulation and
+// therefore remains an accuracy-gated optional variant.
+#if defined(__CUDA_ARCH__) && \
+    ((__CUDA_ARCH__ == 860) || (__CUDA_ARCH__ == 1200))
+    #define EXL3_GEMM_H_ACC 1
+#else
+    #define EXL3_GEMM_H_ACC 0
+#endif
 
 template<EXL3_GEMM_T_ARGS, bool shmem_out_had>
 inline __device__
@@ -44,7 +60,7 @@ void exl3_gemm_kernel_inner
 
     // Sanity checks
     static_assert(EXL3_GEMM_BASE_THREADS == 256);
-    static_assert(TILESIZE_M == 16, "Invalid kernel params");                     // strictly assume size_m <= 16
+    static_assert(TILESIZE_M % 16 == 0, "Invalid kernel params");
     static_assert(TILESIZE_K % 16 == 0, "Invalid kernel params");
     static_assert(TILESIZE_N % 128 == 0, "Invalid kernel params");
     static_assert
@@ -189,9 +205,12 @@ void exl3_gemm_kernel_inner
     half* gl_c_ptr_16 = ((half*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
     float* gl_c_ptr_32 = ((float*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
 
-    register FragA frag_a[FRAG_STAGES];
+    register FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
     register FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
-    register FragC frag_c[FRAGS_N_PER_WARP];
+    register FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+    #if EXL3_GEMM_H_ACC
+        register FragC_h frag_c_h[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+    #endif
 
     auto advance2 = [&] ()
     {
@@ -266,7 +285,7 @@ void exl3_gemm_kernel_inner
             {
                 int R = r + m * 16;
                 int c_swizzled = base_c ^ ((R >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK);
-                ldsm4(frag_a[buf], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
+                ldsm4(frag_a[buf][m], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
             }
         }
 
@@ -288,14 +307,27 @@ void exl3_gemm_kernel_inner
     auto clear_frag_c = [&] ()
     {
         #pragma unroll
-        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
-            frag_c[n] = {};
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                frag_c[m][n] = {};
+        }
+        #if EXL3_GEMM_H_ACC
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    frag_c_h[m][n] = {};
+            }
+        #endif
     };
 
     // Threadblock reduction
     auto threadblock_reduce = [&] ()
     {
-        auto store = [&] (int i)
+        auto store = [&] (int i, int m)
         {
             if (sub_k == i)
             {
@@ -304,13 +336,13 @@ void exl3_gemm_kernel_inner
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
                     #pragma unroll
-                    for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[n][j];
+                    for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[m][n][j];
                 }
             }
             __syncthreads();
         };
 
-        auto add = [&] (int i)
+        auto add = [&] (int i, int m)
         {
             if (sub_k == i)
             {
@@ -319,87 +351,97 @@ void exl3_gemm_kernel_inner
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
                     #pragma unroll
-                    for (int j = 0; j < 4; ++j) frag_c[n][j] += *sh_red++;
+                    for (int j = 0; j < 4; ++j) frag_c[m][n][j] += *sh_red++;
                 }
             }
         };
 
-        auto store_small = [&] (int i)
+        auto store_small = [&] (int i, int m)
         {
-            if (sub_k == i && lane_id / 4 < size_m)
+            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
             {
                 float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
-                    *sh_red++ = frag_c[n][0];
-                    *sh_red++ = frag_c[n][1];
+                    *sh_red++ = frag_c[m][n][0];
+                    *sh_red++ = frag_c[m][n][1];
                 }
             }
             __syncthreads();
         };
 
-        auto add_small = [&] (int i)
+        auto add_small = [&] (int i, int m)
         {
-            if (sub_k == i && lane_id / 4 < size_m)
+            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
             {
                 float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
-                    frag_c[n][0] += *sh_red++;
-                    frag_c[n][1] += *sh_red++;
+                    frag_c[m][n][0] += *sh_red++;
+                    frag_c[m][n][1] += *sh_red++;
                 }
             }
         };
 
-        if (size_m <= 8)
+        // Reuse the same reduction scratch for each 16-row M block. The
+        // barrier between blocks prevents the next store from racing the
+        // preceding add without increasing the dynamic-smem footprint.
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
         {
-            if constexpr (TILEBLOCKS_K == 2)
+            if (size_m <= 8)
             {
-                store_small(1);
-                add_small(0);
+                if constexpr (TILEBLOCKS_K == 2)
+                {
+                    store_small(1, m);
+                    add_small(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 3)
+                {
+                    store_small(1, m);
+                    add_small(0, m);
+                    store_small(2, m);
+                    add_small(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 4)
+                {
+                    store_small(3, m);
+                    add_small(2, m);
+                    store_small(1, m);
+                    add_small(0, m);
+                    store_small(2, m);
+                    add_small(0, m);
+                }
             }
-            if constexpr (TILEBLOCKS_K == 3)
+            else
             {
-                store_small(1);
-                add_small(0);
-                store_small(2);
-                add_small(0);
+                if constexpr (TILEBLOCKS_K == 2)
+                {
+                    store(1, m);
+                    add(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 3)
+                {
+                    store(1, m);
+                    add(0, m);
+                    store(2, m);
+                    add(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 4)
+                {
+                    store(3, m);
+                    add(2, m);
+                    store(1, m);
+                    add(0, m);
+                    store(2, m);
+                    add(0, m);
+                }
             }
-            if constexpr (TILEBLOCKS_K == 4)
-            {
-                store_small(3);
-                add_small(2);
-                store_small(1);
-                add_small(0);
-                store_small(2);
-                add_small(0);
-            }
-        }
-        else
-        {
-            if constexpr (TILEBLOCKS_K == 2)
-            {
-                store(1);
-                add(0);
-            }
-            if constexpr (TILEBLOCKS_K == 3)
-            {
-                store(1);
-                add(0);
-                store(2);
-                add(0);
-            }
-            if constexpr (TILEBLOCKS_K == 4)
-            {
-                store(3);
-                add(2);
-                store(1);
-                add(0);
-                store(2);
-                add(0);
-            }
+
+            if constexpr (TILEBLOCKS_K > 1 && TILEBLOCKS_M > 1)
+                if (m + 1 < TILEBLOCKS_M) __syncthreads();
         }
     };
 
@@ -407,28 +449,32 @@ void exl3_gemm_kernel_inner
     auto write_sum_tile_sh = [&]()
     {
         const int n0 = warp_id * FRAGS_N_PER_WARP;
-        const int r0 = lane_id / 4;
-        const int r1 = r0 + 8;
-        if (r0 < size_m)
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
         {
-            const int c = (lane_id % 4) * 2;
-            #pragma unroll
-            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            const int r0 = m * 16 + lane_id / 4;
+            const int r1 = r0 + 8;
+            if (r0 < size_m)
             {
-                float* c_ptr = ((float*) sh_c) + r0 * TILESIZE_N + (n0 + n) * 8 + c;
-                *c_ptr++ = frag_c[n][0];
-                *c_ptr++ = frag_c[n][1];
+                const int c = (lane_id % 4) * 2;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float* c_ptr = sh_c + r0 * TILESIZE_N + (n0 + n) * 8 + c;
+                    *c_ptr++ = frag_c[m][n][0];
+                    *c_ptr++ = frag_c[m][n][1];
+                }
             }
-        }
-        if (r1 < size_m)
-        {
-            const int c = (lane_id % 4) * 2;
-            #pragma unroll
-            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            if (r1 < size_m)
             {
-                float* c_ptr = ((float*) sh_c) + r1 * TILESIZE_N + (n0 + n) * 8 + c;
-                *c_ptr++ = frag_c[n][2];
-                *c_ptr++ = frag_c[n][3];
+                const int c = (lane_id % 4) * 2;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float* c_ptr = sh_c + r1 * TILESIZE_N + (n0 + n) * 8 + c;
+                    *c_ptr++ = frag_c[m][n][2];
+                    *c_ptr++ = frag_c[m][n][3];
+                }
             }
         }
     };
@@ -464,41 +510,45 @@ void exl3_gemm_kernel_inner
     {
         int n0 = warp_id * FRAGS_N_PER_WARP;
         #pragma unroll
-        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
         {
-            int r0 = lane_id / 4;
-            int r1 = r0 + 8;
-            int c = (lane_id % 4) * 2;
-            if (r0 < size_m)
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
             {
-                if constexpr (c_fp32)
+                int r0 = m * 16 + lane_id / 4;
+                int r1 = r0 + 8;
+                int c = (lane_id % 4) * 2;
+                if (r0 < size_m)
                 {
-                    float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
-                    frag_c[n][0] += *c_ptr++;
-                    frag_c[n][1] += *c_ptr++;
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
+                        frag_c[m][n][0] += *c_ptr++;
+                        frag_c[m][n][1] += *c_ptr++;
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
+                        float2 interm = __half22float2(*c_ptr);
+                        frag_c[m][n][0] += interm.x;
+                        frag_c[m][n][1] += interm.y;
+                    }
                 }
-                else
+                if (r1 < size_m)
                 {
-                    half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
-                    float2 interm = __half22float2(*c_ptr);
-                    frag_c[n][0] += interm.x;
-                    frag_c[n][1] += interm.y;
-                }
-            }
-            if (r1 < size_m)
-            {
-                if constexpr (c_fp32)
-                {
-                    float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
-                    frag_c[n][2] += *c_ptr++;
-                    frag_c[n][3] += *c_ptr++;
-                }
-                else
-                {
-                    half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
-                    float2 interm = __half22float2(*c_ptr);
-                    frag_c[n][2] += interm.x;
-                    frag_c[n][3] += interm.y;
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
+                        frag_c[m][n][2] += *c_ptr++;
+                        frag_c[m][n][3] += *c_ptr++;
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
+                        float2 interm = __half22float2(*c_ptr);
+                        frag_c[m][n][2] += interm.x;
+                        frag_c[m][n][3] += interm.y;
+                    }
                 }
             }
         }
@@ -508,39 +558,43 @@ void exl3_gemm_kernel_inner
     {
         int n0 = warp_id * FRAGS_N_PER_WARP;
         #pragma unroll
-        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
         {
-            int r0 = lane_id / 4;
-            int r1 = r0 + 8;
-            int c = (lane_id % 4) * 2;
-            if (r0 < size_m)
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
             {
-                if constexpr (c_fp32)
+                int r0 = m * 16 + lane_id / 4;
+                int r1 = r0 + 8;
+                int c = (lane_id % 4) * 2;
+                if (r0 < size_m)
                 {
-                    float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
-                    *c_ptr++ = frag_c[n][0];
-                    *c_ptr++ = frag_c[n][1];
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[m][n][0];
+                        *c_ptr++ = frag_c[m][n][1];
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
+                        half2 sum = __floats2half2_rn(frag_c[m][n][0], frag_c[m][n][1]);
+                        *c_ptr = sum;
+                    }
                 }
-                else
+                if (r1 < size_m)
                 {
-                    half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
-                    half2 sum = __floats2half2_rn(frag_c[n][0], frag_c[n][1]);
-                    *c_ptr = sum;
-                }
-            }
-            if (r1 < size_m)
-            {
-                if constexpr (c_fp32)
-                {
-                    float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
-                    *c_ptr++ = frag_c[n][2];
-                    *c_ptr++ = frag_c[n][3];
-                }
-                else
-                {
-                    half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
-                    half2 sum = __floats2half2_rn(frag_c[n][2], frag_c[n][3]);
-                    *c_ptr = sum;
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[m][n][2];
+                        *c_ptr++ = frag_c[m][n][3];
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
+                        half2 sum = __floats2half2_rn(frag_c[m][n][2], frag_c[m][n][3]);
+                        *c_ptr = sum;
+                    }
                 }
             }
         }
@@ -549,6 +603,24 @@ void exl3_gemm_kernel_inner
     // Output reduction
     auto reduce = [&] ()
     {
+        #if EXL3_GEMM_H_ACC
+            // Fold the fp16 MMA accumulators into fp32 once per k-slice.
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float2 f0 = __half22float2(frag_c_h[m][n][0]);
+                    float2 f1 = __half22float2(frag_c_h[m][n][1]);
+                    frag_c[m][n][0] += f0.x;
+                    frag_c[m][n][1] += f0.y;
+                    frag_c[m][n][2] += f1.x;
+                    frag_c[m][n][3] += f1.y;
+                }
+            }
+        #endif
+
         // First reduce all partial sums along k for the current slice
         threadblock_reduce();
 
@@ -607,8 +679,18 @@ void exl3_gemm_kernel_inner
     auto matmul = [&] (int buf)
     {
         #pragma unroll
-        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
-            ptx_mma_m16n8k16(frag_a[buf], frag_b[buf][n], frag_c[n]);
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            {
+                #if EXL3_GEMM_H_ACC
+                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c_h[m][n]);
+                #else
+                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c[m][n]);
+                #endif
+            }
+        }
     };
 
     // Start global to shared pipeline

--- a/exllamav3/exllamav3_ext/quant/exl3_moe.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe.cu
@@ -1,4 +1,5 @@
 #include <cuda_fp16.h>
+#include <cuda_bf16.h>
 #include "exl3_gemm.cuh"
 
 #include <c10/cuda/CUDAGuard.h>
@@ -9,7 +10,102 @@ namespace cg = cooperative_groups;
 #include "../util.cuh"
 #include "comp_units/exl3_moe_instances.cuh"
 #include "exl3_devctx.cuh"
-#include <set>
+#include <map>
+#include <mutex>
+
+template <typename id_t>
+__global__ void exl3_route_histogram_kernel
+(
+    const id_t* __restrict__ topk_ids,
+    const int64_t* __restrict__ expert_map,
+    int64_t* __restrict__ expert_count,
+    int64_t num_routes
+)
+{
+    for (int64_t r = blockIdx.x * blockDim.x + threadIdx.x;
+         r < num_routes; r += (int64_t) blockDim.x * gridDim.x)
+    {
+        int64_t e = expert_map[topk_ids[r]];
+        atomicAdd(reinterpret_cast<unsigned long long*>(expert_count + e), 1ULL);
+    }
+}
+
+__global__ void exl3_route_scan_kernel
+(
+    const int64_t* __restrict__ expert_count,
+    int64_t* __restrict__ expert_offsets,
+    int num_buckets
+)
+{
+    if (blockIdx.x || threadIdx.x) return;
+    int64_t sum = 0;
+    for (int e = 0; e < num_buckets; ++e)
+    {
+        expert_offsets[e] = sum;
+        sum += expert_count[e];
+    }
+}
+
+template <typename weight_t>
+__device__ __forceinline__ half exl3_route_to_half(weight_t v)
+{
+    return __float2half(static_cast<float>(v));
+}
+template <>
+__device__ __forceinline__ half exl3_route_to_half<half>(half v) { return v; }
+template <>
+__device__ __forceinline__ half exl3_route_to_half<__nv_bfloat16>(__nv_bfloat16 v)
+{
+    return __float2half(__bfloat162float(v));
+}
+
+template <typename id_t, typename weight_t>
+__global__ void exl3_route_pack_stable_kernel
+(
+    const id_t* __restrict__ topk_ids,
+    const weight_t* __restrict__ topk_weights,
+    const int64_t* __restrict__ expert_map,
+    int64_t* __restrict__ expert_offsets,
+    int64_t* __restrict__ token_sorted,
+    half* __restrict__ weight_sorted,
+    int64_t num_routes,
+    int topk
+)
+{
+    // One block per local expert (including the sentinel). Each block scans
+    // routes in source order and uses a deterministic block prefix, preserving
+    // the exact stable expert-grouped ordering of torch.argsort.
+    __shared__ int flags[256];
+    __shared__ int running;
+    if (threadIdx.x == 0) running = 0;
+    __syncthreads();
+    const int64_t expert = blockIdx.x;
+    for (int64_t base = 0; base < num_routes; base += blockDim.x)
+    {
+        int64_t r = base + threadIdx.x;
+        int flag = 0;
+        if (r < num_routes) flag = expert_map[topk_ids[r]] == expert;
+        flags[threadIdx.x] = flag;
+        __syncthreads();
+        for (int stride = 1; stride < blockDim.x; stride <<= 1)
+        {
+            int v = threadIdx.x >= stride ? flags[threadIdx.x - stride] : 0;
+            __syncthreads();
+            flags[threadIdx.x] += v;
+            __syncthreads();
+        }
+        if (flag)
+        {
+            int64_t dst = expert_offsets[expert] + running
+                        + flags[threadIdx.x] - 1;
+            token_sorted[dst] = r / topk;
+            weight_sorted[dst] = exl3_route_to_half(topk_weights[r]);
+        }
+        __syncthreads();
+        if (threadIdx.x == 0) running += flags[blockDim.x - 1];
+        __syncthreads();
+    }
+}
 
 int exl3_moe_max_concurrency(int device)
 {
@@ -17,7 +113,27 @@ int exl3_moe_max_concurrency(int device)
     return num_sms / MOE_SMS_PER_EXPERT;
 }
 
-std::set<void*> moe_kernel_attr_set[MAX_DEVICES] = {};
+std::map<void*, int> moe_kernel_attr_smem[MAX_DEVICES] = {};
+std::mutex moe_kernel_attr_mutex[MAX_DEVICES];
+static thread_local int exl3_moe_dq_threshold = 0;
+static thread_local bool exl3_moe_a1_retile = false;
+
+class Exl3MoeA1RetileScope
+{
+private:
+    bool previous;
+
+public:
+    Exl3MoeA1RetileScope(): previous(exl3_moe_a1_retile)
+    {
+        exl3_moe_a1_retile = true;
+    }
+
+    ~Exl3MoeA1RetileScope()
+    {
+        exl3_moe_a1_retile = previous;
+    }
+};
 
 fp_exl3_moe_kernel exl3_moe_kernel_instances[] =
 {
@@ -30,6 +146,12 @@ fp_exl3_moe_kernel exl3_moe_kernel_instances[] =
     exl3_moe_kernel_k6_n128(), exl3_moe_kernel_k6_n256(),
     exl3_moe_kernel_k7_n128(), exl3_moe_kernel_k7_n256(),
     exl3_moe_kernel_k8_n128(), exl3_moe_kernel_k8_n256()
+};
+
+fp_exl3_moe_kernel exl3_moe_retile_kernel_instances[] =
+{
+    exl3_moe_retile_kernel_k3_n128(),
+    exl3_moe_retile_kernel_k3_n256()
 };
 
 /*
@@ -88,6 +210,10 @@ inputs:
     down_mcg
     down_mul1:
         bool, codebook flags
+
+    num_active:
+        number of nonempty experts handled by this kernel, used to size the
+        launch. Pass -1 for the exact legacy 8-SM round-robin schedule.
 */
 
 void exl3_moe
@@ -126,11 +252,16 @@ void exl3_moe
     const bool down_mcg,
     const bool down_mul1,
 
-    const float act_limit
+    const float act_limit,
+    const int num_active
 )
 {
     const at::cuda::OptionalCUDAGuard device_guard(hidden_state.device());
     cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK(num_active >= -1, "num_active must be -1 or nonnegative");
+    if (num_active == 0) return;
+    const bool a1_retile = exl3_moe_a1_retile;
 
     // Validate args
     TORCH_CHECK_DTYPE(hidden_state, kHalf);
@@ -157,6 +288,9 @@ void exl3_moe
     TORCH_CHECK_SHAPES_FULL(temp_state_g, temp_state_u);
     size_t max_tokens_per_expert = temp_state_g.size(1);
     size_t concurrency = temp_state_g.size(0);
+    if (a1_retile)
+        TORCH_CHECK(max_tokens_per_expert >= MOE_TILESIZE_M,
+                    "A1 re-tile requires at least one M32 temp row block");
 
     TORCH_CHECK_DTYPE(temp_intermediate_g, kHalf);
     TORCH_CHECK_DTYPE(temp_intermediate_u, kHalf);
@@ -196,21 +330,66 @@ void exl3_moe
     int cc = DevCtx::instance().get_cc(device);
     int* locks = DevCtx::instance().get_locks(device);
 
-    // Launch
+    // Launch. All blocks must be co-resident for the group barriers. With a
+    // known active count, use one group per active expert (up to available temp
+    // buffers) and widen each group into the otherwise idle SMs. num_active=-1
+    // retains the pre-port grid and round-robin assignment exactly. A1 keeps
+    // that exact eight-CTA K partition but enables greedy M32 route-block
+    // tickets for fused prefill only.
     int block_dim = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;
     TORCH_CHECK(concurrency * MOE_SMS_PER_EXPERT <= num_sms, "Concurrency too high for device num_sms");
-    dim3 grid_dim(MOE_SMS_PER_EXPERT, 1, concurrency);
+    int num_groups = concurrency;
+    int group_size = MOE_SMS_PER_EXPERT;
+    int use_ticket_scheduler = 0;
+    if (a1_retile)
+    {
+        num_groups = MIN((int) concurrency, num_sms / MOE_SMS_PER_EXPERT);
+        group_size = MOE_SMS_PER_EXPERT;
+        use_ticket_scheduler = 1;
+    }
+    else if (num_active > 0)
+    {
+        num_groups = MIN(MIN((int) concurrency, MOE_MAX_GROUPS), num_active);
+        group_size = MIN(num_sms / num_groups, MOE_MAX_SMS_PER_EXPERT);
+        use_ticket_scheduler = 1;
+    }
+    TORCH_CHECK(num_groups * group_size <= num_sms, "MoE grid exceeds device num_sms");
+    dim3 grid_dim(group_size, 1, num_groups);
 
     int N_off = 0;
     if (hidden_dim % 256 == 0 && intermediate_dim % 256 == 0) N_off = 1;
-    fp_exl3_moe_kernel kernel = exl3_moe_kernel_instances[2 * K + N_off];
-
-    if (moe_kernel_attr_set[device].find((void*) kernel) == moe_kernel_attr_set[device].end())
+    fp_exl3_moe_kernel kernel;
+    if (a1_retile)
     {
-        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
-        moe_kernel_attr_set[device].insert((void*) kernel);
-        cuda_check(cudaPeekAtLastError());
+        TORCH_CHECK(K_gate == 3 && K_up == 3 && K_down == 3,
+                    "A1 re-tile is specialized for TR3 gate/up/down weights");
+        kernel = exl3_moe_retile_kernel_instances[N_off];
     }
+    else
+    {
+        kernel = exl3_moe_kernel_instances[2 * K + N_off];
+    }
+
+    int moe_smem_bytes = SMEM_MAX;
+    int moe_smem_attr_bytes = SMEM_MAX;
+    if (a1_retile)
+    {
+        const int max_bits = MAX(K_gate, MAX(K_up, K_down));
+        const int moe_tilesize_n = N_off ? 256 : 128;
+        moe_smem_bytes = exl3_moe_smem_bytes
+        (
+            max_bits, moe_tilesize_n, MOE_A1_SH_STAGES
+        );
+        moe_smem_attr_bytes = MOE_A1_SMEM_MAX_BYTES;
+    }
+    #if MOE_SMEMFIX
+        if (!a1_retile)
+        {
+            const int max_bits = MAX(K_gate, MAX(K_up, K_down));
+            const int moe_tilesize_n = N_off ? 256 : 128;
+            moe_smem_bytes = exl3_moe_smem_bytes(max_bits, moe_tilesize_n);
+        }
+    #endif
 
     void* _hidden_state = hidden_state.data_ptr();
     void* _temp_state_g = temp_state_g.data_ptr();
@@ -258,24 +437,234 @@ void exl3_moe
         (void*) &num_experts,
         (void*) &num_experts_per_tok,
         (void*) &max_tokens_per_expert,
-        (void*) &concurrency,
+        (void*) &num_groups,
         (void*) &act_limit,
         (void*) &act_function,
         (void*) &K_gate,
         (void*) &K_up,
         (void*) &K_down,
+        (void*) &exl3_moe_dq_threshold,
+        (void*) &use_ticket_scheduler,
         (void*) &locks
     };
 
-    cudaLaunchKernel
-    (
-        (void*) kernel,
-        grid_dim,
-        block_dim,
-        kernelArgs,
-        SMEM_MAX,
-        stream
-    );
+    {
+        // Function attributes are shared by all host threads. Keep the exact
+        // attribute value stable until this launch has consumed it.
+        std::lock_guard<std::mutex> attr_lock(moe_kernel_attr_mutex[device]);
+        auto& attr_smem = moe_kernel_attr_smem[device];
+        auto attr_it = attr_smem.find((void*) kernel);
+        if (attr_it == attr_smem.end() || attr_it->second != moe_smem_attr_bytes)
+        {
+            cuda_check(cudaFuncSetAttribute
+            (
+                kernel,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                moe_smem_attr_bytes
+            ));
+            attr_smem[(void*) kernel] = moe_smem_attr_bytes;
+        }
+
+        if (a1_retile)
+        {
+            cuda_check(cudaLaunchCooperativeKernel
+            (
+                (void*) kernel,
+                grid_dim,
+                block_dim,
+                kernelArgs,
+                moe_smem_bytes,
+                stream
+            ));
+        }
+        else
+        {
+            cuda_check(cudaLaunchKernel
+            (
+                (void*) kernel,
+                grid_dim,
+                block_dim,
+                kernelArgs,
+                moe_smem_bytes,
+                stream
+            ));
+        }
+    }
 
     cuda_check(cudaPeekAtLastError());
+}
+
+void exl3_moe_fused
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& topk_ids,
+    const at::Tensor& topk_weights,
+    const at::Tensor& expert_map,
+    const at::Tensor& expert_count,
+    const at::Tensor& expert_offsets,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+    const int act_function,
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+    const float act_limit,
+    const int dq_threshold
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(hidden_state.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    TORCH_CHECK(topk_ids.scalar_type() == at::kLong ||
+                topk_ids.scalar_type() == at::kInt,
+                "topk_ids must be int32 or int64");
+    TORCH_CHECK_DIM(topk_ids, 2);
+    TORCH_CHECK_DIM(topk_weights, 2);
+    TORCH_CHECK_SHAPES_FULL(topk_ids, topk_weights);
+    TORCH_CHECK_DTYPE(expert_map, kLong);
+    TORCH_CHECK_DIM(expert_map, 1);
+    TORCH_CHECK_DTYPE(expert_count, kLong);
+    TORCH_CHECK_DTYPE(expert_offsets, kLong);
+    TORCH_CHECK_SHAPES_FULL(expert_count, expert_offsets);
+    TORCH_CHECK_DTYPE(token_sorted, kLong);
+    TORCH_CHECK_DTYPE(weight_sorted, kHalf);
+    TORCH_CHECK_SHAPES_FULL(token_sorted, weight_sorted);
+    TORCH_CHECK(hidden_state.size(0) == topk_ids.size(0), "route rows != hidden rows");
+    const int64_t num_routes = topk_ids.numel();
+    const int num_buckets = expert_count.numel();
+    TORCH_CHECK(num_buckets == gate_ptrs_trellis.numel() + 1,
+                "expert_count must include one sentinel bucket");
+    TORCH_CHECK(token_sorted.numel() >= num_routes, "route workspace too small");
+
+    cudaMemsetAsync(expert_count.data_ptr(), 0,
+                    expert_count.numel() * expert_count.element_size(), stream);
+    const int threads = 256;
+    const int blocks = std::min<int64_t>(1024, (num_routes + threads - 1) / threads);
+    #define LAUNCH_HIST(ID_T, PTR) \
+        exl3_route_histogram_kernel<ID_T><<<blocks, threads, 0, stream>>>( \
+            PTR, expert_map.data_ptr<int64_t>(), \
+            expert_count.data_ptr<int64_t>(), num_routes)
+    if (topk_ids.scalar_type() == at::kInt)
+        LAUNCH_HIST(int32_t, topk_ids.data_ptr<int32_t>());
+    else
+        LAUNCH_HIST(int64_t, topk_ids.data_ptr<int64_t>());
+    #undef LAUNCH_HIST
+    exl3_route_scan_kernel<<<1, 1, 0, stream>>>
+    (
+        expert_count.data_ptr<int64_t>(), expert_offsets.data_ptr<int64_t>(),
+        num_buckets
+    );
+    #define LAUNCH_PACK(ID_T, ID_PTR, W_T, W_PTR) \
+        exl3_route_pack_stable_kernel<ID_T, W_T><<<num_buckets, threads, 0, stream>>>( \
+            ID_PTR, W_PTR, expert_map.data_ptr<int64_t>(), \
+            expert_offsets.data_ptr<int64_t>(), token_sorted.data_ptr<int64_t>(), \
+            reinterpret_cast<half*>(weight_sorted.data_ptr()), num_routes, \
+            topk_ids.size(1))
+    #define DISPATCH_WEIGHT(ID_T, ID_PTR) \
+        if (topk_weights.scalar_type() == at::kFloat) \
+            LAUNCH_PACK(ID_T, ID_PTR, float, topk_weights.data_ptr<float>()); \
+        else if (topk_weights.scalar_type() == at::kHalf) \
+            LAUNCH_PACK(ID_T, ID_PTR, half, reinterpret_cast<const half*>(topk_weights.data_ptr())); \
+        else if (topk_weights.scalar_type() == at::kBFloat16) \
+            LAUNCH_PACK(ID_T, ID_PTR, __nv_bfloat16, reinterpret_cast<const __nv_bfloat16*>(topk_weights.data_ptr())); \
+        else TORCH_CHECK(false, "topk_weights must be float, half, or bfloat16")
+    if (topk_ids.scalar_type() == at::kInt) {
+        DISPATCH_WEIGHT(int32_t, topk_ids.data_ptr<int32_t>());
+    } else {
+        DISPATCH_WEIGHT(int64_t, topk_ids.data_ptr<int64_t>());
+    }
+    #undef DISPATCH_WEIGHT
+    #undef LAUNCH_PACK
+    cuda_check(cudaPeekAtLastError());
+
+    // Narrowed views carry the actual route count into the unchanged ABI; no
+    // allocation or synchronization is introduced, so this remains graph-safe.
+    exl3_moe_dq_threshold = dq_threshold;
+    exl3_moe
+    (
+        hidden_state, output_state, expert_count,
+        token_sorted.narrow(0, 0, num_routes),
+        weight_sorted.narrow(0, 0, num_routes),
+        temp_state_g, temp_state_u, temp_intermediate_g, temp_intermediate_u,
+        act_function, K_gate, K_up, K_down,
+        gate_ptrs_trellis, gate_ptrs_suh, gate_ptrs_svh,
+        up_ptrs_trellis, up_ptrs_suh, up_ptrs_svh,
+        down_ptrs_trellis, down_ptrs_suh, down_ptrs_svh,
+        gate_mcg, gate_mul1, up_mcg, up_mul1, down_mcg, down_mul1,
+        act_limit,
+        -1
+    );
+    exl3_moe_dq_threshold = 0;
+}
+
+void exl3_moe_fused_retile
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& topk_ids,
+    const at::Tensor& topk_weights,
+    const at::Tensor& expert_map,
+    const at::Tensor& expert_count,
+    const at::Tensor& expert_offsets,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+    const int act_function,
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+    const float act_limit,
+    const int dq_threshold
+)
+{
+    Exl3MoeA1RetileScope retile_scope;
+    exl3_moe_fused
+    (
+        hidden_state, output_state, topk_ids, topk_weights, expert_map,
+        expert_count, expert_offsets, token_sorted, weight_sorted,
+        temp_state_g, temp_state_u, temp_intermediate_g, temp_intermediate_u,
+        act_function, K_gate, K_up, K_down,
+        gate_ptrs_trellis, gate_ptrs_suh, gate_ptrs_svh,
+        up_ptrs_trellis, up_ptrs_suh, up_ptrs_svh,
+        down_ptrs_trellis, down_ptrs_suh, down_ptrs_svh,
+        gate_mcg, gate_mul1, up_mcg, up_mul1,
+        down_mcg, down_mul1, act_limit, dq_threshold
+    );
 }

--- a/exllamav3/exllamav3_ext/quant/exl3_moe.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe.cuh
@@ -41,6 +41,84 @@ void exl3_moe
     const bool down_mcg,
     const bool down_mul1,
 
-    const float act_limit
+    const float act_limit,
+    const int num_active
 );
 
+void exl3_moe_fused
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& topk_ids,
+    const at::Tensor& topk_weights,
+    const at::Tensor& expert_map,
+    const at::Tensor& expert_count,
+    const at::Tensor& expert_offsets,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+    const int act_function,
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+    const float act_limit,
+    const int dq_threshold
+);
+
+// Prefill-only A1 entrypoint. It shares route packing and numerics with
+// exl3_moe_fused, then selects the separately instantiated M32 ticket kernel.
+void exl3_moe_fused_retile
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& topk_ids,
+    const at::Tensor& topk_weights,
+    const at::Tensor& expert_map,
+    const at::Tensor& expert_count,
+    const at::Tensor& expert_offsets,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+    const int act_function,
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+    const float act_limit,
+    const int dq_threshold
+);

--- a/exllamav3/exllamav3_ext/quant/exl3_moe_common.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe_common.cuh
@@ -7,18 +7,54 @@
 #define MOE_ACT_GELU 1
 
 #define MOE_SMS_PER_EXPERT 8
+#define MOE_MAX_SMS_PER_EXPERT 32
 #define MOE_TILESIZE_K 32
-#define MOE_TILESIZE_M 16
+#define MOE_TILESIZE_M 32
 #define MOE_SH_STAGES 3
 #define MOE_FRAG_STAGES 3
+
+// A1 prefill-only re-tile. Keep the established M32/K32 MMA geometry and
+// eight-CTA K partition, but deepen the async-copy pipeline for the separately
+// instantiated route-block kernel. The kernel has 1,024 B of static shared
+// storage, so a 100,352 B dynamic opt-in reaches the 101,376 B SM120 ceiling
+// without exceeding it. Launches still allocate only the exact four-stage
+// working set; registers keep the cooperative pool at one CTA/SM.
+#define MOE_A1_SH_STAGES 4
+#define MOE_A1_SMEM_MAX_BYTES 100352
+
+// Variant switches. Each requested build is selected by these two values.
+#define MOE_SMEMFIX 0
 
 #ifndef EXL3_GEMM_BASE_THREADS
 #define EXL3_GEMM_BASE_THREADS 256
 #endif
 
-#ifndef SMEM_MAX
-#define SMEM_MAX (90 * 1024)  // max shared memory on compute capability 8.6
+#ifndef EXL3_SMEM_MAX_BYTES
+#define EXL3_SMEM_MAX_BYTES (90 * 1024)
 #endif
+
+#ifndef SMEM_MAX
+#define SMEM_MAX EXL3_SMEM_MAX_BYTES
+#endif
+
+// Exact extern-shared allocation used by one fused MoE GEMM launch. This
+// mirrors the byte budget in exl3_gemm_inner.cuh for shmem_out_had == false.
+inline constexpr int exl3_moe_smem_bytes
+(
+    const int bits,
+    const int tilesize_n,
+    const int sh_stages = MOE_SH_STAGES
+)
+{
+    constexpr int tileblocks_k = MOE_TILESIZE_K / 16;
+    constexpr int warps = EXL3_GEMM_BASE_THREADS / 32;
+    const int tileblocks_n = tilesize_n / 16;
+    const int frags_n_per_warp = 2 * tileblocks_n / warps;
+    const int sh_a_stage_size = MOE_TILESIZE_M * MOE_TILESIZE_K;
+    const int sh_b_stage_size = tileblocks_k * tileblocks_n * 256 / 16 * bits;
+    const int sh_c_size = 4 * EXL3_GEMM_BASE_THREADS * frags_n_per_warp;
+    return sh_stages * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size;
+}
 
 #define EXL3_MOE_KERNEL_ARGS                    \
     const half* __restrict__ hidden_state,      \
@@ -53,5 +89,7 @@
     const int K_gate,                           \
     const int K_up,                             \
     const int K_down,                           \
+    const int dq_threshold,                     \
+    const int use_ticket_scheduler,             \
                                                 \
     int* __restrict__ locks

--- a/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cuda_bf16.h>
+#include <cuda/atomic>
 #include <cublas_v2.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,14 +15,20 @@
 #include "exl3_devctx.cuh"
 #include "../ptx.cuh"
 
-template<int t_bits, int MOE_TILESIZE_N>
+template<int t_bits, int MOE_TILESIZE_N, bool a1_retile = false>
+#if MOE_SMEMFIX
+__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16, 2)
+#else
 __global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16)
+#endif
 void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
 {
     const int group_idx = blockIdx.z;
     const int block_idx = blockIdx.x;
+    const int group_size = gridDim.x;  // SMs per group, set at launch
+    const int num_groups = gridDim.z;
     const int block_threads = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;  // blockDim.x
-    const int group_threads = MOE_SMS_PER_EXPERT * block_threads;
+    const int group_threads = group_size * block_threads;
     const int warp_id = threadIdx.x / 32;
     const int warps_per_group = group_threads / 32;
     const int warps_per_block = block_threads / 32;
@@ -36,8 +43,18 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
     // Barriers for group sync
     int* barrier_counters_sense = locks + BARRIER_LOCKS_OFFSET;
 
+    // Expert scheduler state, self-resetting: [0] next ticket,
+    // [1] retired groups, [2 + group] ticket for the group.
+    int* sched = locks + MOE_SCHED_OFFSET;
+
     // Individual GEMM barriers per group
     locks += group_idx * MAX(hidden_dim, intermediate_dim) / 128;
+
+    // In dynamic mode each schedulable expert tile has a monotonically
+    // increasing ticket. Initial tickets are the group indices; completed
+    // groups greedily draw the next unclaimed tile. A negative num_active on
+    // the host selects the legacy round-robin path and never touches sched[].
+    int ticket = group_idx;
 
     // Loop over experts
     int start = 0;
@@ -51,12 +68,13 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
         end += expert_count[expert_idx];
         int token_count = end - start;
 
-        // Skip if no tokens or too many tokens for fused kernel (batch is handled by reconstruct path outside kernel)
+        // Skip empty experts. The default kernel retains max_tokens_per_expert
+        // chunks. A1 makes every M32 route block an independent scheduler item,
+        // so no group serializes multiple M tiles before another can steal work.
         if (token_count == 0) continue;
-        if (token_count > max_tokens_per_expert) continue;
-
-        // Skip if expert is assigned to different group
-        if (expert_idx_assign++ % concurrency != group_idx) continue;
+        // Eager-prefill hybrid dispatch: high-row experts are handled by the
+        // reconstruct-once -> tensor-core HGEMM path after this launch.
+        if (dq_threshold > 0 && token_count >= dq_threshold) continue;
 
         // EXL3 weights for g, u, d
         const uint16_t* exp_gate_trellis = gate_trellis[expert_idx];
@@ -68,6 +86,25 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
         const uint16_t* exp_down_trellis = down_trellis[expert_idx];
         const half* exp_down_suh = down_suh[expert_idx];
         const half* exp_down_svh = down_svh[expert_idx];
+
+        const int expert_start = start;
+        const int expert_end = end;
+        const int route_block_rows = a1_retile ? MOE_TILESIZE_M : max_tokens_per_expert;
+        for (int tile_start = expert_start; tile_start < expert_end;
+             tile_start += route_block_rows)
+        {
+            start = tile_start;
+            token_count = MIN(route_block_rows, expert_end - tile_start);
+
+            // A1 tickets route blocks at exactly M32 granularity. Each winning
+            // eight-CTA group still uses the legacy K/N split and lock order;
+            // only ownership of independent row tiles changes.
+            const int assignment = expert_idx_assign++;
+            if (use_ticket_scheduler)
+            {
+                if (assignment != ticket) continue;
+            }
+            else if (assignment % concurrency != group_idx) continue;
 
         // Gather + input hadamard for g, u
         auto had_gather_gu_in = [&]()
@@ -95,7 +132,7 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     0.088388347648f
                 );
             }
-            group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+            group_barrier(group_idx, group_size, barrier_counters_sense);
         };
 
         had_gather_gu_in();
@@ -110,7 +147,7 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     in_addr,            \
                     trellis,            \
                     out_addr,           \
-                    MIN(size_m, 16),    \
+                    MIN(size_m, MOE_TILESIZE_M), \
                     hidden_dim,         \
                     intermediate_dim,   \
                     locks,              \
@@ -119,7 +156,7 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     MOE_TILESIZE_M,     \
                     MOE_TILESIZE_K,     \
                     MOE_TILESIZE_N,     \
-                    MOE_SH_STAGES,      \
+                    (a1_retile ? MOE_A1_SH_STAGES : MOE_SH_STAGES), \
                     MOE_FRAG_STAGES
                 if constexpr (t_bits)
                     exl3_gemm_kernel_inner<t_bits, false, 1, SHAPE_ARGS, false>(ARGS);
@@ -137,15 +174,15 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                 #undef ARGS
                 #undef SHAPE_ARGS
 
-                in_addr += 16 * hidden_dim;
-                out_addr += 16 * intermediate_dim;
-                size_m -= 16;
+                in_addr += MOE_TILESIZE_M * hidden_dim;
+                out_addr += MOE_TILESIZE_M * intermediate_dim;
+                size_m -= MOE_TILESIZE_M;
             }
         };
 
         gemm_up(temp_state_g, temp_intermediate_g, exp_gate_trellis, K_gate);
         gemm_up(temp_state_u, temp_intermediate_u, exp_up_trellis, K_up);
-        group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
 
         // Output hadamard for g, u + activation+gate + input hadamard for d
         auto had_guad = [&]()
@@ -168,7 +205,7 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     act_function
                 );
             }
-            group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+            group_barrier(group_idx, group_size, barrier_counters_sense);
         };
 
         had_guad();
@@ -183,7 +220,7 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     in_addr,            \
                     trellis,            \
                     out_addr,           \
-                    MIN(size_m, 16),    \
+                    MIN(size_m, MOE_TILESIZE_M), \
                     intermediate_dim,   \
                     hidden_dim,         \
                     locks,              \
@@ -192,7 +229,7 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     MOE_TILESIZE_M,     \
                     MOE_TILESIZE_K,     \
                     MOE_TILESIZE_N,     \
-                    MOE_SH_STAGES,      \
+                    (a1_retile ? MOE_A1_SH_STAGES : MOE_SH_STAGES), \
                     MOE_FRAG_STAGES
                 if constexpr (t_bits)
                     exl3_gemm_kernel_inner<t_bits, false, 1, SHAPE_ARGS, false>(ARGS);
@@ -210,14 +247,14 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                 #undef ARGS
                 #undef SHAPE_ARGS
 
-                in_addr += 16 * intermediate_dim;
-                out_addr += 16 * hidden_dim;
-                size_m -= 16;
+                in_addr += MOE_TILESIZE_M * intermediate_dim;
+                out_addr += MOE_TILESIZE_M * hidden_dim;
+                size_m -= MOE_TILESIZE_M;
             }
         };
 
         gemm_down(temp_intermediate_g, temp_state_g, exp_down_trellis, K_down);
-        group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
 
         // Output hadamard for d + scatter add
         auto had_d_out = [&]()
@@ -240,9 +277,39 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     0.088388347648f * __half2float(weight)
                 );
             }
-            group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
         };
 
-        had_d_out();
+            had_d_out();
+
+            // In dynamic mode publish the next ticket through the end-of-tile
+            // barrier, which also protects the per-group temp buffers for reuse.
+            // Tickets num_groups.. are claimed atomically; 0..num_groups-1 are
+            // the implicit initial assignments.
+            if (use_ticket_scheduler)
+            {
+                if (block_idx == 0 && threadIdx.x == 0)
+                    sched[2 + group_idx] = num_groups + atomicAdd(&sched[0], 1);
+                group_barrier(group_idx, group_size, barrier_counters_sense);
+                ticket = sched[2 + group_idx];
+            }
+            else
+            {
+                group_barrier(group_idx, group_size, barrier_counters_sense);
+            }
+        }
+    }
+
+    // Last dynamic group out resets scheduler state for the next launch. The
+    // acq_rel retirement orders every earlier relaxed ticket grab before reset.
+    if (use_ticket_scheduler && block_idx == 0 && threadIdx.x == 0)
+    {
+        cuda::atomic_ref<int, cuda::thread_scope_device> next_ticket(sched[0]);
+        cuda::atomic_ref<int, cuda::thread_scope_device> retired_groups(sched[1]);
+        int retired = retired_groups.fetch_add(1, cuda::memory_order_acq_rel);
+        if (retired == num_groups - 1)
+        {
+            next_ticket.store(0, cuda::memory_order_relaxed);
+            retired_groups.store(0, cuda::memory_order_relaxed);
+        }
     }
 }

--- a/exllamav3/exllamav3_ext/quant/reconstruct.cu
+++ b/exllamav3/exllamav3_ext/quant/reconstruct.cu
@@ -1,4 +1,5 @@
 #include <cuda_fp16.h>
+#include <cuda_fp8.h>
 #include "reconstruct.cuh"
 #include <c10/cuda/CUDAGuard.h>
 #include <ATen/cuda/CUDAContext.h>
@@ -6,6 +7,7 @@
 #include "../util.cuh"
 #include "../ptx.cuh"
 #include "exl3_dq.cuh"
+#include <float.h>
 
 template <int K, int cb>
 __global__ __launch_bounds__(256)
@@ -134,6 +136,187 @@ void reconstruct_slice
         (const uint16_t*) packed.data_ptr(),
         packed_cols,
         packed_n_offset
+    );
+    cuda_check(cudaPeekAtLastError());
+}
+
+template <int K, int cb>
+__global__ __launch_bounds__(256)
+void reconstruct_fp8dg_nt_kernel
+(
+    uint8_t* __restrict__ g_q_nt,
+    float* __restrict__ g_scales,
+    const uint16_t* __restrict__ g_packed,
+    int packed_blocks_n,
+    int rows_k,
+    int cols_n
+)
+{
+    constexpr int packed_size = 256 * K / 16;  // in uint16s
+    constexpr float fp8_max = 448.0f;          // torch.float8_e4m3fn finfo.max
+
+    int t = threadIdx.x;
+    int lane_id = t % 32;
+    int warp_id = t / 32;
+    int n128 = blockIdx.x;  // original N block; q_nt row block
+    int k128 = blockIdx.y;  // original K block; q_nt col block
+
+    __shared__ uint32_t s_packed[8][packed_size / 2];
+    __shared__ half2 tile[16][8][8];
+    __shared__ int4 sh_tile_i4[128 * 16];  // 128 rows * (128 half / 8 half per int4)
+    __shared__ float sh_amax[256];
+
+    int4* sh_i4 = sh_tile_i4;
+    half* sh_half = reinterpret_cast<half*>(sh_tile_i4);
+
+    #pragma unroll
+    for (int sub = 0; sub < 8; ++sub)
+    {
+        int k16 = k128 * 8 + sub;
+        int n16 = n128 * 8;
+        const uint16_t* packed_tile =
+            g_packed + (k16 * packed_blocks_n + n16) * packed_size;
+
+        if (t < packed_size)
+            ((int4*) s_packed)[t] = ((const int4*) packed_tile)[t];
+        __syncthreads();
+
+        register FragB frag[2];
+        dq_dispatch<K, cb>(s_packed[warp_id], lane_id * 8, frag[0], frag[1]);
+
+        half2 n0 = __shfl_down_sync(0xFFFFFFFF, frag[0][0], 4, 32);
+        half2 n1 = __shfl_down_sync(0xFFFFFFFF, frag[0][1], 4, 32);
+        half2 n2 = __shfl_down_sync(0xFFFFFFFF, frag[1][0], 4, 32);
+        half2 n3 = __shfl_down_sync(0xFFFFFFFF, frag[1][1], 4, 32);
+
+        if (!(lane_id & 4))
+        {
+            half2 m0 = __halves2half2(__low2half(frag[0][0]), __low2half(n0));
+            half2 m1 = __halves2half2(__high2half(frag[0][0]), __high2half(n0));
+            half2 m2 = __halves2half2(__low2half(frag[0][1]), __low2half(n1));
+            half2 m3 = __halves2half2(__high2half(frag[0][1]), __high2half(n1));
+            half2 m4 = __halves2half2(__low2half(frag[1][0]), __low2half(n2));
+            half2 m5 = __halves2half2(__high2half(frag[1][0]), __high2half(n2));
+            half2 m6 = __halves2half2(__low2half(frag[1][1]), __low2half(n3));
+            half2 m7 = __halves2half2(__high2half(frag[1][1]), __high2half(n3));
+            int r0 = (lane_id % 4) * 2;
+            int r1 = r0 + 1;
+            int r2 = r0 + 8;
+            int r3 = r0 + 9;
+            int c0 = lane_id / 8;
+            int c1 = c0 + 4;
+            tile[r0][warp_id][c0] = m0;
+            tile[r1][warp_id][c0] = m1;
+            tile[r2][warp_id][c0] = m2;
+            tile[r3][warp_id][c0] = m3;
+            tile[r0][warp_id][c1] = m4;
+            tile[r1][warp_id][c1] = m5;
+            tile[r2][warp_id][c1] = m6;
+            tile[r3][warp_id][c1] = m7;
+        }
+        __syncthreads();
+
+        int r = t / 16;
+        int c = t % 16;
+        int4* tile_int4 = reinterpret_cast<int4*>(tile);
+        sh_i4[(sub * 16 + r) * 16 + c] = tile_int4[t];
+        __syncthreads();
+    }
+
+    float local_amax = 0.0f;
+    for (int i = t; i < 128 * 128; i += blockDim.x)
+        local_amax = fmaxf(local_amax, fabsf(__half2float(sh_half[i])));
+    sh_amax[t] = local_amax;
+    __syncthreads();
+
+    for (int stride = 128; stride > 0; stride >>= 1)
+    {
+        if (t < stride)
+            sh_amax[t] = fmaxf(sh_amax[t], sh_amax[t + stride]);
+        __syncthreads();
+    }
+
+    float scale = fmaxf(sh_amax[0], 1.0e-10f) / fp8_max;
+    if (t == 0)
+        g_scales[n128 * (rows_k / 128) + k128] = scale;
+    float inv_scale = 1.0f / scale;
+
+    for (int i = t; i < 128 * 128; i += blockDim.x)
+    {
+        int kr = i / 128;
+        int nc = i - kr * 128;
+        int q_row = n128 * 128 + nc;
+        int q_col = k128 * 128 + kr;
+        float v = __half2float(sh_half[i]) * inv_scale;
+        v = fmaxf(-fp8_max, fminf(fp8_max, v));
+        g_q_nt[q_row * rows_k + q_col] =
+            __nv_cvt_float_to_fp8(v, __NV_SATFINITE, __NV_E4M3);
+    }
+}
+
+#define __(i, cb) reconstruct_fp8dg_nt_kernel<i, cb>
+constexpr auto reconstruct_fp8dg_nt_kernel_instances = std::array
+{
+    __(1, 0), __(2, 0), __(3, 0), __(4, 0), __(5, 0), __(6, 0), __(7, 0), __(8, 0),
+    __(1, 1), __(2, 1), __(3, 1), __(4, 1), __(5, 1), __(6, 1), __(7, 1), __(8, 1),
+    __(1, 2), __(2, 2), __(3, 2), __(4, 2), __(5, 2), __(6, 2), __(7, 2), __(8, 2)
+};
+#undef __
+
+/*
+Reconstruct encoded+packed tensor directly to DeepGEMM NT FP8 weight layout.
+packed represents a row-major [K, N] FP16 matrix. q_nt is [N, K] FP8 and
+scales is [N / 128, K / 128] FP32, one scale per DeepGEMM 128x128 tile.
+*/
+void reconstruct_fp8dg_nt
+(
+    at::Tensor q_nt,
+    at::Tensor scales,
+    at::Tensor packed,
+    int K,
+    bool mcg,
+    bool mul1
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(q_nt.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    TORCH_CHECK_DIM(q_nt, 2);
+    TORCH_CHECK_DIM(scales, 2);
+    TORCH_CHECK_DIM(packed, 3);
+    TORCH_CHECK(q_nt.scalar_type() == c10::ScalarType::Float8_e4m3fn,
+                "q_nt must be torch.float8_e4m3fn");
+    TORCH_CHECK_DTYPE(scales, kFloat);
+    TORCH_CHECK_DTYPE(packed, kShort);
+    TORCH_CHECK_SIZE(packed, 2, 256 * K / 16);
+
+    int rows_k = packed.size(0) * 16;
+    int cols_n = packed.size(1) * 16;
+    TORCH_CHECK(rows_k % 128 == 0, "packed K dimension must reconstruct to a multiple of 128");
+    TORCH_CHECK(cols_n % 128 == 0, "packed N dimension must reconstruct to a multiple of 128");
+    TORCH_CHECK(q_nt.size(0) == cols_n && q_nt.size(1) == rows_k,
+                "q_nt must have shape [N, K] for reconstructed packed [K, N]");
+    TORCH_CHECK(scales.size(0) == cols_n / 128 && scales.size(1) == rows_k / 128,
+                "scales must have shape [N / 128, K / 128]");
+    TORCH_CHECK(q_nt.is_contiguous(), "q_nt must be contiguous");
+    TORCH_CHECK(scales.is_contiguous(), "scales must be contiguous");
+    TORCH_CHECK(packed.is_contiguous(), "packed must be contiguous");
+
+    dim3 blockDim(256);
+    dim3 gridDim(cols_n / 128, rows_k / 128);
+
+    int cbi = K - 1;
+    if (mcg) cbi += 8;
+    else if (mul1) cbi += 16;
+
+    reconstruct_fp8dg_nt_kernel_instances[cbi]<<<gridDim, blockDim, 0, stream>>>
+    (
+        reinterpret_cast<uint8_t*>(q_nt.data_ptr()),
+        scales.data_ptr<float>(),
+        reinterpret_cast<const uint16_t*>(packed.data_ptr()),
+        packed.size(1),
+        rows_k,
+        cols_n
     );
     cuda_check(cudaPeekAtLastError());
 }

--- a/exllamav3/exllamav3_ext/quant/reconstruct.cuh
+++ b/exllamav3/exllamav3_ext/quant/reconstruct.cuh
@@ -20,3 +20,13 @@ void reconstruct_slice
     bool mul1,
     int64_t n_offset
 );
+
+void reconstruct_fp8dg_nt
+(
+    at::Tensor q_nt,
+    at::Tensor scales,
+    at::Tensor packed,
+    int K,
+    bool mcg,
+    bool mul1
+);


### PR DESCRIPTION
# PR (draft) — A1 route-packed re-tile for the EXL3 fused MoE kernel (sm120)

**Target:** `turboderp-org/exllamav3` (based on v0.0.43).
**Independent** of the nvfp4 KV work — a standalone sm120 MoE-kernel speedup.

## Title
`[kernel] Persistent route-packed (route_block × n_tile) schedule for exl3 fused MoE on Blackwell (sm120)`

## Motivation
The EXL3 fused grouped-MoE kernel underuses consumer Blackwell (sm120):
- `quant/exl3_moe_common.cuh`: `#define MOE_SMS_PER_EXPERT 8` → concurrency 188/8 = 23, **4 SMs
  idle**; and smem is hardcoded `90*1024` ("CC 8.6") while **sm120 allows ~99 KiB opt-in**.
- The fixed 8-SM-per-expert grouping leaves the grouped GEMM tail-heavy and under-tiled.

## The change
Port the b12x W4A16 persistent schedule idea onto the exl3 grouped shapes: a **persistent
`(route_block × n_tile)` grid** that keeps all 188 SMs busy and split-Ks the grouped GEMM,
replacing the 8-SM-per-expert fixed grouping; use the full sm120 smem opt-in; keep the trellis
codebook dequant (`codebook.cuh`, `exl3_dq.cuh`) and the fp16/bf16 `mma.m16n8k16` accumulate path
**byte-identical** (same numerics). Added as a new entry point `exl3_moe_fused_retile` **alongside**
the existing `exl3_moe`/`exl3_moe_fused` for A/B; opt-in.

Files (diff vs v0.0.43): `quant/exl3_moe.cu` (+447), `quant/exl3_gemm_inner.cuh` (+373),
`quant/exl3_moe_kernel.cuh` (+158), `quant/exl3_moe_common.cuh` (+46).

## Result
**Prefill +7–8%** on GLM-5.2's 192-expert trellis-3.0 tail (4× RTX PRO 6000 Blackwell, TP4).
Numerics unchanged (trellis dequant + MMA path untouched); shipped and serving coherently since
`verdictai/vllm-glm52-tr3-hybrid:v3`. The re-tiled path is additive/opt-in, so the existing
`exl3_moe`/`exl3_moe_fused` remain byte-identical for fallback.  


---
_Branch is based on **v0.0.43**; the diff above is the clean A1 change. It will need a rebase onto v1.0.0 master before merge._
