### PR TITLE
Add Gemma4 E4B and E2B support (per-layer embeddings, cross-layer KV sharing)

### DIFF
--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -23,6 +23,9 @@ from ..modules.arch_specific.gemma4 import (
     Gemma4VisionPatchEmbedder,
     Gemma4VisionPooler,
     Gemma4UnifiedVisionEmbedder,
+    Gemma4PerLayerTokenEmbedding,
+    Gemma4PerLayerProjection,
+    Gemma4PerLayerInject,
 )
 from ..modules.attn import prepare_for_attn
 from ..tokenizer import MMEmbedding, Tokenizer
@@ -93,9 +96,29 @@ class Gemma4Config(Config):
         self.attn_logit_softcapping = self.read_cfg(float, "text_config->attn_logit_softcapping", 0.0)
         self.final_logit_softcapping = self.read_cfg(float, "text_config->final_logit_softcapping", 0.0)
 
+        # Per-layer embeddings (E4B and similar)
         self.hidden_size_per_layer_input = self.read_cfg(int, "text_config->hidden_size_per_layer_input", 0)
-        if self.hidden_size_per_layer_input:
-            raise NotImplementedError("Gemma4 per-layer inputs are not implemented yet")
+        self.vocab_size_per_layer_input = self.read_cfg(int, "text_config->vocab_size_per_layer_input", self.vocab_size)
+
+        # Cross-layer KV sharing (E4B and similar): the last num_kv_shared_layers layers have no K/V
+        # projections and reuse the KV state of the last preceding non-shared layer of the same type
+        self.num_kv_shared_layers = self.read_cfg(int, "text_config->num_kv_shared_layers", 0)
+        if self.num_kv_shared_layers > 0:
+            self.first_kv_shared_layer_idx = self.num_hidden_layers - self.num_kv_shared_layers
+        else:
+            self.first_kv_shared_layer_idx = self.num_hidden_layers
+        self.kv_shared_source_idx = []
+        for idx, layer_type in enumerate(self.layer_types):
+            if idx < self.first_kv_shared_layer_idx:
+                self.kv_shared_source_idx.append(None)
+            else:
+                sources = [
+                    j for j in range(self.first_kv_shared_layer_idx)
+                    if self.layer_types[j] == layer_type
+                ]
+                assert len(sources), \
+                    f"No KV source layer found for shared layer {idx} of type {layer_type}"
+                self.kv_shared_source_idx.append(sources[-1])
 
         self.enable_moe_block = self.read_cfg(bool, "text_config->enable_moe_block", False)
         self.num_experts = self.read_cfg(int, "text_config->num_experts", 0)
@@ -202,24 +225,59 @@ class Gemma4TextModel(Model):
         **kwargs
     ):
         super().__init__(config, **kwargs)
+
+        # TODO: Cross-layer KV sharing is not implemented for the recurrent SWA state path yet, so
+        #       sliding layers fall back to regular paged attention when KV sharing is active
+        if config.num_kv_shared_layers > 0:
+            swa_full = True
         self.swa_full = swa_full
 
         use_moe = config.enable_moe_block
+        use_ple = config.hidden_size_per_layer_input > 0
 
-        self.modules += [
-            Embedding(
+        self.embedding_module = Embedding(
+            config = config,
+            key = f"{key_prefix}.embed_tokens",
+            vocab_size = config.vocab_size,
+            hidden_size = config.hidden_size,
+            multiplier = torch.tensor(config.hidden_size ** 0.5, dtype = torch.bfloat16).float().item()
+        )
+        self.modules += [self.embedding_module]
+
+        self.ple_tok_module = None
+        self.ple_proj_module = None
+        if use_ple:
+            # The embedding module stays loaded during conversion: per_layer_quant_preamble
+            # recomputes the per-layer inputs from input IDs for every quantized module, and the
+            # context component of PLE is derived from the input embeddings
+            self.embedding_module.caps["retain_during_quant"] = True
+            self.ple_tok_module = Gemma4PerLayerTokenEmbedding(
                 config = config,
-                key = f"{key_prefix}.embed_tokens",
-                vocab_size = config.vocab_size,
-                hidden_size = config.hidden_size,
-                multiplier = torch.tensor(config.hidden_size ** 0.5, dtype = torch.bfloat16).float().item()
+                key = f"{key_prefix}.embed_tokens_per_layer",
+                vocab_size = config.vocab_size_per_layer_input,
+                num_layers = config.num_hidden_layers,
+                ple_dim = config.hidden_size_per_layer_input,
             )
-        ]
+            self.ple_proj_module = Gemma4PerLayerProjection(
+                config = config,
+                key = f"{key_prefix}.per_layer_model_projection",
+                key_norm = f"{key_prefix}.per_layer_projection_norm",
+                hidden_size = config.hidden_size,
+                num_layers = config.num_hidden_layers,
+                ple_dim = config.hidden_size_per_layer_input,
+                rms_norm_eps = config.rms_norm_eps,
+            )
+            self.modules += [self.ple_tok_module, self.ple_proj_module]
 
         self.first_block_idx = len(self.modules)
+        self.last_kv_block_idx = None
 
+        attn_modules = []
         for idx in range(config.num_hidden_layers):
             layer_is_full = config.layer_types[idx] == "full_attention"
+            kv_source_idx = config.kv_shared_source_idx[idx]
+            kv_source = attn_modules[kv_source_idx] if kv_source_idx is not None else None
+            store_shared_kv = idx in config.kv_shared_source_idx
 
             if swa_full or config.swa_pattern[idx] <= 0:
                 attn = Attention(
@@ -233,10 +291,10 @@ class Gemma4TextModel(Model):
                     rope_settings = config.rope_settings_global if layer_is_full else config.rope_settings_local,
                     logit_softcapping = config.attn_logit_softcapping,
                     sliding_window = config.swa_pattern[idx],
-                    use_k_as_v = layer_is_full and config.attention_k_eq_v,
+                    use_k_as_v = kv_source is None and layer_is_full and config.attention_k_eq_v,
                     key_q = "q_proj",
-                    key_k = "k_proj",
-                    key_v = "v_proj",
+                    key_k = "k_proj" if kv_source is None else None,
+                    key_v = "v_proj" if kv_source is None else None,
                     key_o = "o_proj",
                     qmap = "block.attn",
                     sm_scale = 1.0,
@@ -249,16 +307,20 @@ class Gemma4TextModel(Model):
                         config = config,
                         key = f"{key_prefix}.layers.{idx}.self_attn.k_norm",
                         rms_norm_eps = config.rms_norm_eps,
-                    ),
+                    ) if kv_source is None else None,
                     v_norm = RMSNorm(
                         config = config,
                         key = f"{key_prefix}.layers.{idx}.self_attn.v_norm",
                         rms_norm_eps = config.rms_norm_eps,
                         unweighted = True,
-                    ),
+                    ) if kv_source is None else None,
                     select_hq_bits = 2 if use_moe else 0,
+                    kv_source = kv_source,
+                    store_shared_kv = store_shared_kv,
                 )
             else:
+                assert kv_source is None and not store_shared_kv, \
+                    "Cross-layer KV sharing is not implemented for SlidingAttention"
                 attn = SlidingAttention(
                     config = config,
                     key = f"{key_prefix}.layers.{idx}.self_attn",
@@ -294,6 +356,8 @@ class Gemma4TextModel(Model):
                     ),
                     select_hq_bits = 2 if use_moe else 0,
                 )
+
+            attn_modules.append(attn)
 
             mlp = GatedMLP(
                 config = config,
@@ -390,11 +454,23 @@ class Gemma4TextModel(Model):
                     rms_norm_eps = config.rms_norm_eps,
                     out_dtype = torch.float,
                 ),
+                ple = Gemma4PerLayerInject(
+                    config = config,
+                    key = f"{key_prefix}.layers.{idx}",
+                    layer_idx = idx,
+                    hidden_size = config.hidden_size,
+                    ple_dim = config.hidden_size_per_layer_input,
+                    rms_norm_eps = config.rms_norm_eps,
+                ) if use_ple else None,
             )
 
             self.modules.append(block)
