### PR TITLE
Allow using multiple draft models at once

### DIFF
--- a/exllamav3/architecture/draft.py
+++ b/exllamav3/architecture/draft.py
@@ -1,0 +1,11 @@
+from ..model.model import Model
+
+class DraftStackModel(Model):
+    def __init__(self, *draft_models: Model):
+        super().__init__(None)
+        self.draft_models = draft_models
+        assert not any(m.caps.get("recurrent_states") for m in self.draft_models), \
+            "Speculative decoding with recurrent draft model not supported."
+        assert not any(isinstance(m, DraftStackModel) for m in self.draft_models), \
+            "Cannot nest draft model stacks."
+        self.caps["stack_draft"] = True

--- a/exllamav3/architecture/draft.py
+++ b/exllamav3/architecture/draft.py
@@ -9,3 +9,4 @@ class DraftStackModel(Model):
         assert not any(isinstance(m, DraftStackModel) for m in self.draft_models), \
             "Cannot nest draft model stacks."
         self.caps["stack_draft"] = True
+        self.draft_verifier_params = {k: v for m in self.draft_models for k, v in m.draft_verifier_params.items()}

--- a/exllamav3/architecture/qwen3_5_mtp.py
+++ b/exllamav3/architecture/qwen3_5_mtp.py
@@ -3,16 +3,10 @@ from typing_extensions import override
 import torch
 import weakref
 
-from ..cache import Cache
-from ..ext import exllamav3_ext as ext
-from ..model.config import Config, no_default
 from ..model.model import Model
-from ..util.rope import RopeStyle
 from ..modules import RMSNorm, Embedding, TransformerBlock, Attention, GatedMLP, Linear, BlockSparseMLP
 from ..modules.arch_specific.qwen3_5_mtp import Qwen3_5MTPInputLayer
 from ..modules.attn import prepare_for_attn
-from ..modules.module import no_p2p_copy
-from ..util.tensor import get_for_device
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/exllamav3/cache/cache.py
+++ b/exllamav3/cache/cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import deque
-from typing import Type
+from typing import Type, List
 import torch
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -372,3 +372,15 @@ class Cache:
 
     def get_all_recurrent_layers(self):
         return self.recurrent_layers
+
+class CacheStack:
+    def __init__(self, *caches: Cache):
+        """
+            Creates a stack of caches, primarily used for draft models.
+        """
+        self.caches = caches
+        assert len(self.caches) > 0, \
+            "Must have at least one cache in the cache stack."
+        assert len({c.max_num_tokens for c in self.caches if c is not None}) <= 1, \
+            "All draft caches must have the same size."
+        self.max_num_tokens = self.caches[0].max_num_tokens

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -241,17 +241,17 @@ class Generator:
 
         # Drafting mode
         self.dflash_draft, self.mtp_draft, self.reg_draft = False, False, False
-        if draft_model is not None:
-            assert isinstance(draft_cache, CacheStack), \
+        if self.draft_model is not None:
+            assert isinstance(self.draft_cache, CacheStack), \
                 "A draft stack must have a cache stack of equal length."
-            assert len(draft_model.draft_models) == len(draft_cache.caches), \
+            assert len(self.draft_model.draft_models) == len(self.draft_cache.caches), \
                 "The draft stack is not the same length as the cache stack."
-            for m in draft_model.draft_models:
+            for m in self.draft_model.draft_models:
                 if m.caps.get("attach_target"):
-                    m.attach_to("model")
-            self.dflash_draft = [m.caps.get("dflash_draft", False) for m in draft_model.draft_models]
-            self.mtp_draft = [m.caps.get("mtp_draft", False) for m in draft_model.draft_models]
-            self.reg_draft = [not self.dflash_draft[i] and not self.mtp_draft[i] for (i, m) in enumerate(draft_model.draft_models)]
+                    m.attach_to(model)
+            self.dflash_draft = [i for i, m in enumerate(self.draft_model.draft_models) if m.caps.get("dflash_draft", False)]
+            self.mtp_draft = [i for i, m in enumerate(self.draft_model.draft_models) if m.caps.get("mtp_draft", False)]
+            self.reg_draft = [i for (i, m) in enumerate(self.draft_model.draft_models) if i not in self.dflash_draft and i not in self.mtp_draft]
 
 
     def num_remaining_jobs(self):
@@ -412,13 +412,13 @@ class Generator:
         # Generation with draft model / ngram
         if self.draft_model or self.ngram_match_min:
             ngram_idx = 1
-            for idx, model in enumerate(self.draft_model.draft_models):
-                if self.dflash_draft[idx]:
-                    self.iterate_draftmodel_dflash_gen(results, idx)
-                elif self.mtp_draft[idx]:
-                    self.iterate_draftmodel_mtp_gen(results, idx)
-                elif self.reg_draft[idx]:
-                    self.iterate_draftmodel_gen(results, idx)
+            for idx, dm in enumerate(self.draft_model.draft_models):
+                if idx in self.dflash_draft:
+                    self.iterate_draftmodel_dflash_gen(results, dm, idx)
+                elif idx in self.mtp_draft:
+                    self.iterate_draftmodel_mtp_gen(results, dm, idx)
+                elif idx in self.reg_draft:
+                    self.iterate_draftmodel_gen(results, dm, idx)
                 ngram_idx += 1
             if self.ngram_match_min:
                 draft_tokens = self.iterate_ngram_gen(results, ngram_idx)
