### PR TITLE
Cache/Attn: Load Q8 cache bytes directly

### DIFF
--- a/exllamav3/modules/attention_fn/triton_paged.py
+++ b/exllamav3/modules/attention_fn/triton_paged.py
@@ -830,11 +830,68 @@ def _qc_load_v(qwords, scales, tok_rows, kv_head, offs_d, mask_n,
     inv_m = 1.0 / (1 << (BITS - 1))
     return ((raw.to(tl.float32) - mh) * (scx.to(tl.float32) * inv_m)).to(tl.float16)
 
+
+@triton.jit
+def _qc_load_q8_kt(qbytes, scales, tok_rows, kv_head, offs_d, mask_n,
+                   n_kv_heads: tl.constexpr, head_dim: tl.constexpr):
+    """Q8-specialized (head_dim, BLOCK_N) load without int32 word expansion."""
+    GPT: tl.constexpr = n_kv_heads * head_dim // 32
+    token_dim: tl.constexpr = n_kv_heads * head_dim
+    base = kv_head * head_dim
+    raw = tl.load(
+        qbytes + tok_rows[None, :] * token_dim + base + offs_d[:, None],
+        mask = mask_n[None, :],
+        other = 0,
+    )
+    sgb = kv_head * (head_dim // 32)
+    sc = tl.load(
+        scales + tok_rows[None, :] * GPT +
+        (sgb + tl.arange(0, head_dim // 32))[:, None],
+        mask = mask_n[None, :],
+        other = 0.0,
+    )
+    scx = tl.reshape(
+        tl.broadcast_to(sc[:, None, :], (head_dim // 32, 32, sc.shape[1])),
+        (head_dim, sc.shape[1]),
+    )
+    return ((raw.to(tl.float32) - 127.5) *
+            (scx.to(tl.float32) * (1.0 / 128.0))).to(tl.float16)
+
+
+@triton.jit
+def _qc_load_q8_v(qbytes, scales, tok_rows, kv_head, offs_d, mask_n,
+                  n_kv_heads: tl.constexpr, head_dim: tl.constexpr):
+    """Transposed orientation of _qc_load_q8_kt."""
+    GPT: tl.constexpr = n_kv_heads * head_dim // 32
+    token_dim: tl.constexpr = n_kv_heads * head_dim
+    base = kv_head * head_dim
+    raw = tl.load(
+        qbytes + tok_rows[:, None] * token_dim + base + offs_d[None, :],
+        mask = mask_n[:, None],
+        other = 0,
+    )
+    sgb = kv_head * (head_dim // 32)
+    sc = tl.load(
+        scales + tok_rows[:, None] * GPT +
+        (sgb + tl.arange(0, head_dim // 32))[None, :],
+        mask = mask_n[:, None],
+        other = 0.0,
+    )
+    scx = tl.reshape(
+        tl.broadcast_to(sc[:, :, None], (sc.shape[0], head_dim // 32, 32)),
+        (sc.shape[0], head_dim),
+    )
+    return ((raw.to(tl.float32) - 127.5) *
+            (scx.to(tl.float32) * (1.0 / 128.0))).to(tl.float16)
+
+
 @triton.jit
 def _paged_attn_decode_split_kernel(
     q,
     k_cache,
     v_cache,
+    k_cache_u8,
+    v_cache_u8,
     block_table,
     cache_seqlens,
     out,
@@ -849,6 +906,7 @@ def _paged_attn_decode_split_kernel(
     sinks,               # last runtime arg: the BC launch appends it after the patched ints
     QCK: tl.constexpr,
     QCV: tl.constexpr,
+    Q8_DIRECT: tl.constexpr,
     q_len: tl.constexpr,
     kv_append_len: tl.constexpr,
     n_q_heads: tl.constexpr,
@@ -913,7 +971,16 @@ def _paged_attn_decode_split_kernel(
 
         if QCK > 0:
             tok_rows = phys * page_size + page_off
-            k_tile = _qc_load_kt(k_cache, k_scales, tok_rows, kv_head, offs_d, offs_n < n_end, QCK, n_kv_heads, head_dim)
+            if QCK == 8 and Q8_DIRECT:
+                k_tile = _qc_load_q8_kt(
+                    k_cache_u8, k_scales, tok_rows, kv_head, offs_d,
+                    offs_n < n_end, n_kv_heads, head_dim,
+                )
+            else:
+                k_tile = _qc_load_kt(
+                    k_cache, k_scales, tok_rows, kv_head, offs_d,
+                    offs_n < n_end, QCK, n_kv_heads, head_dim,
+                )
         else:
             k_ptrs = k_cache + (((phys[None, :] * page_size + page_off[None, :]) * n_kv_heads + kv_head) * head_dim + offs_d[:, None])
             k_tile = tl.load(k_ptrs, mask=offs_n[None, :] < n_end, other=0.0)
@@ -940,7 +1007,16 @@ def _paged_attn_decode_split_kernel(
 
         if QCV > 0:
             tok_rows_v = phys * page_size + page_off
-            v_tile = _qc_load_v(v_cache, v_scales, tok_rows_v, kv_head, offs_d, offs_n < n_end, QCV, n_kv_heads, head_dim)
+            if QCV == 8 and Q8_DIRECT:
+                v_tile = _qc_load_q8_v(
+                    v_cache_u8, v_scales, tok_rows_v, kv_head, offs_d,
+                    offs_n < n_end, n_kv_heads, head_dim,
+                )
+            else:
+                v_tile = _qc_load_v(
+                    v_cache, v_scales, tok_rows_v, kv_head, offs_d,
+                    offs_n < n_end, QCV, n_kv_heads, head_dim,
+                )
         else:
             v_ptrs = v_cache + (((phys[:, None] * page_size + page_off[:, None]) * n_kv_heads + kv_head) * head_dim + offs_d[None, :])
             v_tile = tl.load(v_ptrs, mask=offs_n[:, None] < n_end, other=0.0)
@@ -1062,6 +1138,7 @@ def paged_attn_triton_decode(
     n_kv_heads_override: int | None = None,
     num_warps: int = 4,
     num_stages: int = 2,
+    _q8_direct: bool = True,
 ) -> torch.Tensor:
     """Flash-decoding paged attention for short queries: the kv sequence is split across
     programs (sized from the block table, so no host sync on cache_seqlens) and reduced in a
@@ -1117,9 +1194,13 @@ def paged_attn_triton_decode(
     if qc is not None:
         k_scales, v_scales, qck, qcv = qc
         h32 = _get_h32(q.device)
+        k_cache_u8 = k_cache.view(torch.uint8) if qck == 8 else k_cache
+        v_cache_u8 = v_cache.view(torch.uint8) if qcv == 8 else v_cache
     else:
         k_scales, v_scales, qck, qcv = q, q, 0, 0
         h32 = q
+        k_cache_u8 = k_cache
+        v_cache_u8 = v_cache
 
     if block_n is None:
         block_n = max(16, 8192 // head_dim)   # K + V tiles in smem across num_stages
@@ -1164,10 +1245,11 @@ def paged_attn_triton_decode(
             )
 
         _paged_attn_decode_split_kernel[(programs, num_splits)](
-            q, k_cache, v_cache, block_table, cache_seqlens, out, partial_o, partial_ml,
+            q, k_cache, v_cache, k_cache_u8, v_cache_u8,
+            block_table, cache_seqlens, out, partial_o, partial_ml,
             k_scales, v_scales, h32,
             split_len, num_pages_per_seq, num_splits, sinks,
-            qck, qcv, q_len, kv_append_len, n_q_heads, n_kv_heads,
+            qck, qcv, _q8_direct, q_len, kv_append_len, n_q_heads, n_kv_heads,
             page_size, head_dim, float(softmax_scale),
             bool(causal), int(window_left), int(window_right), float(softcap or 0.0),
             num_splits == 1, has_sinks, block_m, block_h, block_rows, block_n,

--- a/tests/test_q8_direct_load.py
+++ b/tests/test_q8_direct_load.py
@@ -1,0 +1,120 @@
+import os
+import statistics
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+import torch
+
+from exllamav3.modules.attention_fn.triton_paged import (
+    has_triton,
+    paged_attn_triton_decode,
+)
+
+
+def _make_inputs(context: int, head_dim: int):
+    device = torch.device("cuda:0")
+    page_size = 256
+    n_q_heads = 32
+    n_kv_heads = 8
+    num_pages = context // page_size
+    token_dim = n_kv_heads * head_dim
+
+    torch.manual_seed(0)
+    q = torch.randn(
+        (1, 1, n_q_heads, head_dim), dtype = torch.float16, device = device
+    )
+    k_bytes = torch.randint(
+        0, 256, (num_pages, page_size, token_dim), dtype = torch.uint8,
+        device = device,
+    )
+    v_bytes = torch.randint(
+        0, 256, (num_pages, page_size, token_dim), dtype = torch.uint8,
+        device = device,
+    )
+    k_cache = k_bytes.view(torch.int32)
+    v_cache = v_bytes.view(torch.int32)
+    scale_shape = (num_pages, page_size, token_dim // 32)
+    k_scales = torch.rand(scale_shape, dtype = torch.float16, device = device)
+    v_scales = torch.rand(scale_shape, dtype = torch.float16, device = device)
+    block_table = torch.arange(
+        num_pages, dtype = torch.int32, device = device
+    ).unsqueeze(0)
+    cache_seqlens = torch.tensor([context], dtype = torch.int32, device = device)
+
+    return {
+        "q": q,
+        "k": None,
+        "v": None,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "block_table": block_table,
+        "cache_seqlens": cache_seqlens,
+        "qc": (k_scales, v_scales, 8, 8),
+        "max_kv_len": context,
+        "n_kv_heads_override": n_kv_heads,
+        "block_n": max(16, 8192 // head_dim),
+        "num_splits": 16,
+    }
+
+
+def _run(inputs, q8_direct):
+    return paged_attn_triton_decode(
+        **inputs,
+        _q8_direct = q8_direct,
+    )
+
+
+def _benchmark(inputs, q8_direct, warmups = 10, repetitions = 100, samples = 7):
+    for _ in range(warmups):
+        _run(inputs, q8_direct)
+    torch.cuda.synchronize()
+
+    timings = []
+    for _ in range(samples):
+        start = torch.cuda.Event(enable_timing = True)
+        end = torch.cuda.Event(enable_timing = True)
+        start.record()
+        for _ in range(repetitions):
+            _run(inputs, q8_direct)
+        end.record()
+        end.synchronize()
+        timings.append(start.elapsed_time(end) * 1000.0 / repetitions)
+    return statistics.median(timings)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not has_triton,
+    reason = "CUDA and Triton are required",
+)
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@torch.inference_mode()
+def test_q8_direct_load_matches_word_expansion(head_dim):
+    inputs = _make_inputs(1024, head_dim)
+    word = _run(inputs, False)
+    direct = _run(inputs, True)
+    torch.testing.assert_close(direct, word, rtol = 0, atol = 2e-5)
+
+
+@pytest.mark.skipif(
+    os.environ.get("EXL3_RUN_PERF_TESTS") != "1",
+    reason = "set EXL3_RUN_PERF_TESTS=1 to run performance tests",
+)
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not has_triton,
+    reason = "CUDA and Triton are required",
+)
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@torch.inference_mode()
+def test_q8_direct_load_benchmark(head_dim):
+    inputs = _make_inputs(16384, head_dim)
+    word_us = _benchmark(inputs, False)
+    direct_us = _benchmark(inputs, True)
+    speedup = word_us / direct_us
+    print(
+        f"Q8 decode on {torch.cuda.get_device_name()}, head_dim={head_dim}: "
+        f"word={word_us:.3f} us, direct={direct_us:.3f} us, "
+        f"speedup={speedup:.3f}x"
+    )
+    assert direct_us < word_us


### PR DESCRIPTION
## Summary

- specialize Q8 K/V cache reads in Triton paged decode to load contiguous bytes directly instead of expanding `int32` words with shifts and masks
- preserve the existing midpoint quantization, cache layout, scale handling, and generic 2-7 bit paths
- add numerical-parity tests for head dimensions 64, 128, and 256 plus an opt-in CUDA benchmark

## Why

For Q8, each 32-value group is already stored as eight contiguous 32-bit words, i.e. 32 directly addressable bytes. The generic bit-plane expansion is needed for lower bit widths but adds avoidable instructions and register pressure at 8 bits.

No equivalent open PR was found after searching the current upstream PR and issue lists for Q8/quantized-cache/direct-load work.

## Correctness

The direct-byte and existing word-expansion paths were compared through the full paged-decode function. Across RTX 3090, RTX 4090, and RTX PRO 6000 Blackwell, all head-dimension cases passed. The maximum observed absolute output difference was `1.53e-5`.

Normal test mode keeps the performance checks out of CI by default:

```text
3 passed, 3 skipped
```

No model evaluation was run; the focused test compares the optimized kernel directly against the existing implementation using the same Q8 bytes, scales, softmax, and split reduction.

## Benchmarks

Workload: Q8 K/V, one decode token, 16K context, 32 query heads, 8 KV heads, 16 splits, 10 warmups, 7 samples of 100 repetitions. Times are median microseconds for full paged decode.

| GPU | Head dim | Word expansion | Direct bytes | Speedup |
|---|---:|---:|---:|---:|
| RTX 3090 | 64 | 55.624 | 43.684 | 1.273x |
| RTX 3090 | 128 | 109.464 | 76.411 | 1.433x |
| RTX 3090 | 256 | 230.010 | 137.503 | 1.673x |
| RTX 4090 | 64 | 32.604 | 24.658 | 1.322x |
| RTX 4090 | 128 | 57.668 | 38.407 | 1.501x |
| RTX 4090 | 256 | 105.434 | 62.915 | 1.676x |
| RTX PRO 6000 | 64 | 26.969 | 24.076 | 1.120x |
| RTX PRO 6000 | 128 | 45.889 | 30.797 | 1.490x |
| RTX PRO 6000 | 256 | 86.551 | 53.033 | 1.632x |

## Tests

```bash
python -m pytest tests/test_q8_direct_load.py -q
EXL3_RUN_PERF_TESTS=1 python -m pytest tests/test_q8_direct_load.py -q -s
python -m py_compile exllamav3/modules/attention_fn/triton_paged.py tests/test_q8_direct_load.py
git diff --check HEAD^ HEAD
```

The focused tests passed on all three GPU architectures; syntax and whitespace checks passed.

AI assistance was used to implement and benchmark this change. The submitter reviewed the diff and test results.