+            if kv_source is None:
+                self.last_kv_block_idx = len(self.modules) - 1
 
-        self.last_kv_module_idx = len(self.modules) - 1
+        # Layers that reuse shared KV never write to the cache, so prefill can stop at the last
+        # block whose attention layer produces KV state
+        self.last_kv_module_idx = self.last_kv_block_idx
 
         self.modules += [
             RMSNorm(
@@ -422,9 +498,21 @@ class Gemma4TextModel(Model):
             self.calibration_all_experts = True
 
         self.caps.update({
-            "supports_tp": True,
+            # TP is not implemented for per-layer embeddings or cross-layer KV sharing (E4B)
+            "supports_tp": not use_ple and config.num_kv_shared_layers == 0,
             "atomic_mm_prefill": config.use_bidirectional_attention == "vision",
         })
+
+        if use_ple or config.num_kv_shared_layers > 0:
+            self.caps.update({
+                # Modules exchange state through params during the forward pass (per-layer inputs,
+                # shared K/V). Conversion supports this via per_layer_quant_preamble and
+                # quant_preserve, but neither the side-channel state nor the calibration input IDs
+                # survive a conversion checkpoint, so resuming is not possible. Tools that stream
+                # modules with per-module params (e.g. measure_model) are not supported at all
+                "can_resume_quant": False,
+                "forward_side_channel": True,
+            })
 
         # SWA layers are recurrent, optionally. Checkpoints are expensive so default to a longer interval
         self.recurrent_state_cls = None
@@ -438,10 +526,28 @@ class Gemma4TextModel(Model):
 
     @override
     def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        if self.config.hidden_size_per_layer_input:
+            params["g4_input_ids"] = input_ids
         _prepare_noncausal_mm_spans(input_ids, params)
         if not self.swa_full:
             prepare_for_recurrence(input_ids, params, self)
         return prepare_for_attn(input_ids, params)
+
+
+    @override
+    def per_layer_quant_preamble(self, params: dict):
+        # Conversion rebuilds params for every module pass; recompute the combined per-layer
+        # inputs from the calibration input IDs (the embedding and PLE modules are retained in
+        # memory throughout conversion). Shared K/V from layers that set store_shared_kv is
+        # carried across modules by the quant_preserve mechanism instead
+        if self.ple_proj_module is None or self.ple_proj_module.device is None:
+            return
+        if self.embedding_module.device is None or self.ple_tok_module.device is None:
+            return
+        x = self.embedding_module.forward(params["input_ids"], params)
+        x = self.ple_tok_module.forward(x, params)
+        x = self.ple_proj_module.prepare_for_device(x, params)
+        self.ple_proj_module.forward(x, params)
 
 
     @override

--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -91,6 +91,8 @@ class Gemma4Config(Config):
 
         self.assert_cfg(str, "text_config->hidden_activation", "gelu_pytorch_tanh", True)
         self.intermediate_size = self.read_cfg(int, "text_config->intermediate_size", no_default)
+        # E2B and similar: KV-shared layers have a double-width MLP
+        self.use_double_wide_mlp = self.read_cfg(bool, "text_config->use_double_wide_mlp", False)
 
         self.rms_norm_eps = self.read_cfg(float, "text_config->rms_norm_eps", no_default)
         self.attn_logit_softcapping = self.read_cfg(float, "text_config->attn_logit_softcapping", 0.0)
@@ -359,11 +361,14 @@ class Gemma4TextModel(Model):
 
             attn_modules.append(attn)
 
+            layer_intermediate_size = config.intermediate_size * \
+                (2 if config.use_double_wide_mlp and kv_source is not None else 1)
+
             mlp = GatedMLP(
                 config = config,
                 key = f"{key_prefix}.layers.{idx}.mlp",
                 hidden_size = config.hidden_size,
-                intermediate_size = config.intermediate_size,
+                intermediate_size = layer_intermediate_size,
                 key_up = "up_proj",
                 key_gate = "gate_proj",
                 key_down = "down_proj",

--- a/exllamav3/architecture/gemma4.py
+++ b/exllamav3/architecture/gemma4.py
@@ -227,11 +227,6 @@ class Gemma4TextModel(Model):
         **kwargs
     ):
         super().__init__(config, **kwargs)
-
-        # TODO: Cross-layer KV sharing is not implemented for the recurrent SWA state path yet, so
-        #       sliding layers fall back to regular paged attention when KV sharing is active
-        if config.num_kv_shared_layers > 0:
-            swa_full = True
         self.swa_full = swa_full
 
         use_moe = config.enable_moe_block
@@ -321,8 +316,6 @@ class Gemma4TextModel(Model):
                     store_shared_kv = store_shared_kv,
                 )
             else:
-                assert kv_source is None and not store_shared_kv, \
-                    "Cross-layer KV sharing is not implemented for SlidingAttention"
                 attn = SlidingAttention(
                     config = config,
                     key = f"{key_prefix}.layers.{idx}.self_attn",
@@ -335,8 +328,8 @@ class Gemma4TextModel(Model):
                     logit_softcapping = config.attn_logit_softcapping,
                     sliding_window = config.swa_pattern[idx],
                     key_q = "q_proj",
-                    key_k = "k_proj",
-                    key_v = "v_proj",
+                    key_k = "k_proj" if kv_source is None else None,
+                    key_v = "v_proj" if kv_source is None else None,
                     key_o = "o_proj",
                     qmap = "block.attn",
                     sm_scale = 1.0,
@@ -349,14 +342,16 @@ class Gemma4TextModel(Model):
                         config = config,
                         key = f"{key_prefix}.layers.{idx}.self_attn.k_norm",
                         rms_norm_eps = config.rms_norm_eps,
-                    ),
+                    ) if kv_source is None else None,
                     v_norm = RMSNorm(
                         config = config,
                         key = f"{key_prefix}.layers.{idx}.self_attn.v_norm",
                         rms_norm_eps = config.rms_norm_eps,
                         unweighted = True,
-                    ),
+                    ) if kv_source is None else None,
                     select_hq_bits = 2 if use_moe else 0,
+                    kv_source = kv_source,
+                    store_shared_kv = store_shared_kv,
                 )
 
             attn_modules.append(attn)

--- a/exllamav3/cache/recurrent_util.py
+++ b/exllamav3/cache/recurrent_util.py
@@ -64,6 +64,12 @@ def prepare_for_recurrence(input_ids: torch.Tensor, params: dict, model) -> torc
 
 
 def advance_recurrent_states(input_ids: torch.Tensor, params: dict, model):
+    # Layers whose state is read by later layers within the same forward pass (cross-layer KV
+    # sharing) defer their destructive state updates to this point. Positions have not advanced
+    # yet, so the update sees the same state bookkeeping it would have inline
+    for fn in params.pop("deferred_state_updates", []):
+        fn()
+
     rs = params.get("recurrent_states")
     history = params.get("recurrent_history")
     if rs:

--- a/exllamav3/conversion/measure_model.py
+++ b/exllamav3/conversion/measure_model.py
@@ -143,6 +143,13 @@ def main(args, job_state):
     print(f"    Architecture: {config_ref.architecture}")
     model_ref = Model.from_config(config_ref)
     model_q = [Model.from_config(c) for c in config_q]
+    if any(m.caps.get("forward_side_channel") for m in [model_ref] + model_q):
+        print(
+            f" !! {col_red}Error: this architecture passes side-channel state between modules "
+            f"during the forward pass (e.g. per-layer embeddings or cross-layer KV sharing), "
+            f"which this tool's per-module streaming does not support.{col_default}"
+        )
+        raise SystemExit(1)
     print(f" -- Created model instances:")
     r_layout = model_ref.get_layout_tree(4)
     print(r_layout)

--- a/exllamav3/modules/arch_specific/gemma4.py
+++ b/exllamav3/modules/arch_specific/gemma4.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing_extensions import override
 import torch.nn.functional as F