@@ -612,7 +612,7 @@ class Generator:
             temp_hidden = batch_state
 
     # TODO: Refactor, share code with other draft fns
-    def iterate_draftmodel_dflash_gen(self, results: list, drafter: int = 0):
+    def iterate_draftmodel_dflash_gen(self, results: list, model: Model, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -149,8 +149,6 @@ class Generator:
         self.num_drafters = 0
         self.num_draft_tokens = 0
         if draft_model is not None:
-            assert not ngram_match_min, \
-                "Cannot use both draft model and n-gram draft."
             assert draft_cache is not None, \
                 "Must supply cache for draft model"
             assert draft_cache.max_num_tokens == cache.max_num_tokens, \
@@ -412,15 +410,16 @@ class Generator:
         # Generation with draft model / ngram
         if self.draft_model or self.ngram_match_min:
             ngram_idx = 1
-            for idx, dm in enumerate(self.draft_model.draft_models):
-                cache = self.draft_cache.caches[idx]
-                if idx in self.dflash_draft:
-                    self.iterate_draftmodel_dflash_gen(results, dm, cache, idx)
-                elif idx in self.mtp_draft:
-                    self.iterate_draftmodel_mtp_gen(results, dm, cache, idx)
-                elif idx in self.reg_draft:
-                    self.iterate_draftmodel_gen(results, dm, cache, idx)
-                ngram_idx += 1
+            if self.draft_model:
+                for idx, dm in enumerate(self.draft_model.draft_models):
+                    cache = self.draft_cache.caches[idx]
+                    if idx in self.dflash_draft:
+                        self.iterate_draftmodel_dflash_gen(results, dm, cache, idx)
+                    elif idx in self.mtp_draft:
+                        self.iterate_draftmodel_mtp_gen(results, dm, cache, idx)
+                    elif idx in self.reg_draft:
+                        self.iterate_draftmodel_gen(results, dm, cache, idx)
+                    ngram_idx += 1
             if self.ngram_match_min:
                 draft_tokens = self.iterate_ngram_gen(results, ngram_idx)
             draft_ids = self.draft_ids_pinned[:, :, :].reshape(self.draft_ids_pinned.shape[0], -1)
@@ -675,6 +674,7 @@ class Generator:
 
         # Crop out the first token after sampling to keep batch contiguous for lm_head
         new_ids = new_ids[:, 1:]
+        window = min(window, new_ids.shape[1])
         self.draft_ids_pinned[:batch_size, drafter, :window].copy_(new_ids[:batch_size, :window])
 
 

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+from exllamav3.architecture.draft import DraftStackModel
 import torch
 from ..model.model import Model
-from ..cache.cache import Cache
+from ..cache.cache import Cache, CacheStack
 from ..cache.recurrent import RecurrentCache
 from ..tokenizer.tokenizer import Tokenizer
 from ..constants import PAGE_SIZE
@@ -28,12 +29,12 @@ class Generator:
         max_chunk_size: int = 2048,
         max_q_size: int = 8,
         draft_model: Model | None = None,
-        draft_cache: Cache | None = None,
+        draft_cache: Cache | CacheStack | None = None,
         num_draft_tokens: int | None = None,
         show_visualizer: bool = False,
         enable_defrag: bool = True,
         recurrent_cache_size: int = 4 * 1024**3,
-        recurrent_checkpoint_interval: int = None,
+        recurrent_checkpoint_interval: int | None = None,
         recurrent_checkpoint_interval_pp: int = 32768,
         ngram_match_min: int = 0,
         dynamic_draft_tokens: bool = False,
@@ -145,7 +146,9 @@ class Generator:
         # Draft model
         self.draft_model = draft_model
         self.draft_cache = draft_cache
-        if draft_model:
+        self.num_drafters = 0
+        self.num_draft_tokens = 0
+        if draft_model is not None:
             assert not ngram_match_min, \
                 "Cannot use both draft model and n-gram draft."
             assert draft_cache is not None, \
@@ -155,13 +158,19 @@ class Generator:
             assert not draft_model.caps.get("recurrent_states"), \
                 "Speculative decoding with recurrent draft model not supported."
             if num_draft_tokens:
-                self.num_draft_tokens = num_draft_tokens
+                self.num_draft_tokens += num_draft_tokens
             else:
-                self.num_draft_tokens = draft_model.caps.get("default_draft_size", 4)
-        elif ngram_match_min:
-            self.num_draft_tokens = num_draft_tokens if num_draft_tokens is not None else 4
-        else:
-            self.num_draft_tokens = 0
+                self.num_draft_tokens += draft_model.caps.get("default_draft_size", 4)
+            if draft_model.caps.get("stack_draft", False):
+                self.num_drafters = len(draft_model.draft_models)
+            else:
+                # Wrap the drafter for simplicity later on
+                self.draft_model = DraftStackModel(self.draft_model)
+                self.draft_cache = CacheStack(self.cache)
+                self.num_drafters = 1
+        if ngram_match_min:
+            self.num_draft_tokens += num_draft_tokens if num_draft_tokens is not None else 4
+            self.num_drafters += 1
 
         self.ngram_match_min = ngram_match_min
         self.dynamic_draft = dynamic_draft_tokens and self.num_draft_tokens > 0
@@ -192,12 +201,12 @@ class Generator:
         # Buffers
         if draft_model or ngram_match_min:
             self.draft_input_ids_pinned = torch.empty(
-                (max_batch_size, 1),
+                (max_batch_size, self.num_drafters, 1),
                 dtype = torch.long,
                 pin_memory = False
             )
             self.draft_ids_pinned = torch.empty(
-                (max_batch_size, self.num_draft_tokens),
+                (max_batch_size, self.num_drafters, self.num_draft_tokens),
                 dtype = torch.long,
                 pin_memory = False
             )
@@ -231,10 +240,17 @@ class Generator:
         self.recurrent_checkpoint_interval_pp = ceil_span(recurrent_checkpoint_interval_pp, self.max_chunk_size)
 
         # Drafting mode
-        if draft_model is not None and draft_model.caps.get("attach_target"):
-            draft_model.attach_to(model)
-        self.dflash_draft = self.draft_model is not None and self.draft_model.caps.get("dflash_draft", False)
-        self.mtp_draft = self.draft_model is not None and self.draft_model.caps.get("mtp_draft", False)
+        if draft_model is not None:
+            assert isinstance(draft_cache, CacheStack), \
+                "A draft stack must have a cache stack of equal length."
+            assert len(draft_model.draft_models) == len(draft_cache.caches), \
+                "The draft stack is not the same length as the cache stack."
+            for m in draft_model.draft_models:
+                if m.caps.get("attach_target"):
+                    m.attach_to("model")
+            self.dflash_draft = [m.caps.get("dflash_draft", False) for m in draft_model.draft_models]
+            self.mtp_draft = [m.caps.get("mtp_draft", False) for m in draft_model.draft_models]
+            self.reg_draft = [not self.dflash_draft[i] and not self.mtp_draft[i] for (i, m) in enumerate(draft_model.draft_models)]
 
 
     def num_remaining_jobs(self):
@@ -392,22 +408,20 @@ class Generator:
         if self.recurrent_cache is not None:
             self.recurrent_checkpoint()
 
-        # Generation with draft model
-        if self.draft_model:
-            if self.dflash_draft:
-                draft_tokens = self.iterate_draftmodel_dflash_gen(results)
-                self.iterate_gen(results, draft_tokens)
-            elif self.mtp_draft:
-                draft_tokens = self.iterate_draftmodel_mtp_gen(results)
-                self.iterate_gen(results, draft_tokens)
-            else:
-                draft_tokens = self.iterate_draftmodel_gen(results)
-                self.iterate_gen(results, draft_tokens)
-
-        # Generation with n-gram draft
-        elif self.ngram_match_min:
-            draft_tokens = self.iterate_ngram_gen(results)
-            self.iterate_gen(results, draft_tokens)
+        # Generation with draft model / ngram
+        if self.draft_model or self.ngram_match_min:
+            ngram_idx = 1
+            for idx, model in enumerate(self.draft_model.draft_models):
+                if self.dflash_draft[idx]:
+                    self.iterate_draftmodel_dflash_gen(results, idx)
+                elif self.mtp_draft[idx]:
+                    self.iterate_draftmodel_mtp_gen(results, idx)
+                elif self.reg_draft[idx]:
+                    self.iterate_draftmodel_gen(results, idx)
+                ngram_idx += 1
+            if self.ngram_match_min:
+                draft_tokens = self.iterate_ngram_gen(results, ngram_idx)
+            self.iterate_gen(results, self.draft_ids_pinned[:, :, :self.draft_window()].reshape(self.max_batch_size, -1))
 
         # Regular generation
         else:
@@ -457,7 +471,7 @@ class Generator:
         return w
 
 
-    def iterate_draftmodel_gen(self, results: list):
+    def iterate_draftmodel_gen(self, results: list, model: Model, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0
@@ -497,7 +511,7 @@ class Generator:
                 job.time_first_token = time.time()
             job_ids = job.get_input_ids_list()
             input_ids_list += job_ids
-        batch_ids = self.draft_input_ids_pinned[:batch_size, :]
+        batch_ids = self.draft_input_ids_pinned[:batch_size, drafter, :]
         batch_ids.copy_(torch.cat(input_ids_list, dim = 0))
 
         # Greedy sample batched draft tokens
@@ -505,7 +519,7 @@ class Generator:
         if window == 0:
             return None
         for idx in range(window):
-            batch_logits = self.draft_model.forward(
+            batch_logits = model.forward(
                 input_ids = batch_ids,
                 params = {
                     "attn_mode": "flash_attn",
@@ -515,11 +529,11 @@ class Generator:
                 }
             )
             new_ids = torch.argmax(batch_logits, dim = -1)
-            self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
+            self.draft_ids_pinned[:batch_size, drafter, idx:idx+1].copy_(new_ids)
             batch_ids.copy_(new_ids)
             cache_seqlens += 1
 
-        self.draft_model.prefill(
+        model.prefill(
             input_ids = batch_ids,
             params = {
                 "attn_mode": "flash_attn",
@@ -529,10 +543,8 @@ class Generator:
             }
         )
 
-        return self.draft_ids_pinned[:, :window]
 
-
-    def iterate_draftmodel_mtp_gen(self, results: list):
+    def iterate_draftmodel_mtp_gen(self, results: list, model: Model, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0
@@ -573,7 +585,7 @@ class Generator:
             job_ids = job.get_input_ids_list()
             input_ids_list += job_ids
             mtp_hidden_list.append(job.mtp_last_hidden)
-        batch_ids = self.draft_input_ids_pinned[:batch_size, :]
+        batch_ids = self.draft_input_ids_pinned[:batch_size, drafter, :]
         batch_ids.copy_(torch.cat(input_ids_list, dim = 0))
         temp_hidden = torch.cat(mtp_hidden_list, dim = 0)
 
@@ -589,21 +601,17 @@ class Generator:
                 "cache": self.draft_cache,
                 "cache_seqlens": cache_seqlens,
             }
-            batch_state = self.draft_model.forward(batch_ids, params)
+            batch_state = model.forward(batch_ids, params)
             lm_head = self.model.modules[self.model.logit_layer_idx]
             batch_state = lm_head.prepare_for_device(batch_state, params)
-            new_ids = self.draft_model.sample_from_state(batch_state, params)
-            self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
+            new_ids = model.sample_from_state(batch_state, params)
+            self.draft_ids_pinned[:batch_size, drafter, idx:idx+1].copy_(new_ids)
             batch_ids.copy_(new_ids)
             cache_seqlens += 1
             temp_hidden = batch_state
 
-
-        return self.draft_ids_pinned[:, :window]
-
-
     # TODO: Refactor, share code with other draft fns
-    def iterate_draftmodel_dflash_gen(self, results: list):
+    def iterate_draftmodel_dflash_gen(self, results: list, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0
@@ -613,7 +621,7 @@ class Generator:
             max_seq_len = max(
                 max_seq_len,
                 job.get_max_seq_len() + self.num_draft_tokens + 1,
-                job.get_max_seq_len() + self.draft_model.config.block_size + 1
+                job.get_max_seq_len() + model.config.block_size + 1
             )
             batch_size += 1
         if batch_size == 0:
@@ -656,19 +664,18 @@ class Generator:
             "cache": self.draft_cache,
             "cache_seqlens": cache_seqlens,
         }
-        out_state = self.draft_model.forward(
+        out_state = model.forward(
             input_ids = batch_ids,
             params = params,
         )
-        new_ids = self.draft_model.sample_from_state(out_state, params)
+        new_ids = model.sample_from_state(out_state, params)
 
         # Crop out the first token after sampling to keep batch contiguous for lm_head
         new_ids = new_ids[:, 1:]
-        self.draft_ids_pinned[:batch_size, :window].copy_(new_ids[:batch_size, :window])
-        return self.draft_ids_pinned[:, :window]
+        self.draft_ids_pinned[:batch_size, drafter, :window].copy_(new_ids[:batch_size, :window])
 
 
-    def iterate_ngram_gen(self, results: list):
+    def iterate_ngram_gen(self, results: list, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0
@@ -697,7 +704,7 @@ class Generator:
 
         # Trim to minimum length in batch
         draft_ids = torch.cat([d[:, :min_len] for d in draft_ids], dim = 0)
-        return draft_ids
+        self.draft_ids_pinned[:batch_size, drafter, :min_len].copy_(draft_ids)
 
 
     def _staging(self, name, rows: int, width: int | None = None, dtype = torch.int32):
@@ -723,12 +730,12 @@ class Generator:
         max_seq_len = 0
         for job in self.active_jobs:
             if not job.is_prefill_done(): continue
-            max_seq_len = max(max_seq_len, job.get_max_seq_len() + self.num_draft_tokens)
+            max_seq_len = max(max_seq_len, job.get_max_seq_len() + self.num_draft_tokens * self.num_drafters)
             batch_size += len(job.sequences)
         if batch_size == 0:
             return
         if draft_tokens is not None:
-            max_seq_len += draft_tokens.shape[-1]
+            max_seq_len += draft_tokens.shape[-1] * draft_tokens.shape[-2]
 
         # Create block index table for batch
         # The model sees a compact batch, so build per-row mappings from logical page positions to physical cache

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -166,7 +166,7 @@ class Generator:
             else:
                 # Wrap the drafter for simplicity later on
                 self.draft_model = DraftStackModel(self.draft_model)
-                self.draft_cache = CacheStack(self.cache)
+                self.draft_cache = CacheStack(self.draft_cache)
                 self.num_drafters = 1
         if ngram_match_min:
             self.num_draft_tokens += num_draft_tokens if num_draft_tokens is not None else 4
@@ -201,7 +201,7 @@ class Generator:
         # Buffers
         if draft_model or ngram_match_min:
             self.draft_input_ids_pinned = torch.empty(
-                (max_batch_size, self.num_drafters, 1),
+                (max_batch_size, 1),
                 dtype = torch.long,
                 pin_memory = False
             )
@@ -413,16 +413,18 @@ class Generator:
         if self.draft_model or self.ngram_match_min:
             ngram_idx = 1
             for idx, dm in enumerate(self.draft_model.draft_models):
+                cache = self.draft_cache.caches[idx]
                 if idx in self.dflash_draft:
-                    self.iterate_draftmodel_dflash_gen(results, dm, idx)
+                    self.iterate_draftmodel_dflash_gen(results, dm, cache, idx)
                 elif idx in self.mtp_draft:
-                    self.iterate_draftmodel_mtp_gen(results, dm, idx)
+                    self.iterate_draftmodel_mtp_gen(results, dm, cache, idx)
                 elif idx in self.reg_draft:
-                    self.iterate_draftmodel_gen(results, dm, idx)
+                    self.iterate_draftmodel_gen(results, dm, cache, idx)
                 ngram_idx += 1
             if self.ngram_match_min:
                 draft_tokens = self.iterate_ngram_gen(results, ngram_idx)
-            self.iterate_gen(results, self.draft_ids_pinned[:, :, :self.draft_window()].reshape(self.max_batch_size, -1))
+            draft_ids = self.draft_ids_pinned[:, :, :].reshape(self.draft_ids_pinned.shape[0], -1)
+            self.iterate_gen(results, draft_ids)
 
         # Regular generation
         else:
@@ -472,7 +474,7 @@ class Generator:
         return w
 
 
-    def iterate_draftmodel_gen(self, results: list, model: Model, drafter: int = 0):
+    def iterate_draftmodel_gen(self, results: list, model: Model, cache: Cache, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0
@@ -512,7 +514,7 @@ class Generator:
                 job.time_first_token = time.time()
             job_ids = job.get_input_ids_list()
             input_ids_list += job_ids
-        batch_ids = self.draft_input_ids_pinned[:batch_size, drafter, :]
+        batch_ids = self.draft_input_ids_pinned[:batch_size, :]
         batch_ids.copy_(torch.cat(input_ids_list, dim = 0))
 
         # Greedy sample batched draft tokens
@@ -525,7 +527,7 @@ class Generator:
                 params = {
                     "attn_mode": "flash_attn",
                     "block_table": block_index,
-                    "cache": self.draft_cache,
+                    "cache": cache,
                     "cache_seqlens": cache_seqlens,
                 }
             )
@@ -539,13 +541,13 @@ class Generator:
             params = {
                 "attn_mode": "flash_attn",
                 "block_table": block_index,
-                "cache": self.draft_cache,
+                "cache": cache,
                 "cache_seqlens": cache_seqlens
             }
         )
 
 
-    def iterate_draftmodel_mtp_gen(self, results: list, model: Model, drafter: int = 0):
+    def iterate_draftmodel_mtp_gen(self, results: list, model: Model, cache: Cache, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0
@@ -586,7 +588,7 @@ class Generator:
             job_ids = job.get_input_ids_list()
             input_ids_list += job_ids
             mtp_hidden_list.append(job.mtp_last_hidden)
-        batch_ids = self.draft_input_ids_pinned[:batch_size, drafter, :]
+        batch_ids = self.draft_input_ids_pinned[:batch_size, :]
         batch_ids.copy_(torch.cat(input_ids_list, dim = 0))
         temp_hidden = torch.cat(mtp_hidden_list, dim = 0)
 
@@ -599,7 +601,7 @@ class Generator:
                 "target_hidden": temp_hidden,
                 "attn_mode": "flash_attn",
                 "block_table": block_index,
-                "cache": self.draft_cache,
+                "cache": cache,
                 "cache_seqlens": cache_seqlens,
             }
             batch_state = model.forward(batch_ids, params)
@@ -612,7 +614,7 @@ class Generator:
             temp_hidden = batch_state
 
     # TODO: Refactor, share code with other draft fns
-    def iterate_draftmodel_dflash_gen(self, results: list, model: Model, drafter: int = 0):
+    def iterate_draftmodel_dflash_gen(self, results: list, model: Model, cache: Cache, drafter: int = 0):
 
         # Get shape of active batch
         batch_size = 0
@@ -662,7 +664,7 @@ class Generator:
         params = {
             "attn_mode": "flash_attn",
             "block_table": block_index,
-            "cache": self.draft_cache,
+            "cache": cache,
             "cache_seqlens": cache_seqlens,
         }
         out_state = model.forward(
@@ -1040,51 +1042,53 @@ class Generator:
         # Accept new target_hidden if DFlash. DFlash draft models can update their cache from target-model hidden
         # states for the tokens accepted above, keeping draft and target cache layouts aligned.
         if self.dflash_draft:
-            self.draft_model.update_kv_from_target(
-                target_hidden = p_export_states,
-                cache = self.draft_cache,
-                lengths = accepted_lengths,
-                params = {
-                    "block_table": block_index,
-                    "cache_seqlens": p_cache_seqlens,
-                }
-            )
+            for idx in self.dflash_draft:
+                self.draft_model.draft_models[idx].update_kv_from_target(
+                    target_hidden = p_export_states,
+                    cache = self.draft_cache.caches[idx],
+                    lengths = accepted_lengths,
+                    params = {
+                        "block_table": block_index,
+                        "cache_seqlens": p_cache_seqlens,
+                    }
+                )
 
         # Accept new target_hidden if MTP. MTP draft models can update their cache from target-model hidden
         # states for the tokens accepted above, keeping draft and target cache layouts aligned.
         if self.mtp_draft:
-            target_hidden = p_export_states[-1]
-            accepted_idx = 0
-            for job, a_idx, b_idx in zip(self.active_jobs, logit_mapping[:-1], logit_mapping[1:]):
-                if a_idx == b_idx:
-                    continue
-                accepted_length = accepted_lengths[accepted_idx]
-                accepted_idx += 1
+            for idx in self.mtp_draft:
+                target_hidden = p_export_states[-1]
+                accepted_idx = 0
+                for job, a_idx, b_idx in zip(self.active_jobs, logit_mapping[:-1], logit_mapping[1:]):
+                    if a_idx == b_idx:
+                        continue
+                    accepted_length = accepted_lengths[accepted_idx]
+                    accepted_idx += 1
 
-                # A banned-string rewind invalidated this job's carry; leave it unset so drafting pauses until the
-                # next target forward provides a fresh one, and don't propagate hidden states from the abandoned
-                # window into the draft cache
-                if id(job) in rewound_jobs:
-                    continue
+                    # A banned-string rewind invalidated this job's carry; leave it unset so drafting pauses until the
+                    # next target forward provides a fresh one, and don't propagate hidden states from the abandoned
+                    # window into the draft cache
+                    if id(job) in rewound_jobs:
+                        continue
 
-                # Position K was drafted from the last target state already. Replace accepted
-                # speculative positions K+1..K+A-1 with the corresponding target-state inputs.
-                if accepted_length > 1:
-                    self.draft_model.prefill(
-                        batch_ids[a_idx:b_idx, 1:accepted_length],
-                        {
-                            "attn_mode": "flash_attn",
-                            "block_table": block_index[a_idx:b_idx],
-                            "cache": self.draft_cache,
-                            "cache_seqlens": p_cache_seqlens[a_idx:b_idx] + 1,
-                            "target_hidden": target_hidden[a_idx:b_idx, :accepted_length - 1, :],
-                        },
-                    )
+                    # Position K was drafted from the last target state already. Replace accepted
+                    # speculative positions K+1..K+A-1 with the corresponding target-state inputs.
+                    if accepted_length > 1:
+                        self.draft_model.draft_models[idx].prefill(
+                            batch_ids[a_idx:b_idx, 1:accepted_length],
+                            {
+                                "attn_mode": "flash_attn",
+                                "block_table": block_index[a_idx:b_idx],
+                                "cache": self.draft_cache.caches[idx],
+                                "cache_seqlens": p_cache_seqlens[a_idx:b_idx] + 1,
+                                "target_hidden": target_hidden[a_idx:b_idx, :accepted_length - 1, :],
+                            },
+                        )
 
-                # The next unprocessed token is paired with the preceding target hidden state.
-                job.mtp_last_hidden = target_hidden[
-                    a_idx:b_idx, accepted_length - 1:accepted_length, :
-                ].clone()
+                    # The next unprocessed token is paired with the preceding target hidden state.
+                    job.mtp_last_hidden = target_hidden[
+                        a_idx:b_idx, accepted_length - 1:accepted_length, :
+                    ].clone()
 
         # Release pages for completed jobs. Finished and requeued jobs no longer need their active page references.
         # Requeued recurrent jobs may stash the last checkpoint first so the next queued job can resume from cached

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -240,6 +240,7 @@ class Generator:
         self.recurrent_checkpoint_interval_pp = ceil_span(recurrent_checkpoint_interval_pp, self.max_chunk_size)
 
         # Drafting mode
+        self.dflash_draft, self.mtp_draft, self.reg_draft = False, False, False
         if draft_model is not None:
             assert isinstance(draft_cache, CacheStack), \
                 "A draft stack must have a cache stack of equal length."
@@ -735,7 +736,7 @@ class Generator:
         if batch_size == 0:
             return
         if draft_tokens is not None:
-            max_seq_len += draft_tokens.shape[-1] * draft_tokens.shape[-2]
+            max_seq_len += draft_tokens.shape[-1]
 
         # Create block index table for batch
         # The model sees a compact batch, so build per-row mappings from logical page positions to physical cache

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -1182,7 +1182,9 @@ class Job:
                     "mm_span_prefix": mm_span_prefix,
                 }
                 if self.generator.draft_model:
-                    params.update(self.generator.draft_model.draft_verifier_params)
+                    for m in self.generator.draft_model.draft_models:
+                        params.update(m.draft_verifier_params)
+                    
                 if self.generator.mtp_draft:
                     # MTP needs the target's post-final-norm state for every prompt token.
                     # Normal prefill stops at the last cache-writing layer, before final norm.
@@ -1192,26 +1194,27 @@ class Job:
                     self.generator.model.prefill(input_ids = prefill_ids, params = params)
 
                 if self.generator.dflash_draft:
-                    self.generator.draft_model.update_kv_from_target(
-                        target_hidden = params.get("export_states"),
-                        cache = self.generator.draft_cache,
-                        params = {
-                            "block_table": seq.block_index_tensor,
-                            "cache_seqlens": params["cache_seqlens"],
-                        }
-                    )
-                elif self.generator.draft_model:
-                    if self.generator.mtp_draft:
-                        target_hidden = params.get("export_states")[-1]
-                        carry_hidden = seq.mtp_carry_hidden
-                        if carry_hidden is None:
-                            carry_hidden = torch.zeros_like(target_hidden[:, :1, :])
-                        shifted_hidden = torch.cat((carry_hidden, target_hidden[:, :-1, :]), dim = 1)
-                        seq.mtp_carry_hidden = target_hidden[:, -1:, :].clone()
-                        self.mtp_last_hidden = seq.mtp_carry_hidden
-                    else:
-                        shifted_hidden = None
-                    self.generator.draft_model.prefill(
+                    for idx in self.generator.dflash_draft:
+                        self.generator.draft_model.draft_models[idx].update_kv_from_target(
+                            target_hidden = params.get("export_states"),
+                            cache = self.generator.draft_cache.caches[idx],
+                            params = {
+                                "block_table": seq.block_index_tensor,
+                                "cache_seqlens": params["cache_seqlens"],
+                            }
+                        )
+                if self.generator.mtp_draft:
+                    target_hidden = params.get("export_states")[-1]
+                    carry_hidden = seq.mtp_carry_hidden
+                    if carry_hidden is None:
+                        carry_hidden = torch.zeros_like(target_hidden[:, :1, :])
+                    shifted_hidden = torch.cat((carry_hidden, target_hidden[:, :-1, :]), dim = 1)
+                    seq.mtp_carry_hidden = target_hidden[:, -1:, :].clone()
+                    self.mtp_last_hidden = seq.mtp_carry_hidden
+                else:
+                    shifted_hidden = None
+                for idx in self.generator.mtp_draft + self.generator.reg_draft:
+                    self.generator.draft_model.draft_models[idx].prefill(
                         input_ids = prefill_ids,
                         params = {
                             "target_hidden": shifted_hidden,

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -1213,18 +1213,19 @@ class Job:
                     self.mtp_last_hidden = seq.mtp_carry_hidden
                 else:
                     shifted_hidden = None
-                for idx in self.generator.mtp_draft + self.generator.reg_draft:
-                    self.generator.draft_model.draft_models[idx].prefill(
-                        input_ids = prefill_ids,
-                        params = {
-                            "target_hidden": shifted_hidden,
-                            "attn_mode": "flash_attn",
-                            "block_table": seq.block_index_tensor,
-                            "cache": self.generator.draft_cache.caches[idx],
-                            "cache_seqlens": torch.tensor([prefill_start], dtype = torch.int32),
-                            "indexed_embeddings": self.embeddings if self.generator.mtp_draft else None,
-                        }
-                    )
+                if self.generator.mtp_draft or self.generator.reg_draft:
+                    for idx in self.generator.mtp_draft + self.generator.reg_draft:
+                        self.generator.draft_model.draft_models[idx].prefill(
+                            input_ids = prefill_ids,
+                            params = {
+                                "target_hidden": shifted_hidden,
+                                "attn_mode": "flash_attn",
+                                "block_table": seq.block_index_tensor,
+                                "cache": self.generator.draft_cache.caches[idx],
+                                "cache_seqlens": torch.tensor([prefill_start], dtype = torch.int32),
+                                "indexed_embeddings": self.embeddings if self.generator.mtp_draft else None,
+                            }
+                        )
 
                 # Atomic MM prefill may have extended the forward pass past prefill_end, advancing any
                 # recurrent state beyond the chunk boundary. The extension is processed again by the

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -1220,7 +1220,7 @@ class Job:
                             "target_hidden": shifted_hidden,
                             "attn_mode": "flash_attn",
                             "block_table": seq.block_index_tensor,
-                            "cache": self.generator.draft_cache,
+                            "cache": self.generator.draft_cache.caches[idx],
                             "cache_seqlens": torch.tensor([prefill_start], dtype = torch.int32),
                             "indexed_embeddings": self.embeddings if self.generator.mtp_draft else None,
                         }

--- a/exllamav3/model_init.py
+++ b/exllamav3/model_init.py
@@ -1,3 +1,5 @@
+from exllamav3.cache.cache import CacheStack
+from exllamav3.architecture.draft import DraftStackModel
 from types import SimpleNamespace
 
 from . import Model, Config, Cache, Tokenizer
@@ -175,15 +177,9 @@ def init(
     def printp(p: bool, s: str):
         if p: print(s)
 
-    return_draft = "draft_model_dir" in args
+    return_draft = "draft_model_dir" in args or "mtp" in args
     draft_model_dir = args.draft_model_dir if return_draft else None
-    if "mtp" in args:
-        assert not (args.mtp and draft_model_dir), "Cannot specify both --mtp and --draft_model_dir"
-        if args.mtp:
-            args.draft_model_dir = draft_model_dir = args.model_dir
-        use_mtp = draft_model_dir and Path(args.model_dir).resolve() == Path(draft_model_dir).resolve()
-    else:
-        use_mtp = False
+    use_mtp = True if "mtp" in args and args.mtp else False
 
     # Config
     config = Config.from_directory(args.model_dir, layer_map = args.layer_map)
@@ -199,14 +195,12 @@ def init(
         assert not args.tensor_parallel, "--draft_moe_cpu_layers currently requires layer-split mode"
         assert draft_model_dir, "--draft_moe_cpu_layers requires a draft model (or --mtp)"
     if use_mtp:
-        draft_config = config
-        # Shared config: the MTP head is a separate component with its own budget and worker
+        mtp_config = config
         config.infer_params.draft_moe_cpu_offload = dmcl
         if dmclt is not None:
             config.infer_params.draft_moe_cpu_threads = dmclt
-    elif draft_model_dir:
+    if draft_model_dir:
         draft_config = Config.from_directory(draft_model_dir)
-        # Separate config: the draft model's own text component takes the budget
         draft_config.infer_params.moe_cpu_offload = dmcl
         if dmclt is not None:
             draft_config.infer_params.moe_cpu_threads = dmclt
@@ -236,10 +230,15 @@ def init(
 
     # Model instance
     model = Model.from_config(config, swa_full = args.swa_full)
+    mtp_model = Model.from_config(
+        mtp_config,
+        swa_full = args.swa_full,
+        component = "mtp"
+    ) if use_mtp else None
     draft_model = Model.from_config(
         draft_config,
         swa_full = args.swa_full,
-        component = "mtp" if use_mtp else "text",
+        component = "text",
     ) if draft_model_dir else None
 
     # Cache
@@ -268,6 +267,13 @@ def init(
                 max_history = max_history,
                 max_batch_size = args.autosplit_max_batch_size,
             )
+            mtp_cache = Cache(
+                mtp_model,
+                max_num_tokens = args.cache_size,
+                layer_type = CacheLayer_quant,
+                k_bits = k_bits,
+                v_bits = v_bits,
+            ) if use_mtp else None
             draft_cache = Cache(
                 draft_model,
                 max_num_tokens = args.cache_size,
@@ -283,6 +289,11 @@ def init(
                 max_history = max_history,
                 max_batch_size = args.autosplit_max_batch_size,
             )
+            mtp_cache = Cache(
+                mtp_model,
+                max_num_tokens = args.cache_size,
+                layer_type = CacheLayer_fp16,
+            ) if use_mtp else None
             draft_cache = Cache(
                 draft_model,
                 max_num_tokens = args.cache_size,
@@ -290,6 +301,7 @@ def init(
             ) if draft_model_dir else None
     else:
         cache = None
+        mtp_cache = None
         draft_cache = None
 
     # Split
@@ -317,6 +329,18 @@ def init(
             tp_dev_limits[key] = value
     if len(tp_dev_limits) and not args.tensor_parallel:
         printp(not quiet, " !! Warning, parallelism are do not applied to layer-split model")
+
+    # Load mtp model
+    if use_mtp:
+        printp(not quiet, f" -- Loading {args.model_dir} (mtp)")
+        mtp_model.load(
+            use_per_device = split,
+            progressbar = progress,
+            verbose = args.load_verbose,
+            max_batch_size = args.autosplit_max_batch_size,
+            autosplit_no_forward = args.autosplit_no_forward,
+            **kwargs
+        )
 
     # Load draft model
     if draft_model_dir:
@@ -355,6 +379,13 @@ def init(
     # Metrics
     if args.load_metrics:
         config.stc.metrics.print()
+
+    if not draft_model and mtp_model:
+        draft_model = mtp_model
+        draft_cache = mtp_cache
+    elif draft_model and mtp_model:
+        draft_model = DraftStackModel(draft_model, mtp_model)
+        draft_cache = CacheStack(draft_cache, mtp_cache)
 
     if return_draft:
         return model, config, cache, tokenizer, draft_model, draft_config, draft_cache


### PR DESCRIPTION
Created because I'm very indecisive. Also, it seems that dflash and mtp don't completely overlap, they each have distinctive qualities and I want the best of both worlds. Currently:

- [x] Model works without draft
- [x] Model works with dflash only
- [ ] Model works with mtp only
- [ ] Model works with ngram only
- [ ] Model works with dflash and mtp

Will test more combinations and update the list later. This approach adds two classes: DraftStackModel which wraps around multiple draft models and CacheStack which wraps around multiple Caches,