### PR TITLE
[measure.py] Use dormant VRAM first, then spill to RAM

### DIFF
--- a/exllamav3/conversion/measure_model.py
+++ b/exllamav3/conversion/measure_model.py
@@ -7,7 +7,6 @@ from .calibration_data import get_default_calibration
 from .state_store import TieredStateStore, auto_kldiv_batch, ram_available_bytes
 import json
 import torch.nn.functional as F
-import math
 from collections import defaultdict
 
 col_default = "\u001b[0m"
@@ -193,7 +192,7 @@ def main(args, job_state):
     init_states_ref = torch.cat(init_states_ref, dim = 0)
 
     # Plan memory. Snapshots fill otherwise-idle VRAM first, spill to system RAM second,
-    # and only reach swap if both are genuinely exhausted. All budgets are autodetected;
+    # and only reach swap if both are exhausted. All budgets are autodetected;
     # -ms optionally caps the combined budget manually. NOTE: the true working set is
     # targets_per_pass * NUM_CANDIDATES * state_size (one snapshot per candidate per
     # target), and the last module additionally materializes a [rows*cols, vocab] fp16
@@ -220,6 +219,12 @@ def main(args, job_state):
         budget = vram_budget + ram_budget
     # A single module's targets must always fit in one pass
     budget = max(budget, max(len(t) for t in targets_per_layer) * num_cand * state_size + 2 * state_size)