-from .. import Module, Linear, LayerNorm
+from .. import Module, Linear, LayerNorm, RMSNorm
 from ...model import Config
 import torch
 from ...util.tensor import get_for_device, to2
@@ -274,4 +274,245 @@ class Gemma4UnifiedVisionEmbedder(Module):
         pos_embs = (self.pos_embedding[clamped, axes] * valid).sum(-2)
 
         x = self.pos_norm.forward(x + pos_embs, params)
+        return x
+
+
+class Gemma4PerLayerTokenEmbedding(Module):
+    """
+    Token-identity component of Gemma4 per-layer embeddings (PLE). Looks up input IDs in the packed
+    embed_tokens_per_layer table, scaled by sqrt(ple_dim), and stores the result in params for the
+    downstream projection module. Hidden states pass through unchanged. The table is large
+    (vocab_size x num_layers * ple_dim), so like the main token embedding it prefers CPU placement.
+    """
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        vocab_size: int,
+        num_layers: int,
+        ple_dim: int,
+    ):
+        super().__init__(config, key, None)
+        self.vocab_size = vocab_size
+        self.num_layers = num_layers
+        self.ple_dim = ple_dim
+        self.embedding = None
+        self._numel = vocab_size * num_layers * ple_dim
+        # Multiplier survives the bf16 round trip the reference implementation applies to it
+        self.multiplier = torch.tensor(ple_dim ** 0.5, dtype = torch.bfloat16).float().item()
+        self.caps.update({
+            "prefer_cpu": True,
+            # Stays loaded during conversion so per_layer_quant_preamble can recompute the
+            # combined per-layer inputs for every quantized module (same pattern as ValueEmbeddings)
+            "retain_during_quant": True,
+        })
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        self.device = device
+        weight = self.config.stc.get_tensor(self.key + ".weight", self.device, float2half = True, allow_bf16 = True)
+        self._numel = weight.numel()
+        self.embedding = torch.nn.Embedding(
+            self.vocab_size,
+            self.num_layers * self.ple_dim,
+            device = "meta"
+        )
+        self.embedding.weight = torch.nn.Parameter(weight)
+
+    @override
+    def unload(self):
+        self.device = None
+        self.embedding = None
+
+    @override
+    def get_tensors(self):
+        return {
+            f"{self.key}.weight": self.embedding.weight.data.contiguous()
+        }
+
+    @override
+    def weights_numel(self):
+        return self._numel
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        # g4_input_ids is set by prepare_inputs() on the normal forward path; the conversion and
+        # autosplit pipelines call modules directly and supply plain input_ids instead
+        input_ids = params.get("g4_input_ids")
+        if input_ids is None:
+            input_ids = params["input_ids"]
+        input_ids = input_ids.to(self.embedding.weight.device)
+        # Indexed multimodal embeddings use synthetic token IDs beyond the vocabulary; the PLE
+        # table has no rows for them, so those positions look up the pad token (ID 0) instead,
+        # matching the reference implementation
+        if input_ids.numel() and input_ids.max().item() >= self.vocab_size:
+            input_ids = torch.where(
+                input_ids < self.vocab_size,
+                input_ids,
+                torch.zeros_like(input_ids),
+            )
+        tok = self.embedding(input_ids)
+        tok = tok.view(*input_ids.shape, self.num_layers, self.ple_dim)
+        tok = tok.half() * self.multiplier
+        params["g4_ple_tok"] = tok
+        return x
+
+
+class Gemma4PerLayerProjection(Module):
+    """
+    Context-aware component of Gemma4 PLE. Projects the (scaled) input embeddings to per-layer space,
+    normalizes, and combines with the token-identity component computed by Gemma4PerLayerTokenEmbedding.
+    Stores the combined (bsz, seq_len, num_layers, ple_dim) tensor in params; hidden states pass
+    through unchanged.
+    """
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        key_norm: str,
+        hidden_size: int,
+        num_layers: int,
+        ple_dim: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.ple_dim = ple_dim
+
+        self.caps.update({
+            # Stays loaded during conversion so per_layer_quant_preamble can recompute the
+            # combined per-layer inputs for every quantized module
+            "retain_during_quant": True,
+        })
+
+        # TODO: PLE projections (this one plus the per-layer gate/projection pairs) are kept
+        #       unquantized for now, ~83M params / ~165 MB at fp16 for E4B. Giving them a qmap is
+        #       pending an evaluation of the accuracy/size tradeoff.
+        self.proj = Linear(
+            config = config,
+            key = key,
+            in_features = hidden_size,
+            out_features = num_layers * ple_dim,
+            qmap = None,
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+        self.norm = RMSNorm(
+            config = config,
+            key = key_norm,
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.half,
+        )
+        self.register_submodule(self.proj)
+        self.register_submodule(self.norm)
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+    # The norm's tensor lives under a sibling key prefix (per_layer_projection_norm), which the
+    # default per-module-key prefix scan in the compile step would miss
+    @override
+    def get_compile_sizes(self, stc):
+        return stc.get_tensor_sizes(self.key) + stc.get_tensor_sizes(self.norm.key)
+
+    @override
+    def get_compile_tensors(self, stc):
+        return stc.get_tensors(self.key, allow_bf16 = True) | stc.get_tensors(self.norm.key, allow_bf16 = True)
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        ctx = self.proj.forward(x.half(), params)
+        ctx = ctx * (self.hidden_size ** -0.5)
+        ctx = ctx.view(*x.shape[:-1], self.num_layers, self.ple_dim)
+        ctx = self.norm.forward(ctx, params, out_dtype = torch.half)
+        tok = get_for_device(params, "g4_ple_tok", ctx.device)
+        ple = (ctx + tok) * (2 ** -0.5)
+        params["g4_ple"] = ple
+        return x
+
+
+class Gemma4PerLayerInject(Module):
+    """
+    Per-decoder-layer PLE injection: gated projection of this layer's per-layer input added to the
+    residual stream at the end of the transformer block (before the layer scalar is applied).
+    """
+
+    def __init__(
+        self,
+        config: Config | None,
+        key: str,
+        layer_idx: int,
+        hidden_size: int,
+        ple_dim: int,
+        rms_norm_eps: float,
+    ):
+        super().__init__(config, key, None)
+        self.layer_idx = layer_idx
+
+        # TODO: unquantized for now (see Gemma4PerLayerProjection); pending evaluation
+        self.gate = Linear(
+            config = config,
+            key = f"{key}.per_layer_input_gate",
+            in_features = hidden_size,
+            out_features = ple_dim,
+            qmap = None,
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+        self.proj = Linear(
+            config = config,
+            key = f"{key}.per_layer_projection",
+            in_features = ple_dim,
+            out_features = hidden_size,
+            qmap = None,
+            out_dtype = torch.half,
+            pad_to = 1,
+        )
+        self.norm = RMSNorm(
+            config = config,
+            key = f"{key}.post_per_layer_input_norm",
+            rms_norm_eps = rms_norm_eps,
+            out_dtype = torch.float,
+        )
+        self.register_submodule(self.gate)
+        self.register_submodule(self.proj)
+        self.register_submodule(self.norm)
+
+    @override
+    def optimizer_targets(self):
+        return []
+
+    @override
+    def forward(
+        self,
+        x: torch.Tensor,
+        params: dict,
+        out_dtype: torch.dtype | None = None
+    ) -> torch.Tensor:
+        ple = get_for_device(params, "g4_ple", self.device)
+        ple = ple[..., self.layer_idx, :]
+        y = self.gate.forward(x.half(), params)
+        y = F.gelu(y, approximate = "tanh")
+        y = y * ple
+        y = self.proj.forward(y, params)
+        y = self.norm.forward(y, params, out_dtype = torch.float)
+        x += y
         return x

--- a/exllamav3/modules/arch_specific/gemma4.py
+++ b/exllamav3/modules/arch_specific/gemma4.py
@@ -397,9 +397,12 @@ class Gemma4PerLayerProjection(Module):
             "retain_during_quant": True,
         })
 
