### PR TITLE
Fix int32 offset overflow in the Triton prefill kernel at large geometries

### DIFF
--- a/exllamav3/modules/attention_fn/triton_paged.py
+++ b/exllamav3/modules/attention_fn/triton_paged.py
@@ -1384,7 +1384,10 @@ def _paged_attn_prefill_kernel(
     offs_d = tl.arange(0, head_dim)
     valid_row = offs_m < q_len
 
-    q_ptrs = q + (((batch * q_len + offs_m[:, None]) * n_q_heads + q_head) * head_dim + offs_d[None, :])
+    # q/out element offsets reach q_len * n_q_heads * head_dim, past int32 at ~64k rows for
+    # 32-head/256-dim geometry: widen the row term
+    row64 = (batch * q_len + offs_m[:, None]).to(tl.int64)
+    q_ptrs = q + ((row64 * n_q_heads + q_head) * head_dim + offs_d[None, :])
     q_tile = tl.load(q_ptrs, mask = valid_row[:, None], other = 0.0)
     if QCK > 0:
         q_tile = _rot_h32(q_tile, h32, BLOCK_M, head_dim)
@@ -1493,7 +1496,8 @@ def _paged_attn_prefill_kernel(
         )
 
     if IS_SPLIT:
-        pid_lin = (pid_m * tl.num_programs(1) + bh) * num_splits + split
+        # partial_o offsets reach programs * num_splits * BLOCK_M * head_dim: widen
+        pid_lin = ((pid_m * tl.num_programs(1) + bh) * num_splits + split).to(tl.int64)
         po_base = pid_lin * BLOCK_M * head_dim
         tl.store(partial_o + po_base + tl.arange(0, BLOCK_M)[:, None] * head_dim + offs_d[None, :], acc)
         ml_base = pid_lin * BLOCK_M * 2
@@ -1510,7 +1514,7 @@ def _paged_attn_prefill_kernel(
         out_tile = acc / tl.where(l[:, None] == 0.0, 1.0, l[:, None])
         if QCV > 0:
             out_tile = _rot_h32(out_tile, h32, BLOCK_M, head_dim)
-        out_ptrs = out + (((batch * q_len + offs_m[:, None]) * n_q_heads + q_head) * head_dim + offs_d[None, :])
+        out_ptrs = out + ((row64 * n_q_heads + q_head) * head_dim + offs_d[None, :])
         tl.store(out_ptrs, out_tile, mask = valid_row[:, None])
 
 
@@ -1537,7 +1541,8 @@ def _paged_attn_prefill_combine_kernel(
     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, head_dim)
     rows = tl.arange(0, BLOCK_M)
-    pid_lin = (pid_m * tl.num_programs(1) + bh) * num_splits
+    # same int32 overflow considerations as the prefill kernel: partial and out offsets widen
+    pid_lin = ((pid_m * tl.num_programs(1) + bh) * num_splits).to(tl.int64)
 
     m_max = tl.full((BLOCK_M,), -float("inf"), tl.float32)
     for sp in range(num_splits):
@@ -1565,7 +1570,8 @@ def _paged_attn_prefill_combine_kernel(
     out_tile = acc / tl.where(l_sum[:, None] == 0.0, 1.0, l_sum[:, None])
     if QCV > 0:
         out_tile = _rot_h32(out_tile, h32, BLOCK_M, head_dim)
-    out_ptrs = out + (((batch * q_len + offs_m[:, None]) * n_q_heads + q_head) * head_dim + offs_d[None, :])
+    row64 = (batch * q_len + offs_m[:, None]).to(tl.int64)
+    out_ptrs = out + ((row64 * n_q_heads + q_head) * head_dim + offs_d[None, :])
     tl.store(out_ptrs, out_tile, mask = (offs_m[:, None] < q_len))
 
 
@@ -1745,13 +1751,20 @@ def paged_attn_triton_prefill(
             _decode_sm_count[dev] = torch.cuda.get_device_properties(q.device).multi_processor_count
         sms = _decode_sm_count[dev]
         num_splits = 1
-        if bound_kv >= 8192:
+        if bound_kv >= 8192 and programs:
             best = None
             for cand in (1, 2, 3, 4, 5, 6, 8):
                 cost = math.ceil(programs * cand / sms) / cand + 0.03 * (cand - 1)
                 if best is None or cost < best[0]:
                     best = (cost, cand)
             num_splits = best[1]
+            # Splitting fixes grid quantization when programs are few; at large program counts
+            # the ceil-noise in the cost model can still pick a high split count whose fp32
+            # partial buffer is enormous (64k q_len x 32 heads: ~2 GB per split). The gain there
+            # is negligible by construction, so bound the buffer rather than trust the penalty
+            max_partial_bytes = 128 * 1024 * 1024
+            max_splits = max(1, max_partial_bytes // (programs * block_m * head_dim * 4))
+            num_splits = min(num_splits, max_splits)
 
     if num_splits > 1:
         partial_o = torch.empty(programs * num_splits * block_m * head_dim, dtype = torch.float32, device = q.device)

--- a/tests/test_triton_paged_overflow.py
+++ b/tests/test_triton_paged_overflow.py
@@ -1,0 +1,149 @@
+import math
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from exllamav3.modules.attention_fn.triton_paged import paged_attn_triton_prefill
+
+
+device = os.environ.get("EXL3_TEST_DEVICE", "cuda:0")
+GiB = 1024**3
+
+
+def _require_cuda_memory(min_free_bytes: int):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    free_bytes, _ = torch.cuda.mem_get_info(device)
+    if free_bytes < min_free_bytes:
+        pytest.skip(f"test requires at least {min_free_bytes / GiB:.1f} GiB free CUDA memory")
+
+
+def _empty_cuda_cache():
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+
+
+@torch.inference_mode()
+def test_prefill_q_and_out_offsets_past_int32():
+    """Q/out element offsets are row * n_q_heads * head_dim + ...; at 32 heads x 256 dim the
+    int32 boundary sits at row 2**31 / 8192 = 262144. Rows past it wrapped negative before the
+    row64 widening: the q load reads far out of bounds and the out store never lands, leaving
+    the NaN sentinel in place. ~9 GiB: q and out must each span > 2**31 elements (4 GiB fp16)."""
+    _require_cuda_memory(10 * GiB)
+
+    q_len = 262272  # two BLOCK_M = 64 blocks past the 262144 boundary
+    n_q_heads = 32
+    head_dim = 256
+
+    q = torch.zeros((1, q_len, n_q_heads, head_dim), dtype = torch.half, device = device)
+    k = torch.zeros((1, q_len, 1, head_dim), dtype = torch.half, device = device)
+    v = torch.zeros_like(k)
+    out = torch.full_like(q, torch.nan)
+
+    token = torch.arange(q_len, dtype = torch.float32, device = device)
+    head = torch.arange(n_q_heads, dtype = torch.float32, device = device)
+    q[0, :, :, 0] = ((token.remainder(127) - 63)[:, None] / 16 + head[None, :] / 32).half()
+    k[0, :, 0, 0] = torch.where(token.remainder(2) == 0, 1.0, -1.0).half()
+    v[0, :, 0, 0] = (token.remainder(251) / 251).half()
+
+    actual = paged_attn_triton_prefill(
+        q, None, None, None, None, None, None,
+        causal = True,
+        window_size = 1,
+        num_splits = 1,
+        out = out,
+        k_new = k,
+        v_new = v,
+    )
+
+    # 262142 sits below the boundary as a control; the rest overflow without the fix
+    for pos in (262142, 262144, 262206, 262271):
+        scores = q[0, pos, :, 0].float()[:, None] * \
+            k[0, pos - 1:pos + 1, 0, 0].float()[None, :] / math.sqrt(head_dim)
+        weights = scores.softmax(dim = -1)
+        expected = weights @ v[0, pos - 1:pos + 1, 0, 0].float()
+        torch.testing.assert_close(actual[0, pos, :, 0].float(), expected, atol = 3e-4, rtol = 3e-4)
+        torch.testing.assert_close(
+            actual[0, pos, :, 1:],
+            torch.zeros_like(actual[0, pos, :, 1:]),
+        )
+
+    del actual, out, v, k, q
+    _empty_cuda_cache()
+
+
+@torch.inference_mode()
+def test_prefill_split_partial_offsets_past_int32():
+    """partial_o element offsets are pid_lin * BLOCK_M * head_dim with pid_lin up to
+    programs * num_splits; at 16384 tokens x 32 heads (programs = 8192, BLOCK_M = 64) the
+    boundary of 2**31 / 16384 = 131072 falls at split count 16, so 17 splits push the tail
+    programs past it. ~10 GiB: the fp32 partial buffer must span > 2**31 elements (8.5 GiB)."""
+    _require_cuda_memory(11 * GiB)
+
+    q_len = 16384
+    n_q_heads = 32
+    head_dim = 256
+
+    q = torch.zeros((1, q_len, n_q_heads, head_dim), dtype = torch.half, device = device)
+    k = torch.zeros((1, q_len, 1, head_dim), dtype = torch.half, device = device)
+    v = torch.zeros_like(k)
+    out = torch.full_like(q, torch.nan)
+
+    # q = k = 0 gives uniform attention, so row `pos` must come out as the prefix mean of v.
+    # v varies by position so that partials landing in (or read from) the wrong slot are
+    # detectably wrong rather than interchangeable
+    token = torch.arange(q_len, dtype = torch.float32, device = device)
+    v[0, :, 0, 0] = (token.remainder(251) / 251).half()
+
+    actual = paged_attn_triton_prefill(
+        q, None, None, None, None, None, None,
+        causal = True,
+        window_size = None,
+        num_splits = 17,
+        out = out,
+        k_new = k,
+        v_new = v,
+    )
+
+    prefix_mean = v[0, :, 0, 0].float().cumsum(0) / (token + 1)
+
+    # overflow starts at row 15360 for the high heads (pid_m = 240, bh >= 30) and covers all
+    # heads from 15424; 1000 is a below-boundary control
+    for pos in (1000, 15360, 16000, 16383):
+        torch.testing.assert_close(
+            actual[0, pos, :, 0].float(),
+            prefix_mean[pos].expand(n_q_heads),
+            atol = 1e-3,
+            rtol = 1e-3,
+        )
+        torch.testing.assert_close(
+            actual[0, pos, :, 1:],
+            torch.zeros_like(actual[0, pos, :, 1:]),
+        )
+
+    del actual, out, v, k, q
+    _empty_cuda_cache()
+
+
+@torch.inference_mode()
+def test_prefill_empty_q_with_long_kv_returns_empty():
+    _require_cuda_memory(1 * GiB)
+
+    q = torch.empty((1, 0, 8, 128), dtype = torch.half, device = device)
+    k = torch.empty((1, 8192, 1, 128), dtype = torch.half, device = device)
+    v = torch.empty_like(k)
+
+    actual = paged_attn_triton_prefill(
+        q, None, None, None, None, None, None,
+        causal = True,
+        k_new = k,
+        v_new = v,
+    )
+
+    assert actual.shape == q.shape
+    assert actual.dtype == q.dtype
+    assert actual.device == q.device


### PR DESCRIPTION
## Problem

The Triton prefill kernel computes element offsets in int32, which wraps negative once a tensor crosses 2^31 elements. Two paths are affected:

- **Q/out addressing** (`(row * n_q_heads + q_head) * head_dim + d`): overflows past 2^31 elements — e.g. 262,144 query rows at 32 heads × 256 head_dim. The q load then reads far out of bounds and the out store never lands.
- **Split-partial addressing** (`pid_lin * BLOCK_M * head_dim`): overflows when `programs * num_splits * BLOCK_M * head_dim` crosses 2^31, in both the prefill store and the combine-pass loads.

Separately, the auto-split heuristic can misbehave at large program counts: ceil-noise in the cost model can pick a high split count whose fp32 partial buffer runs to tens of GB (e.g. ~17 GB at 64k tokens × 32 heads) for negligible scheduling gain, causing OOM. We hit this evaluating a Gemma3-class model at long context.

## Fix

- Widen the row term (q/out) and `pid_lin` (partials) to int64 in `_paged_attn_prefill_kernel` and `_paged_attn_prefill_combine_kernel`.
- Clamp the auto-picked `num_splits` so the partial buffer stays under 128 MB, and guard the heuristic against `programs == 0`.

## Tests

`tests/test_triton_paged_overflow.py` crosses the 2^31 element-offset boundary in both paths and checks exact expected values, using a NaN sentinel in `out` so a wrapped store is detected. Both tests were verified to fail against the previous kernel and pass with the fix. Note for CI: crossing 2^31 elements inherently requires large allocations, so the tests need ~10–11 GiB of free VRAM and skip below that. A third small test covers the `programs == 0` guard.