+    if budget > vram_budget + ram_budget:
+        print(
+            f" !! {col_red}Minimum working set ({budget / 1024**3:.1f} GB for one module's snapshots) exceeds "
+            f"detected memory ({(vram_budget + ram_budget) / 1024**3:.1f} GB VRAM + RAM); "
+            f"the run will proceed but expect heavy swapping{col_default}"
+        )
     print(
         f" -- State budget: {vram_budget / 1024**3:.1f} GB VRAM + {ram_budget / 1024**3:.1f} GB RAM"
         f" (reserving {reserve / 1024**3:.1f} GB VRAM for module loads + output-layer logits)"

--- a/exllamav3/conversion/measure_model.py
+++ b/exllamav3/conversion/measure_model.py
@@ -1,8 +1,10 @@
 import argparse
+import os
 import torch
 from .. import Config, Model, Tokenizer
 from ..util.progress import ProgressBar
 from .calibration_data import get_default_calibration
+from .state_store import TieredStateStore, auto_kldiv_batch, ram_available_bytes
 import json
 import torch.nn.functional as F
 import math
@@ -28,7 +30,7 @@ parser.add_argument("-cr", "--cal_rows", type = int, default = 10, help = "Calib
 parser.add_argument("-cc", "--cal_cols", type = int, default = 1024, help = "Calibration data size, columns, default: 1024")
 # parser.add_argument("-d", "--devices", type = str, default = "0", help = "List of devices to use, e.g. --devices 0,1,2")
 parser.add_argument("-d", "--device", type = int, default = 0, help = "Device index")
-parser.add_argument("-ms", "--max_sys", type = float, default = 8, help = "Max system memory for state data, in GB")
+parser.add_argument("-ms", "--max_sys", type = float, default = None, help = "Optional manual cap on the total state-data budget (VRAM + RAM combined), in GB. Default: autodetect")
 
 def prepare(args) -> (dict, dict, bool, str):
     if not args.in_dir:
@@ -78,8 +80,8 @@ def prepare_state(args, job_state, config, model, tokenizer):
 def kldiv(s, ref):
     r = ref.view(-1, ref.shape[-1])
     s = s.view(-1, s.shape[-1])
-    bsz, _ = s.shape
-    max_batch = 512
+    bsz, vocab = s.shape
+    max_batch = auto_kldiv_batch(vocab)
     kld = 0
     for i in range(0, bsz, max_batch):
         ref_probs = torch.softmax(r[i : i+max_batch, ...].to(s.device), dim = -1, dtype = torch.float)
@@ -190,19 +192,51 @@ def main(args, job_state):
     init_states_ref = prepare_state(args, job_state, config_ref, model_ref, tokenizer)
     init_states_ref = torch.cat(init_states_ref, dim = 0)
 
-    # Chunk to limit system RAM
+    # Plan memory. Snapshots fill otherwise-idle VRAM first, spill to system RAM second,
+    # and only reach swap if both are genuinely exhausted. All budgets are autodetected;
+    # -ms optionally caps the combined budget manually. NOTE: the true working set is
+    # targets_per_pass * NUM_CANDIDATES * state_size (one snapshot per candidate per
+    # target), and the last module additionally materializes a [rows*cols, vocab] fp16
+    # logits tensor in VRAM per forward — both are accounted for below.
     print(f" -- Total optimized params: {total_targets}")
     state_size = config_ref.hidden_size * init_states_ref.numel() * 4
-    r_sys = int(args["max_sys"] * 1024**3) - state_size * 2
-    t_sys_cand = total_targets * state_size
-    num_chunks = int(math.ceil(t_sys_cand / r_sys))
+    vocab_size = getattr(config_ref, "vocab_size", None) or tokenizer.actual_vocab_size
+    head_transient = init_states_ref.numel() * vocab_size * 2
+
+    def _model_bytes(d):
+        return sum(
+            os.path.getsize(os.path.join(d, f))
+            for f in os.listdir(d) if f.endswith(".safetensors")
+        )
+    module_estimate = int(sum(_model_bytes(d) for d in [dir_ref] + dir_q) / len(model_ref.modules) * 1.5)
+    reserve = head_transient + module_estimate + (4 << 30)
+    store = TieredStateStore(device, reserve_bytes = reserve)
+    free_vram, _ = torch.cuda.mem_get_info(device)
+    vram_budget = max(0, free_vram - reserve)
+    ram_budget = max(0, int(ram_available_bytes() * 0.85) - head_transient)
+    if args["max_sys"] is not None:
+        budget = int(args["max_sys"] * 1024**3)
+    else:
+        budget = vram_budget + ram_budget
+    # A single module's targets must always fit in one pass
+    budget = max(budget, max(len(t) for t in targets_per_layer) * num_cand * state_size + 2 * state_size)
+    print(
+        f" -- State budget: {vram_budget / 1024**3:.1f} GB VRAM + {ram_budget / 1024**3:.1f} GB RAM"
+        f" (reserving {reserve / 1024**3:.1f} GB VRAM for module loads + output-layer logits)"
+        + ("" if args["max_sys"] is None else f"; capped at {budget / 1024**3:.1f} GB by -ms")
+    )
+    # Pack modules into passes greedily against the real working-set cost per module
     tpl = targets_per_layer
-    lpc = int(math.ceil(len(tpl) / num_chunks))
     tpl_chunks = []
-    for i in range(0, len(tpl), lpc):
-        tpl_c = [(t if i <= j < i + lpc else []) for j, t in enumerate(tpl)]
-        if any(t for t in tpl_c):
-            tpl_chunks.append(tpl_c)
+    chunk_start, chunk_bytes = 0, 2 * state_size
+    for j in range(len(tpl)):
+        need = len(tpl[j]) * num_cand * state_size
+        if chunk_bytes + need > budget and any(tpl[i] for i in range(chunk_start, j)):
+            tpl_chunks.append([(tt if chunk_start <= i < j else []) for i, tt in enumerate(tpl)])
+            chunk_start, chunk_bytes = j, 2 * state_size
+        chunk_bytes += need
+    if any(tpl[i] for i in range(chunk_start, len(tpl))):
+        tpl_chunks.append([(tt if chunk_start <= i else []) for i, tt in enumerate(tpl)])
 
     all_cand_groups = []
     all_cand_costs = [[] for _ in range(num_cand)]
@@ -245,9 +279,9 @@ def main(args, job_state):
 
                 # Reference forward pass
                 params = {"activate_all_experts": True, "attn_mode": "flash_attn_nc"}
-                s = module.prepare_for_device(states_ref, params)
+                s = module.prepare_for_device(store.load(states_ref), params)
                 s = module.forward(s, params)
-                new_states_ref = s.cpu()
+                new_states_ref = store.store(s)
                 del s
                 torch.cuda.empty_cache()
                 pb.update(pb_prog)
@@ -276,13 +310,13 @@ def main(args, job_state):
 
                 # Advance base state
                 params = {"activate_all_experts": True, "attn_mode": "flash_attn_nc"}
-                s = modules[0].prepare_for_device(states_q, params)
+                s = modules[0].prepare_for_device(store.load(states_q), params)
                 s = modules[0].forward(s, params)
                 if last_fwd:
                     base_kld = kldiv(s, new_states_ref)
                     new_states_q = None
                 else:
-                    new_states_q = s.cpu()
+                    new_states_q = store.store(s)
                 del s
                 torch.cuda.empty_cache()
                 pb.update(pb_prog)
@@ -296,13 +330,13 @@ def main(args, job_state):
                     for i in range(len(cand_states[k])):
                         states_c = cand_states[k][i]
                         params = {"activate_all_experts": True, "attn_mode": "flash_attn_nc"}
-                        s = modules[0].prepare_for_device(states_c, params)
+                        s = modules[0].prepare_for_device(store.load(states_c), params)
                         s = modules[0].forward(s, params)
                         if last_fwd:
                             cand_kld[k][i] += kldiv(s, new_states_ref) - base_kld
                             cand_states[k][i] = None
                         else:
-                            cand_states[k][i] = s.cpu()
+                            cand_states[k][i] = store.store(s)
                         del s
                         torch.cuda.empty_cache()
                         pb.update(pb_prog)
@@ -327,12 +361,12 @@ def main(args, job_state):
                             "attn_mode": "flash_attn_nc",
                             "ovr": {key : model_q[k + 1].find_module(key) for key in t}
                         }
-                        s = modules[0].prepare_for_device(states_q, params)
+                        s = modules[0].prepare_for_device(store.load(states_q), params)
                         s = modules[0].forward(s, params)
                         if last_fwd:
                             cand_kld[k][i] = kldiv(s, new_states_ref) - base_kld
                         else:
-                            cand_states[k].append(s.cpu())
+                            cand_states[k].append(store.store(s))
                         del s
                         torch.cuda.empty_cache()
                         pb.update(pb_prog)
@@ -428,4 +462,5 @@ def main(args, job_state):
         f.write(json.dumps(results, indent = 4))
 
     # Done
+    print(f" -- {store.stats()}")
     print(" -- Done")

--- a/exllamav3/conversion/state_store.py
+++ b/exllamav3/conversion/state_store.py
@@ -20,7 +20,7 @@ Motivation (measured on gpt-oss-120b, 36L/128-expert MoE, 96 GB GPU / 123 GB RAM
 The store keeps snapshots in VRAM while ``free - size > reserve`` holds (checked live,
 per store, so module loads and transients are automatically respected), spilling to
 pageable system RAM otherwise. If RAM is exhausted the OS pages to swap — degraded but
-alive, and only reachable after both real tiers are genuinely full.
+alive, and only reachable after both real tiers are full.
 
 Correctness notes:
 

--- a/exllamav3/conversion/state_store.py
+++ b/exllamav3/conversion/state_store.py
@@ -56,7 +56,7 @@ def ram_available_bytes() -> int:
         pass
     try:
         return os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
-    except (ValueError, OSError):
+    except (AttributeError, ValueError, OSError):   # os.sysconf does not exist on Windows
         return 16 << 30  # conservative fallback; store() degrades gracefully anyway
 
 

--- a/exllamav3/conversion/state_store.py
+++ b/exllamav3/conversion/state_store.py
@@ -1,0 +1,144 @@
+"""
+Tiered storage for measurement state snapshots: VRAM first, system RAM second, swap only
+as a genuine last resort — with all budgets autodetected so the user never has to size
+anything.
+
+Motivation (measured on gpt-oss-120b, 36L/128-expert MoE, 96 GB GPU / 123 GB RAM):
+
+  * measure_model.py snapshots one full calibration state per (tensor-group, candidate)
+    per pass. These snapshots were stored via ``.cpu()``, so a pass's working set lived
+    entirely in system RAM while tens of GB of VRAM sat idle (the GPU only holds one
+    layer's modules at a time during measurement).
+  * The old ``-ms`` chunking formula under-budgets the working set by a factor of
+    ``num_candidates`` (states are stored per candidate, not per target), which makes
+    OOM-by-formula easy: peak = targets_in_pass x num_candidates x state_size.
+  * The final module is special: every candidate forward materializes a
+    ``[rows*cols, vocab]`` logits tensor in VRAM regardless of where snapshots live
+    (~25 GB at cal 32x2048 over a 200k vocab). VRAM reserved for snapshots must leave
+    room for it, or the run dies at the finish line.
+
+The store keeps snapshots in VRAM while ``free - size > reserve`` holds (checked live,
+per store, so module loads and transients are automatically respected), spilling to
+pageable system RAM otherwise. If RAM is exhausted the OS pages to swap — degraded but
+alive, and only reachable after both real tiers are genuinely full.
+
+Correctness notes:
+
+  * ``store()`` CLONES device tensors. ``.cpu()`` used to provide snapshot semantics as
+    a side effect of the device move; a zero-copy VRAM "store" aliases the live residual
+    buffer, which module.forward() mutates in place — every snapshot silently becomes
+    the same trampled tensor.
+  * ``load()`` returns a PRIVATE device tensor. ``prepare_for_device()`` fast-paths
+    same-device inputs with no copy, so a VRAM-resident snapshot fed straight to
+    ``forward()`` would be corrupted for its next read (the base state is re-read once
+    per target). CPU-resident snapshots get their copy for free via ``.to(device)``.
+
+Run ``python -m exllamav3.conversion.state_store`` for a self-test of both properties.
+"""
+
+import os
+import torch
+
+
+def ram_available_bytes() -> int:
+    """Best-effort available system RAM (reclaimable-aware on Linux)."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except ImportError:
+        pass
+    try:
+        return os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+    except (ValueError, OSError):
+        return 16 << 30  # conservative fallback; store() degrades gracefully anyway
+
+
+def auto_kldiv_batch(vocab_size: int, budget_elements: int = 32 << 20) -> int:
+    """
+    Softmax chunk rows for the final KL-div step, sized so a single kernel stays small
+    enough for display-watchdog systems (a 512 x 200k fp32 softmax is one long kernel
+    launch and gets killed on desktops). Scales with vocab: ~128 rows at 200k vocab,
+    512 at 32k.
+    """
+    return max(16, min(512, budget_elements // max(1, vocab_size)))
+
+
+class TieredStateStore:
+
+    def __init__(self, device: torch.device, reserve_bytes: int, ram_floor_bytes: int = 4 << 30):
+        """
+        :param device:
+            CUDA device snapshots may reside on.
+        :param reserve_bytes:
+            VRAM to keep free at all times (module loads + forward activations + the
+            final-module logits transient). Snapshots never intrude on it.
+        :param ram_floor_bytes:
+            When available RAM falls below this, warn once that the OS is about to
+            page (the store still proceeds — swap is the last resort, not an error).
+        """
+        self.device = device
+        self.reserve = reserve_bytes
+        self.ram_floor = ram_floor_bytes
+        self.kept_vram = 0
+        self.spilled_ram = 0
+        self._warned_swap = False
+
+    def store(self, t: torch.Tensor) -> torch.Tensor:
+        """Snapshot a tensor: private copy in VRAM if the reserve allows, else RAM."""
+        if t.device.type == "cuda":
+            nbytes = t.numel() * t.element_size()
+            free, _ = torch.cuda.mem_get_info(t.device)
+            if free - nbytes > self.reserve:
+                self.kept_vram += 1
+                return t.clone()  # MUST copy: forward() mutates its input in place
+            self.spilled_ram += 1
+            if not self._warned_swap and ram_available_bytes() < self.ram_floor:
+                self._warned_swap = True
+                print(" !! System RAM nearly exhausted; the OS may start paging state "
+                      "data to swap (run continues, but slowly)")
+        return t.cpu()
+
+    def load(self, t: torch.Tensor) -> torch.Tensor:
+        """
+        Materialize a snapshot on-device as a PRIVATE tensor safe to hand to a forward
+        pass that mutates its input. CPU tensors are copied by the transfer; device
+        tensors must be cloned explicitly.
+        """
+        if t.device == self.device:
+            return t.clone()
+        return t  # prepare_for_device() copies host tensors on upload
+
+    def stats(self) -> str:
+        return f"{self.kept_vram} state snapshots in VRAM, {self.spilled_ram} spilled to RAM"
+
+
+def _selftest():
+    if not torch.cuda.is_available():
+        print("CUDA unavailable; self-test skipped")
+        return
+    dev = torch.device("cuda:0")
+    store = TieredStateStore(dev, reserve_bytes = 2 << 30)
+    buf = torch.zeros(64 << 20, dtype = torch.half, device = dev)   # 128 MB
+    snap = store.store(buf)
+    assert snap.data_ptr() != buf.data_ptr(), "snapshot aliases live buffer"
+    buf += 1
+    assert snap.abs().sum().item() == 0, "snapshot trampled by in-place mutation"
+    loaded = store.load(snap)
+    assert loaded.data_ptr() != snap.data_ptr(), "load() returned the stored snapshot itself"
+    loaded += 7
+    assert snap.abs().sum().item() == 0, "stored snapshot corrupted through load()"
+    tiny = TieredStateStore(dev, reserve_bytes = 1 << 60)           # impossible reserve
+    spilled = tiny.store(buf)
+    assert spilled.device.type == "cpu", "reserve floor not respected"
+    print("state_store self-test passed:", store.stats())
+
+
+if __name__ == "__main__":
+    _selftest()


### PR DESCRIPTION
This tweaks the measure.py logic to use VRAM for state storage first, accounting for processing the HEAD layer and the VRAM spike that occurs therein and in so doing not over provisioning the VRAM budget and causing an OOM. This should help prevent swapping when measure.py is run by using the otherwise dormant VRAM as fast storage for the measurement of a set of quants.