-        # TODO: PLE projections (this one plus the per-layer gate/projection pairs) are kept
-        #       unquantized for now, ~83M params / ~165 MB at fp16 for E4B. Giving them a qmap is
-        #       pending an evaluation of the accuracy/size tradeoff.
+        # The PLE projections (this one plus the per-layer gate/projection pairs, ~83M params /
+        # ~165 MB at fp16 for E4B) are deliberately kept unquantized. Measured on E4B at 4.0 bpw,
+        # giving them qmaps roughly doubled KL vs the bf16 reference (mean 0.034 -> 0.061, top-1
+        # 90.5% -> 87.9%) while saving only ~1% of file size: the per-layer gates feed the
+        # residual stream directly and their errors compound across all layers, and the extra
+        # tensors dilute the bit budget for the attention/MLP weights.
         self.proj = Linear(
             config = config,
             key = key,

--- a/exllamav3/modules/attn.py
+++ b/exllamav3/modules/attn.py
@@ -183,7 +183,9 @@ class Attention(Module):
         gate_softplus: bool = False,
         tp_split_norm: bool = True,
         select_hq_bits: int = 0,
-        qbits_key: str = "bits"
+        qbits_key: str = "bits",
+        kv_source: "Attention | None" = None,
+        store_shared_kv: bool = False,
     ):
         super().__init__(config, key, None)
 
@@ -212,6 +214,15 @@ class Attention(Module):
             "Attn: gate_softplus is only implemented for the headwise gate"
         self.key_sinks = key_sinks
         self.sinks = None
+
+        # Cross-layer KV sharing (Gemma4 E4B): a layer with kv_source set has no K/V projections of its
+        # own; it reuses the post-norm, post-RoPE K/V that the source layer stashed in params during the
+        # current forward pass, and (in cached mode) reads/appends via the source layer's cache index. A
+        # layer with store_shared_kv set stashes its K/V for downstream sharing layers.
+        self.kv_source = kv_source
+        self.store_shared_kv = store_shared_kv
+        assert kv_source is None or (key_k is None and key_v is None and k_proj is None and v_proj is None), \
+            "Attention layer with kv_source cannot also have K/V projections"
 
         if post_rope_norm:
             assert q_norm is None and k_norm is None, \
@@ -317,7 +328,7 @@ class Attention(Module):
 
         # Register q/k norms
         if q_norm:
-            assert k_norm, "Must have both Q and K norms, or neither"
+            assert k_norm or self.kv_source is not None, "Must have both Q and K norms, or neither"
             self.q_norm = q_norm
             self.k_norm = k_norm
             self.register_submodule(self.q_norm)
@@ -325,7 +336,7 @@ class Attention(Module):
             if isinstance(q_norm, RMSNorm):
                 self.norm_eps = q_norm.rms_norm_eps
                 self.norm_constant_bias = q_norm.constant_bias
-                assert self.norm_eps == k_norm.rms_norm_eps
+                assert k_norm is None or self.norm_eps == k_norm.rms_norm_eps
             else:
                 self.norm_eps = q_norm.layernorm_eps
                 self.norm_constant_bias = 0.0
@@ -370,9 +381,10 @@ class Attention(Module):
                 self.g_proj = None
                 self.headwise_gate = False
 
-        self.caps.update({
-            "kv_cache": True
-        })
+        if self.kv_source is None:
+            self.caps.update({
+                "kv_cache": True
+            })
 
         self.cache_layers = []
         self.tp_cache_lookup = {}
@@ -401,9 +413,11 @@ class Attention(Module):
     @override
     def optimizer_targets(self):
         q = self.q_proj.optimizer_targets()
-        k = self.k_proj.optimizer_targets()
-        v = self.v_proj.optimizer_targets()
         o = self.o_proj.optimizer_targets()
+        if self.kv_source is not None:
+            return [[q, o]]
+        k = self.k_proj.optimizer_targets()
+        v = self.v_proj.optimizer_targets() if self.v_proj is not None else []
         return [[q, k + v, o]]
 
 
@@ -431,6 +445,7 @@ class Attention(Module):
         if (
             not self.config.infer_params.no_reconstruct and
             not self.use_k_as_v and
+            self.kv_source is None and
             device != torch.device("cpu") and
             self.k_proj.quant_type == "exl3" and
             self.v_proj is not None and
@@ -472,7 +487,7 @@ class Attention(Module):
             self.prealloc_qg_1 = g_tensor_cache.get(device, (2, 1, self.num_q_heads * self.head_dim), torch.half, "qg_1")
 
         # Head norm
-        if self.q_norm and isinstance(self.q_norm, RMSNorm) and not self.q_norm.span_heads:
+        if self.q_norm and self.k_norm and isinstance(self.q_norm, RMSNorm) and not self.q_norm.span_heads:
             self.q_norm_tensor = self.q_norm.weight.data
             self.k_norm_tensor = self.k_norm.weight.data
 
@@ -600,6 +615,10 @@ class Attention(Module):
             )
             q = qg[0].view(bsz, q_len, self.num_q_heads * self.head_dim)
             g = qg[1].view(bsz, q_len, self.num_q_heads * self.head_dim)
+
+        if self.kv_source is not None:
+            q = q.view(bsz, q_len, self.num_q_heads, self.head_dim)
+            return q, None, None, g
 
         if self.multi_kv is None or bsz * q_len > 32:
             k = self.k_proj.forward(x, params)
@@ -743,7 +762,8 @@ class Attention(Module):
                 q, k = self.apply_qk_norms_tp(q, k, params)
             elif not self.rope or self.q_norm_tensor is None:
                 q = self.q_norm.forward(q, params, out_dtype = torch.half)
-                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+                if self.k_norm is not None:
+                    k = self.k_norm.forward(k, params, out_dtype = torch.half)
 
         if self.rope:
             q, k = self.rope.apply(
@@ -760,11 +780,33 @@ class Attention(Module):
                 self.post_rope_norm
             )
 
-        if simulate_kv_quant:
+        if simulate_kv_quant and k is not None:
             # (k_bits, v_bits) or (k_bits, v_bits, compand_a)
             sq_ca = simulate_kv_quant[2] if len(simulate_kv_quant) > 2 else 0.0
             _sim_kvq_inplace(k, simulate_kv_quant[0], sq_ca)
             _sim_kvq_inplace(v, simulate_kv_quant[1], sq_ca)
+
+        if self.store_shared_kv:
+            params[f"g4_shared_kv.{self.layer_idx}"] = (k, v)
+            if "quant_preserve" in params:
+                # Conversion rebuilds params per module; carry the shared K/V forward to the
+                # consumer layers' capture/forward passes. Kept on device: ~16 MB per calibration
+                # row for Gemma4 E4B
+                params["quant_preserve"][f"g4_shared_kv.{self.layer_idx}"] = (k, v)
+        if self.kv_source is not None:
+            # Without a cache there is no history, so moving the source K/V is sufficient for
+            # correctness when a layer split puts the source on another device
+            shared = params.get(f"g4_shared_kv.{self.kv_source.layer_idx}")
+            if shared is None:
+                raise RuntimeError(
+                    f"Layer {self.layer_idx} expects shared K/V from layer {self.kv_source.layer_idx}, "
+                    f"but none was stashed in this forward pass. The source layer must run before "
+                    f"this layer within the same forward pass (or its state must be carried over "
+                    f"via quant_preserve during conversion)."
+                )
+            k, v = shared
+            k = k.to(q.device)
+            v = v.to(q.device)
 
         o = attn_dispatch(
             q = q,
@@ -842,8 +884,11 @@ class Attention(Module):
 
         # Graph-captured C++ path for the whole decode attention block (causality is baked
         # into the slot kernels, so non-causal callers like the DFlash draft graph too)
+        # Layers that produce or consume shared KV take the regular python path: the consumer
+        # needs the producer's K/V stashed in params, which the graph-captured path bypasses
         if (
             _bc_attn_enable and non_causal_spans is None and
+            self.kv_source is None and not self.store_shared_kv and
             bsz <= _bc_max_bsz and seqlen <= _bc_max_qlen
         ):
             o = self.bc_attn_step(x, cache, params, block_table, cache_seqlens)
@@ -863,7 +908,8 @@ class Attention(Module):
                 q, k = self.apply_qk_norms_tp(q, k, params)
             elif not self.rope or self.q_norm_tensor is None:
                 q = self.q_norm.forward(q, params, out_dtype = torch.half)
-                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+                if self.k_norm is not None:
+                    k = self.k_norm.forward(k, params, out_dtype = torch.half)
 
         if self.rope:
             q, k = self.rope.apply(
@@ -880,18 +926,43 @@ class Attention(Module):
                 self.post_rope_norm
             )
 
-        if simulate_kv_quant:
+        if simulate_kv_quant and k is not None:
             # (k_bits, v_bits) or (k_bits, v_bits, compand_a)
             sq_ca = simulate_kv_quant[2] if len(simulate_kv_quant) > 2 else 0.0
             _sim_kvq_inplace(k, simulate_kv_quant[0], sq_ca)
             _sim_kvq_inplace(v, simulate_kv_quant[1], sq_ca)
+
+        if self.store_shared_kv:
+            params[f"g4_shared_kv.{self.layer_idx}"] = (k, v)
+            if "quant_preserve" in params:
+                params["quant_preserve"][f"g4_shared_kv.{self.layer_idx}"] = (k, v)
+        if self.kv_source is not None:
+            # Reuse the source layer's K/V for the current tokens and attend through the source
+            # layer's cache. The dispatch re-appends the same rows the source layer already wrote,
+            # which is idempotent, so no special-casing of the cache update is needed
+            shared = params.get(f"g4_shared_kv.{self.kv_source.layer_idx}")
+            if shared is None:
+                raise RuntimeError(
+                    f"Layer {self.layer_idx} expects shared K/V from layer {self.kv_source.layer_idx}, "
+                    f"but none was stashed in this forward pass."
+                )
+            k, v = shared
+            if k.device != q.device:
+                # The source layer's paged cache history lives on the source device and cannot be
+                # migrated per token, so cached attention requires co-location
+                raise RuntimeError(
+                    f"KV-sharing layer {self.layer_idx} (device {q.device}) is on a different device "
+                    f"than its source layer {self.kv_source.layer_idx} (device {k.device}). Cached "
+                    f"inference requires KV-sharing layers to be on the same device as their source "
+                    f"layer; adjust the model split accordingly."
+                )
 
         o = attn_dispatch(
             q = q,
             k = k,
             v = v,
             cache = cache,
-            cache_idx = self.layer_idx,
+            cache_idx = self.layer_idx if self.kv_source is None else self.kv_source.layer_idx,
             cache_instance = params.get("layer_instance"),
             block_table = block_table,
             cache_seqlens = cache_seqlens,
@@ -915,6 +986,8 @@ class Attention(Module):
 
 
     def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        assert self.kv_source is None and not self.store_shared_kv, \
+            "TP is not implemented for models with cross-layer KV sharing"
         storage = 0
         storage += self.q_proj.storage_size()
         storage += self.k_proj.storage_size()

--- a/exllamav3/modules/sliding_attn.py
+++ b/exllamav3/modules/sliding_attn.py
@@ -272,6 +272,8 @@ class SlidingAttention(Module):
         full_gate: bool = False,
         gate_softplus: bool = False,
         select_hq_bits: int = 0,
+        kv_source: "SlidingAttention | None" = None,
+        store_shared_kv: bool = False,
     ):
         super().__init__(config, key, None)
         assert sliding_window > 0
@@ -320,6 +322,16 @@ class SlidingAttention(Module):
         self.g_proj = None
         self.key_sinks = key_sinks
         self.sinks = None
+
+        # Cross-layer KV sharing (Gemma4 E4B/E2B): a layer with kv_source set has no K/V projections
+        # or recurrent state of its own; it attends read-only over the source layer's ring-buffer
+        # state and the K/V the source stashed in params during the current forward pass. A layer
+        # with store_shared_kv set stashes its K/V and attention view, and defers its destructive
+        # state update until after the sharing layers have attended (see advance_recurrent_states)
+        self.kv_source = kv_source
+        self.store_shared_kv = store_shared_kv
+        assert kv_source is None or (key_k is None and key_v is None and k_proj is None and v_proj is None), \
+            "SlidingAttention layer with kv_source cannot also have K/V projections"
 
         if post_rope_norm:
             assert q_norm is None and k_norm is None, \
@@ -376,7 +388,7 @@ class SlidingAttention(Module):
             self.register_submodule(self.k_proj)
             self.register_submodule(self.v_proj)
         else:
-            assert k_proj and v_proj
+            assert (k_proj and v_proj) or self.kv_source is not None
             self.k_proj = k_proj
             self.v_proj = v_proj
             self.register_submodule(self.k_proj)
@@ -403,7 +415,7 @@ class SlidingAttention(Module):
 
         # Register q/k norms
         if q_norm:
-            assert k_norm, "Must have both Q and K norms, or neither"
+            assert k_norm or self.kv_source is not None, "Must have both Q and K norms, or neither"
             self.q_norm = q_norm
             self.k_norm = k_norm
             self.register_submodule(self.q_norm)
@@ -411,7 +423,7 @@ class SlidingAttention(Module):
             if isinstance(q_norm, RMSNorm):
                 self.norm_eps = q_norm.rms_norm_eps
                 self.norm_constant_bias = q_norm.constant_bias
-                assert self.norm_eps == k_norm.rms_norm_eps
+                assert k_norm is None or self.norm_eps == k_norm.rms_norm_eps
             else:
                 self.norm_eps = q_norm.layernorm_eps
                 self.norm_constant_bias = 0.0
@@ -453,19 +465,22 @@ class SlidingAttention(Module):
                 self.g_proj = None
                 self.headwise_gate = False
 
-        self.caps.update({
-            "recurrent_cache": True,
-            "sliding_window_overp": sliding_window_overp
-        })
+        if self.kv_source is None:
+            self.caps.update({
+                "recurrent_cache": True,
+                "sliding_window_overp": sliding_window_overp
+            })
         self.layer_state_cls = SWALayerState
 
 
     @override
     def optimizer_targets(self):
         q = self.q_proj.optimizer_targets()
+        o = self.o_proj.optimizer_targets()
+        if self.kv_source is not None:
+            return [[q, o]]
         k = self.k_proj.optimizer_targets()
         v = self.v_proj.optimizer_targets()
-        o = self.o_proj.optimizer_targets()
         return [[q, k + v, o]]
 
 
@@ -492,6 +507,7 @@ class SlidingAttention(Module):
         # Test if K and V proj can be fused
         if (
             not self.config.infer_params.no_reconstruct and
+            self.kv_source is None and
             device != torch.device("cpu") and
             self.k_proj.quant_type == "exl3" and
             self.v_proj.quant_type == "exl3" and
@@ -531,7 +547,7 @@ class SlidingAttention(Module):
             self.prealloc_qg_1 = g_tensor_cache.get(device, (2, 1, self.num_q_heads * self.head_dim), torch.half, "qg_1")
 
         # Head norm
-        if self.q_norm and isinstance(self.q_norm, RMSNorm) and not self.q_norm.span_heads:
+        if self.q_norm and self.k_norm and isinstance(self.q_norm, RMSNorm) and not self.q_norm.span_heads:
             self.q_norm_tensor = self.q_norm.weight.data
             self.k_norm_tensor = self.k_norm.weight.data
 
@@ -643,6 +659,10 @@ class SlidingAttention(Module):
             )
             q = qg[0].view(bsz, q_len, self.num_q_heads * self.head_dim)
             g = qg[1].view(bsz, q_len, self.num_q_heads * self.head_dim)
+
+        if self.kv_source is not None:
+            q = q.view(bsz, q_len, self.num_q_heads, self.head_dim)
+            return q, None, None, g
 
         if self.multi_kv is None or bsz * q_len > 32:
             k = self.k_proj.forward(x, params)
@@ -769,7 +789,8 @@ class SlidingAttention(Module):
         if self.q_norm:
             if not self.rope or self.q_norm_tensor is None:
                 q = self.q_norm.forward(q, params, out_dtype = torch.half)
-                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+                if self.k_norm is not None:
+                    k = self.k_norm.forward(k, params, out_dtype = torch.half)
 
         if self.rope:
             q, k = self.rope.apply(
@@ -785,6 +806,25 @@ class SlidingAttention(Module):
                 inv_freq,
                 self.post_rope_norm
             )
+
+        if self.store_shared_kv:
+            params[f"g4_shared_kv.{self.layer_idx}"] = (k, v)
+            if "quant_preserve" in params:
+                params["quant_preserve"][f"g4_shared_kv.{self.layer_idx}"] = (k, v)
+        if self.kv_source is not None:
+            # Without a cache there is no history, so the source layer's K/V for the current
+            # tokens is the complete context
+            shared = params.get(f"g4_shared_kv.{self.kv_source.layer_idx}")
+            if shared is None:
+                raise RuntimeError(
+                    f"Layer {self.layer_idx} expects shared K/V from layer {self.kv_source.layer_idx}, "
+                    f"but none was stashed in this forward pass. The source layer must run before "
+                    f"this layer within the same forward pass (or its state must be carried over "
+                    f"via quant_preserve during conversion)."
+                )
+            k, v = shared
+            k = k.to(q.device)
+            v = v.to(q.device)
 
         o = paged_attn_triton_prefill(
             q, None, None, None, None, None, None,
@@ -821,8 +861,11 @@ class SlidingAttention(Module):
         non_causal_spans = params.get("non_causal_spans")
 
         # Graph-captured C++ path for the whole decode step
+        # Layers that produce or consume shared KV take the regular python path: the consumer
+        # needs the source layer's stashed K/V and attention view, which the graph bypasses
         if (
             _bc_attn_enable and causal and non_causal_spans is None and
+            self.kv_source is None and not self.store_shared_kv and
             bsz <= _bc_max_bsz and seqlen <= _bc_max_qlen
         ):
             rsg = params.get("recurrent_states")
@@ -836,7 +879,8 @@ class SlidingAttention(Module):
         if self.q_norm:
             if not self.rope or self.q_norm_tensor is None:
                 q = self.q_norm.forward(q, params, out_dtype = torch.half)
-                k = self.k_norm.forward(k, params, out_dtype = torch.half)
+                if self.k_norm is not None:
+                    k = self.k_norm.forward(k, params, out_dtype = torch.half)
 
         if self.rope:
             q, k = self.rope.apply(
@@ -853,114 +897,92 @@ class SlidingAttention(Module):
                 self.post_rope_norm
             )
 
-        # Recurrent state: a short contiguous fp16 K/V span per sequence, viewed as a paged
-        # cache (kv_state_size is a multiple of the page size) so the batch runs as one kernel
-        # call with per-row block tables and sequence lengths
-        rsg = params.get("recurrent_states")
-        assert rsg is not None, "SlidingAttention.forward() called in flash_attn mode with no recurrent states"
-        layer_instance = (self.layer_idx, params.get("layer_instance", 0))
-        if rsg[0].exported:
-            rsl = self.tp_recurrent_lookup[rsg[0].cache]
-        else:
-            rsl = rsg[0].cache.get_recurrent_layer(layer_instance)
-        k_states, v_states = rsl.get_state_tensors()
-
-        S = self.kv_state_size
-        pps = S // PAGE_SIZE
-        k_pages = k_states.view(-1, PAGE_SIZE, self.num_kv_heads, self.head_dim)
-        v_pages = v_states.view(-1, PAGE_SIZE, self.num_kv_heads, self.head_dim)
-        sw = self.sliding_window
-
-        def pad(z):
-            return (z + PAGE_SIZE - 1) // PAGE_SIZE * PAGE_SIZE
-
-        if seqlen <= 16 and not non_causal_spans:
-            # Decode: append into the state (shifting it left first on the rare step where the
-            # window run reaches the end of the buffer) and attend over the pages
-            bt, cache_seqlens = self._decode_state_prep(rsg, k_states, v_states, seqlen)
-
-            o = paged_attn_triton_decode(
-                q, k, v, k_pages, v_pages, bt, cache_seqlens,
-                causal = causal,
-                softmax_scale = self.sm_scale,
-                window_size = (sw, 0),
-                softcap = self.logit_softcapping,
-                sinks = self.sinks,
-                max_kv_len = S,
-            )
+        if self.kv_source is not None:
+            # Attend read-only over the source layer's state and stashed K/V; this layer has no
+            # ring buffer of its own and never writes or shifts the source's
+            o = self._shared_swa_attend(q, params, causal, non_causal_spans)
 
         else:
-            # Prefill: attend over [hot window of the state || new K/V], reading the new tokens
-            # straight from the projection output (nothing staged, the state is untouched until
-            # after), then rebase the state onto the tail
-            hots, wposs = [], []
-            for rs in rsg:
-                cache_pos = rs.position - rs.window_beg
-                cache_wpos = max(cache_pos - sw, 0) // PAGE_SIZE * PAGE_SIZE
-                wposs.append(cache_wpos)
-                hots.append(cache_pos - cache_wpos)
+            # Recurrent state: a short contiguous fp16 K/V span per sequence, viewed as a paged
+            # cache (kv_state_size is a multiple of the page size) so the batch runs as one kernel
+            # call with per-row block tables and sequence lengths
+            rsg = params.get("recurrent_states")
+            assert rsg is not None, "SlidingAttention.forward() called in flash_attn mode with no recurrent states"
+            layer_instance = (self.layer_idx, params.get("layer_instance", 0))
+            if rsg[0].exported:
+                rsl = self.tp_recurrent_lookup[rsg[0].cache]
+            else:
+                rsl = rsg[0].cache.get_recurrent_layer(layer_instance)
+            k_states, v_states = rsl.get_state_tensors()
 
-            bt = torch.tensor(
-                [[rs.slot * pps + wposs[i] // PAGE_SIZE + j for j in range(pps)] for i, rs in enumerate(rsg)],
-                dtype = torch.int32, device = self.device
-            )
-            cache_seqlens = torch.tensor(hots, dtype = torch.int32).to(self.device, non_blocking = True)
+            S = self.kv_state_size
+            pps = S // PAGE_SIZE
+            k_pages = k_states.view(-1, PAGE_SIZE, self.num_kv_heads, self.head_dim)
+            v_pages = v_states.view(-1, PAGE_SIZE, self.num_kv_heads, self.head_dim)
+            sw = self.sliding_window
 
-            if not non_causal_spans:
-                o = paged_attn_triton_prefill(
-                    q, None, None, k_pages, v_pages, bt, cache_seqlens,
+            if seqlen <= 16 and not non_causal_spans:
+                # Decode: append into the state (shifting it left first on the rare step where the
+                # window run reaches the end of the buffer) and attend over the pages
+                bt, cache_seqlens = self._decode_state_prep(rsg, k_states, v_states, seqlen)
+
+                if self.store_shared_kv:
+                    # Sharing layers replay this call with their own Q; the kernel re-appending
+                    # the same K/V rows at the same positions is idempotent, and the state prep
+                    # (with its destructive shift) already ran exactly once, above
+                    params[f"g4_shared_swa.{self.layer_idx}"] = {
+                        "mode": "decode", "k": k, "v": v, "k_pages": k_pages, "v_pages": v_pages,
+                        "bt": bt, "cache_seqlens": cache_seqlens,
+                    }
+
+                o = paged_attn_triton_decode(
+                    q, k, v, k_pages, v_pages, bt, cache_seqlens,
                     causal = causal,
                     softmax_scale = self.sm_scale,
                     window_size = (sw, 0),
                     softcap = self.logit_softcapping,
                     sinks = self.sinks,
-                    k_new = k,
-                    v_new = v,
+                    max_kv_len = S,
                 )
-            else:
-                # Spans tile the chunk; each attends over the state plus the new tokens up to its
-                # own end, bidirectionally within itself when flagged non-causal
-                o = []
-                for span in non_causal_spans:
-                    a, b, c = span[:3]
-                    # pre-chunk extent of a re-fed span suffix: widen the left window as if the
-                    # whole span were in the chunk
-                    pre = span[3] if len(span) > 3 else 0
-                    l = b - a
-                    o_ = paged_attn_triton_prefill(
-                        q[:, a : b].contiguous(), None, None, k_pages, v_pages, bt, cache_seqlens,
-                        causal = not c,
-                        softmax_scale = self.sm_scale,
-                        window_size = (max(sw, l + pre), l - 1) if c else (sw, 0),
-                        softcap = self.logit_softcapping,
-                        sinks = self.sinks,
-                        k_new = k[:, : b].contiguous(),
-                        v_new = v[:, : b].contiguous(),
-                    )
-                    o.append(o_)
-                o = torch.cat(o, dim = 1)
 
-            # State update: keep the last window (page-aligned base) of [old || new] per row
-            for i, rs in enumerate(rsg):
-                cache_pos = rs.position - rs.window_beg
-                if cache_pos + seqlen <= S:
-                    k_states[rs.slot, cache_pos : cache_pos + seqlen].copy_(k[i])
-                    v_states[rs.slot, cache_pos : cache_pos + seqlen].copy_(v[i])
-                    rs.wshift = 0
+            else:
+                # Prefill: attend over [hot window of the state || new K/V], reading the new tokens
+                # straight from the projection output (nothing staged, the state is untouched until
+                # after), then rebase the state onto the tail
+                hots, wposs = [], []
+                for rs in rsg:
+                    cache_pos = rs.position - rs.window_beg
+                    cache_wpos = max(cache_pos - sw, 0) // PAGE_SIZE * PAGE_SIZE
+                    wposs.append(cache_wpos)
+                    hots.append(cache_pos - cache_wpos)
+
+                bt = torch.tensor(
+                    [[rs.slot * pps + wposs[i] // PAGE_SIZE + j for j in range(pps)] for i, rs in enumerate(rsg)],
+                    dtype = torch.int32, device = self.device
+                )
+                cache_seqlens = torch.tensor(hots, dtype = torch.int32).to(self.device, non_blocking = True)
+
+                if self.store_shared_kv:
+                    params[f"g4_shared_swa.{self.layer_idx}"] = {
+                        "mode": "prefill", "k": k, "v": v, "k_pages": k_pages, "v_pages": v_pages,
+                        "bt": bt, "cache_seqlens": cache_seqlens,
+                    }
+
+                o = self._swa_prefill_attend(
+                    q, k, v, k_pages, v_pages, bt, cache_seqlens, causal, non_causal_spans
+                )
+
+                if self.store_shared_kv:
+                    # The state update rebases the ring buffer in place, which would corrupt the
+                    # view the sharing layers attend over; defer it until the forward pass ends
+                    # (advance_recurrent_states applies it before positions advance)
+                    params.setdefault("deferred_state_updates", []).append(
+                        lambda: self._apply_prefill_state_update(
+                            rsg, k_states, v_states, k, v, wposs, hots, seqlen
+                        )
+                    )
                 else:
-                    cache_wpos, cache_hot = wposs[i], hots[i]
-                    shift = pad(cache_hot + seqlen) - S
-                    rs.wshift = shift + cache_wpos
-                    n_keep = cache_hot - shift
-                    if n_keep > 0:
-                        k_states[rs.slot, :n_keep].copy_(k_states[rs.slot, cache_wpos + shift : cache_wpos + cache_hot].clone())
-                        v_states[rs.slot, :n_keep].copy_(v_states[rs.slot, cache_wpos + shift : cache_wpos + cache_hot].clone())
-                        k_states[rs.slot, n_keep : n_keep + seqlen].copy_(k[i])
-                        v_states[rs.slot, n_keep : n_keep + seqlen].copy_(v[i])
-                    else:
-                        skip = shift - cache_hot
-                        k_states[rs.slot, : seqlen - skip].copy_(k[i, skip:])
-                        v_states[rs.slot, : seqlen - skip].copy_(v[i, skip:])
+                    self._apply_prefill_state_update(rsg, k_states, v_states, k, v, wposs, hots, seqlen)
 
         if self.headwise_gate:
             if self.gate_softplus: ext.mul_softplus_broadcast_(o, g)
@@ -972,7 +994,132 @@ class SlidingAttention(Module):
         return o
 
 
+    def _swa_prefill_attend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        k_pages: torch.Tensor,
+        v_pages: torch.Tensor,
+        bt: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        causal: bool,
+        non_causal_spans: list | None,
+    ):
+        """Prefill attention over [hot window of the state || new K/V], without touching the state."""
+        sw = self.sliding_window
+
+        if not non_causal_spans:
+            return paged_attn_triton_prefill(
+                q, None, None, k_pages, v_pages, bt, cache_seqlens,
+                causal = causal,
+                softmax_scale = self.sm_scale,
+                window_size = (sw, 0),
+                softcap = self.logit_softcapping,
+                sinks = self.sinks,
+                k_new = k,
+                v_new = v,
+            )
+
+        # Spans tile the chunk; each attends over the state plus the new tokens up to its
+        # own end, bidirectionally within itself when flagged non-causal
+        o = []
+        for span in non_causal_spans:
+            a, b, c = span[:3]
+            # pre-chunk extent of a re-fed span suffix: widen the left window as if the
+            # whole span were in the chunk
+            pre = span[3] if len(span) > 3 else 0
+            l = b - a
+            o_ = paged_attn_triton_prefill(
+                q[:, a : b].contiguous(), None, None, k_pages, v_pages, bt, cache_seqlens,
+                causal = not c,
+                softmax_scale = self.sm_scale,
+                window_size = (max(sw, l + pre), l - 1) if c else (sw, 0),
+                softcap = self.logit_softcapping,
+                sinks = self.sinks,
+                k_new = k[:, : b].contiguous(),
+                v_new = v[:, : b].contiguous(),
+            )
+            o.append(o_)
+        return torch.cat(o, dim = 1)
+
+
+    def _apply_prefill_state_update(self, rsg, k_states, v_states, k, v, wposs, hots, seqlen):
+        """State update: keep the last window (page-aligned base) of [old || new] per row."""
+        S = self.kv_state_size
+
+        def pad(z):
+            return (z + PAGE_SIZE - 1) // PAGE_SIZE * PAGE_SIZE
+
+        for i, rs in enumerate(rsg):
+            cache_pos = rs.position - rs.window_beg
+            if cache_pos + seqlen <= S:
+                k_states[rs.slot, cache_pos : cache_pos + seqlen].copy_(k[i])
+                v_states[rs.slot, cache_pos : cache_pos + seqlen].copy_(v[i])
+                rs.wshift = 0
+            else:
+                cache_wpos, cache_hot = wposs[i], hots[i]
+                shift = pad(cache_hot + seqlen) - S
+                rs.wshift = shift + cache_wpos
+                n_keep = cache_hot - shift
+                if n_keep > 0:
+                    k_states[rs.slot, :n_keep].copy_(k_states[rs.slot, cache_wpos + shift : cache_wpos + cache_hot].clone())
+                    v_states[rs.slot, :n_keep].copy_(v_states[rs.slot, cache_wpos + shift : cache_wpos + cache_hot].clone())
+                    k_states[rs.slot, n_keep : n_keep + seqlen].copy_(k[i])
+                    v_states[rs.slot, n_keep : n_keep + seqlen].copy_(v[i])
+                else:
+                    skip = shift - cache_hot
+                    k_states[rs.slot, : seqlen - skip].copy_(k[i, skip:])
+                    v_states[rs.slot, : seqlen - skip].copy_(v[i, skip:])
+
+
+    def _shared_swa_attend(
+        self,
+        q: torch.Tensor,
+        params: dict,
+        causal: bool,
+        non_causal_spans: list | None,
+    ):
+        """Read-only attention for a KV-sharing layer over the source layer's state and stashed K/V."""
+        stash = params.get(f"g4_shared_swa.{self.kv_source.layer_idx}")
+        if stash is None:
+            raise RuntimeError(
+                f"Layer {self.layer_idx} expects shared K/V from layer {self.kv_source.layer_idx}, "
+                f"but none was stashed in this forward pass. The source layer must run before "
+                f"this layer within the same forward pass."
+            )
+        k, v = stash["k"], stash["v"]
+        if k.device != q.device:
+            # The source layer's ring-buffer state lives on the source device and cannot be
+            # migrated per step, so recurrent attention requires co-location
+            raise RuntimeError(
+                f"KV-sharing layer {self.layer_idx} (device {q.device}) is on a different device "
+                f"than its source layer {self.kv_source.layer_idx} (device {k.device}). Recurrent "
+                f"inference requires KV-sharing layers to be on the same device as their source "
+                f"layer; adjust the model split accordingly."
+            )
+
+        if stash["mode"] == "decode":
+            # Re-appending the source layer's rows at the same positions is idempotent
+            return paged_attn_triton_decode(
+                q, k, v, stash["k_pages"], stash["v_pages"], stash["bt"], stash["cache_seqlens"],
+                causal = causal,
+                softmax_scale = self.sm_scale,
+                window_size = (self.sliding_window, 0),
+                softcap = self.logit_softcapping,
+                sinks = self.sinks,
+                max_kv_len = self.kv_state_size,
+            )
+        else:
+            return self._swa_prefill_attend(
+                q, k, v, stash["k_pages"], stash["v_pages"], stash["bt"], stash["cache_seqlens"],
+                causal, non_causal_spans
+            )
+
+
     def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        assert self.kv_source is None and not self.store_shared_kv, \
+            "TP is not implemented for models with cross-layer KV sharing"
         storage = 0
         storage += self.q_proj.storage_size()
         storage += self.k_proj.storage_size()
@@ -1019,6 +1166,8 @@ class SlidingAttention(Module):
 
     def tp_export(self, plan, producer):
         assert self.device is not None, "Cannot export module for TP before loading."
+        assert self.kv_source is None and not self.store_shared_kv, \
+            "TP is not implemented for models with cross-layer KV sharing"
         assert not (self.q_norm is not None and isinstance(self.q_norm, RMSNorm) and self.q_norm.span_heads), \
             "TP export of SlidingAttention with span_heads norms is not implemented"
 

--- a/exllamav3/modules/transformer.py
+++ b/exllamav3/modules/transformer.py
@@ -22,6 +22,7 @@ class TransformerBlock(Module):
         mlp_norm: RMSNorm | LayerNorm | None = None,
         mlp: MLP | GatedMLP | BlockSparseMLP | None = None,
         mlp_post_norm: RMSNorm | LayerNorm | None = None,
+        ple: Module | None = None,
         backout_extract: bool = False,
         backout_lambda: float | None = None,
         key_layer_scalar: str | None = None,
@@ -43,6 +44,7 @@ class TransformerBlock(Module):
         self.mlp_norm = mlp_norm
         self.mlp = mlp
         self.mlp_post_norm = mlp_post_norm
+        self.ple = ple
         self.backout_extract = backout_extract
         self.backout_lambda = backout_lambda
         self.qbits_key = qbits_key
@@ -63,6 +65,7 @@ class TransformerBlock(Module):
         self.register_submodule(self.mlp_norm)
         self.register_submodule(self.mlp)
         self.register_submodule(self.mlp_post_norm)
+        self.register_submodule(self.ple)
 
         self.num_slices = mlp.num_slices if mlp else 1
 
@@ -216,6 +219,11 @@ class TransformerBlock(Module):
             else:
                 x += y
 
+        # Per-layer embedding injection (Gemma4 E4B): applied to the residual stream after the MLP,
+        # before the layer scalar
+        if self.ple is not None:
+            x = self.ple.forward(x, params)
+
         if export_state:
             s = params.get("export_states")
             if not s:
@@ -245,6 +253,7 @@ class TransformerBlock(Module):
 
     def tp_export(self, plan, producer):
         assert self.device is not None, "Cannot export module for TP before loading."
+        assert self.ple is None, "TP export of TransformerBlock with per-layer embeddings is not implemented"
 
         def _export(child):
             nonlocal producer


### PR DESCRIPTION
Adds text-mode support for Gemma4 E4B and E2B, which previously raised
NotImplementedError. These models share the Gemma4 config format but add two
architectural features:

**Per-layer embeddings (PLE)**
- `embed_tokens_per_layer` lookup (prefer_cpu, like the main embedding) plus a
  projection of the input embeddings, combined as `(ctx + tok)/sqrt(2)` per the
  reference implementation, carried through the forward pass in `params`.
- Each block applies a gated injection into the residual stream via a new
  optional `ple` submodule on `TransformerBlock` (applied after the MLP
  residual, before the layer scalar).
- The PLE projections stay unquantized (~165 MB at fp16 for E4B): measured at
  4.0 bpw, quantizing them roughly doubles KLD for ~1% file-size saving — the
  per-layer gates feed the residual stream at every layer, so their error
  compounds. Rationale documented in a code comment.

**Cross-layer KV sharing**
- The last `num_kv_shared_layers` layers have no K/V projections; each reuses
  the post-norm, post-RoPE K/V of the last preceding non-shared layer of the
  same attention type (E4B: sliding layers share layer 22, full layers 23).
- `Attention` and `SlidingAttention` gain `kv_source` / `store_shared_kv`.
  Producers stash their K/V (and, for the recurrent SWA path, their attention
  view) in `params`; consumers attend read-only. Re-appending identical rows
  to a paged cache is idempotent, so all existing cache/kernel paths work
  unchanged.
- For the SWA ring-buffer path, the producer's destructive state update is
  deferred via `params["deferred_state_updates"]` and applied in
  `advance_recurrent_states` before positions advance, so sharing layers see
  the pre-update window. `swa_full` remains available as an option.
- Prefill stops at the last KV-producing block (18 of 42 layers skipped for
  E4B), and no cache/state is allocated for sharing layers. Measured on a
  4.0 bpw E4B quant: a 128k-token cache is 4.97 GB vs 10.16 GB with swa_full.

**E2B** additionally sets `use_double_wide_mlp`: KV-shared layers use MLPs at
2x intermediate_size (verified against checkpoint shapes and the reference).

**Conversion**
- The embedding/PLE modules set `retain_during_quant` and a
  `per_layer_quant_preamble` override recomputes per-layer inputs per module
  pass (same pattern as NanoChat's value embeddings); shared K/V rides
  `quant_preserve`.
- Since neither the side-channel state nor calibration input IDs survive
  checkpoints, these models set `can_resume_quant = False` (NanoChat
  precedent). A new generic `forward_side_channel` cap lets measure_model.py
  fail fast with a clear error instead of a KeyError mid-stream.
- `Gemma4PerLayerProjection` overrides `get_compile_sizes/tensors` because its
  norm tensor lives under a sibling key prefix the per-module scan would miss.

**Limitations (guarded, not silent)**
- Text only; the E4B/E2B vision and audio towers are not implemented.
- TP: `supports_tp` is False for these models; export paths assert.
- Layer split: cache-less attention moves shared K/V across devices; cached
  attention raises a descriptive error if a sharing layer is placed on a
  different device than its source (the source's cache history cannot
  migrate).

**Validation**
- bf16 vs transformers 5.14: 100% top-1 agreement at every position on test
  prompts (mean KL ~1e-3, fp16-vs-bf16 noise); greedy-identical cached
  generation for both models.
- Recurrent SWA sharing vs swa_full: token-identical greedy output on a
  3019-token prompt + 64 decode steps (covers chunked prefill, ring-buffer
  rebase, decode-time shifts).
- E4B converted at 4.0 bpw (head 6): wikitext-2 KLD 0.024 mean / top-1 92.6%
  vs bf16, perplexity +1.4% (wikitext, 512-token windows) and +0.07% on
  contiguous clean prose. ~2.9 GB VRAM at load.
