### PR TITLE
Exclude multimodal-dependent pages from the CPU cache tier

### DIFF
--- a/exllamav3/generator/cpu_cache.py
+++ b/exllamav3/generator/cpu_cache.py
@@ -4,6 +4,7 @@ import threading
 import torch
 from collections import deque
 from ..constants import PAGE_SIZE
+from ..tokenizer.mm_embedding import FIRST_MM_EMBEDDING_INDEX
 
 
 def _align(n: int, a: int) -> int:
@@ -82,12 +83,18 @@ class CPUPageCache:
         self._order_pops = 0
         self._order_rebuild = max(64, self.max_slots // 8)
 
+        # Multimodal taint verdicts by page hash (see mm_tainted). Verdicts are content-addressed and never
+        # stale; the cap only bounds memory, and clearing costs one O(chain) rebuild on the next store
+        self._taint_memo = {}
+        self._taint_memo_cap = 65536
+
         self.metrics = {
             "pushes": 0,        # pages copied to the tier on GPU eviction
             "dedup_hits": 0,    # pushes skipped because the page was already stored
             "restores": 0,      # pages copied back into the GPU cache at allocation
             "evictions": 0,     # tier entries dropped to make room
             "cold_allocs": 0,   # pushes that had to pin a slab synchronously (spare pool was empty)
+            "mm_rejects": 0,    # pushes declined because the page's K/V depends on multimodal embeddings
         }
 
         # Transfers run at PCIe speed, but pinning host memory only manages ~2.5 GB/s and serializes with copy
@@ -223,11 +230,66 @@ class CPUPageCache:
         self._order_pops = 0
 
 
+    def mm_tainted(self, page) -> bool:
+        """
+        Whether a page's K/V state depends on multimodal embeddings. MM tokens are embedding indices rather
+        than content, and through attention they influence the K/V of every later page in the sequence, so the
+        chained token-ID hash cannot verify any page downstream of one. A page is tainted if its own tokens
+        contain an MM index or if any ancestor's do. Ancestry is walked through complete VRAM pages and ends
+        clean at the chain root or at a tier entry (entries are only stored untainted, so their ancestry is
+        already verified); a chain that cannot be followed counts as tainted.
+
+        Verdicts are memoized by page hash: the chained hash commits to every token ID from the root down, so
+        taint is a pure function of the hash and a cached verdict can never go stale. This makes tearing down
+        an N-page chain O(N) rather than O(N^2): eviction is leaf-first, so the first (deepest) store walks to
+        the root and memoizes the whole path, and each later store hits the memo immediately. Verdicts from an
+        unfollowable chain are conservative, state-dependent and never cached.
+        """
+        memo = self._taint_memo
+        path = []
+        while True:
+            verdict = memo.get(page.phash)
+            if verdict is not None:
+                break
+            if bool((page.sequence >= FIRST_MM_EMBEDDING_INDEX).any()):
+                path.append(page.phash)
+                verdict = True
+                break
+            path.append(page.phash)
+            if page.prev_hash is None:
+                verdict = False
+                break
+            if page.prev_hash in self.entries:
+                verdict = False
+                break
+            if self.pagetable is None:
+                return True
+            page = self.pagetable.get_live_page(page.prev_hash)
+            if page is None:
+                return True
+            if len(path) > self.pagetable.max_pages:
+                return True
+        if len(memo) + len(path) > self._taint_memo_cap:
+            memo.clear()
+        for h in path:
+            memo[h] = verdict
+        return verdict
+
+
     def store(self, page, serial: int, protect: set | None = None):
         """
         Copy a dying page's cache state into the tier (device-to-host, async on the current stream). Duplicate
         hashes only refresh the entry's recency.
+
+        Pages whose K/V depends on multimodal embeddings are not stored (see mm_tainted): their hashes key on
+        embedding indices, not on image content. Freshly encoded embeddings always draw new indices from the
+        global allocator, so a re-uploaded identical image can never hit such an entry, while deserialized
+        embeddings (MMEmbedding(imp)) carry externally assigned indices that this tier cannot verify against
+        its longer retention window. The entries are dead weight at best and a stale K/V hit at worst.
         """
+        if self.mm_tainted(page):
+            self.metrics["mm_rejects"] += 1
+            return
         e = self.entries.get(page.phash)
         if e is not None:
             e["access_serial"] = serial

--- a/tests/test_cpu_cache.py
+++ b/tests/test_cpu_cache.py
@@ -1,0 +1,167 @@
+import pytest
+import torch
+
+from exllamav3.constants import PAGE_SIZE
+from exllamav3.generator.cpu_cache import CPUPageCache
+from exllamav3.tokenizer.mm_embedding import FIRST_MM_EMBEDDING_INDEX
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason = "requires CUDA")
+
+NUM_PAGES = 4
+
+
+class _FakeLayer:
+    def __init__(self, tensors):
+        self.tensors = tensors
+    def get_tensors(self):
+        return self.tensors
+
+
+class _FakeCache:
+    """Minimal stand-in for Cache: one layer with paged K/V tensors on the GPU."""
+    def __init__(self):
+        k = torch.randn((NUM_PAGES, 8, 16), dtype = torch.float16, device = "cuda")
+        v = torch.randn((NUM_PAGES, 8, 16), dtype = torch.float16, device = "cuda")
+        self.layers = {0: _FakeLayer([k, v])}
+
+
+class _FakePage:
+    """Minimal stand-in for CachePage: the fields CPUPageCache.store reads."""
+    def __init__(self, phash, page_index, sequence, prev_hash = None):
+        self.phash = phash
+        self.prev_hash = prev_hash
+        self.page_index = page_index
+        self.kv_position = PAGE_SIZE
+        self.sequence = sequence
+
+
+class _FakePageTable:
+    """Minimal stand-in for PageTable: hash lookup of complete VRAM pages."""
+    def __init__(self, pages = ()):
+        self.pages = {p.phash: p for p in pages}
+        self.max_pages = 1024
+        self.lookups = 0
+
+    def get_live_page(self, phash):
+        self.lookups += 1
+        page = self.pages.get(phash)
+        if page is not None and page.kv_position == PAGE_SIZE:
+            return page
+        return None
+
+
+def _text_sequence():
+    return torch.arange(PAGE_SIZE, dtype = torch.long).unsqueeze(0)
+
+
+def _mm_sequence():
+    seq = _text_sequence()
+    seq[0, PAGE_SIZE // 2] = FIRST_MM_EMBEDDING_INDEX + 42
+    return seq
+
+
+@requires_cuda
+def test_mm_pages_not_stored():
+    cache = _FakeCache()
+    cpc = CPUPageCache([cache], max_size = 64 * 1024)
+
+    text_page = _FakePage(b"\x01" * 16, 0, _text_sequence())
+    cpc.store(text_page, serial = 1)
+    assert text_page.phash in cpc
+    assert len(cpc) == 1
+
+    mm_page = _FakePage(b"\x02" * 16, 1, _mm_sequence())
+    cpc.store(mm_page, serial = 2)
+    assert mm_page.phash not in cpc
+    assert len(cpc) == 1
+    assert cpc.metrics["mm_rejects"] == 1
+    assert cpc.metrics["pushes"] == 1
+
+
+@requires_cuda
+def test_mm_taint_propagates_through_descendants():
+    # A text-only page downstream of an MM page carries K/V that depends on the image content (through
+    # attention) under a hash that only commits to token IDs, so the whole descendant chain must be rejected.
+    cache = _FakeCache()
+    cpc = CPUPageCache([cache], max_size = 64 * 1024)
+
+    mm_page = _FakePage(b"\x10" * 16, 0, _mm_sequence())
+    child = _FakePage(b"\x11" * 16, 1, _text_sequence(), prev_hash = mm_page.phash)
+    grandchild = _FakePage(b"\x12" * 16, 2, _text_sequence(), prev_hash = child.phash)
+    cpc.attach(_FakePageTable([mm_page, child, grandchild]))
+
+    cpc.store(child, serial = 1)
+    cpc.store(grandchild, serial = 2)
+    assert len(cpc) == 0
+    assert cpc.metrics["mm_rejects"] == 2
+
+
+@requires_cuda
+def test_clean_ancestry_through_tier_entry():
+    # An ancestor already stored in the tier proves its own chain was verified MM-free, so the walk may stop
+    # there; a chain that cannot be followed at all is conservatively rejected.
+    cache = _FakeCache()
+    cpc = CPUPageCache([cache], max_size = 64 * 1024)
+    cpc.attach(_FakePageTable())
+
+    parent = _FakePage(b"\x20" * 16, 0, _text_sequence())
+    cpc.store(parent, serial = 1)
+
+    child = _FakePage(b"\x21" * 16, 1, _text_sequence(), prev_hash = parent.phash)
+    cpc.store(child, serial = 2)     # parent absent from VRAM but present in the tier
+    assert child.phash in cpc
+
+    orphan = _FakePage(b"\x22" * 16, 2, _text_sequence(), prev_hash = b"\x99" * 16)
+    cpc.store(orphan, serial = 3)    # ancestry unverifiable
+    assert orphan.phash not in cpc
+    assert cpc.metrics["mm_rejects"] == 1
+
+
+@requires_cuda
+def test_taint_walk_is_memoized():
+    # Tearing down an N-page chain must not walk N^2/2 ancestors: the deepest store memoizes taint verdicts
+    # for its whole path (verdicts are pure functions of the chained hash), so later stores resolve without
+    # any further chain lookups.
+    chain_len = 8
+    cache = _FakeCache()
+    cpc = CPUPageCache([cache], max_size = 64 * 1024)
+
+    pages = []
+    for i in range(chain_len):
+        prev_hash = pages[-1].phash if pages else None
+        pages.append(_FakePage(bytes([0x30 + i]) * 16, i % NUM_PAGES, _text_sequence(), prev_hash = prev_hash))
+    pt = _FakePageTable(pages)
+    cpc.attach(pt)
+
+    cpc.store(pages[-1], serial = 1)                # deepest leaf: walks to root once
+    assert len(cpc._taint_memo) == chain_len
+    walk_lookups = pt.lookups
+    assert walk_lookups == chain_len - 1
+
+    for i, page in enumerate(reversed(pages[:-1])): # leaf-first teardown of the rest
+        cpc.store(page, serial = 2 + i)
+    assert pt.lookups == walk_lookups               # every verdict came from the memo
+    assert cpc.metrics["pushes"] == chain_len
+
+
+@requires_cuda
+def test_store_fetch_roundtrip():
+    cache = _FakeCache()
+    cpc = CPUPageCache([cache], max_size = 64 * 1024)
+    tensors = cache.layers[0].get_tensors()
+    originals = [t[0].clone() for t in tensors]
+
+    page = _FakePage(b"\x03" * 16, 0, _text_sequence())
+    cpc.store(page, serial = 1)
+
+    # Destroy the source page, then restore the stored copy into a different page index
+    for t in tensors:
+        t[0].fill_(0.0)
+    entry = cpc.fetch(page.phash, page_index = 2, serial = 2)
+    torch.cuda.synchronize()
+
+    for t, orig in zip(tensors, originals):
+        assert torch.equal(t[2], orig)
+    assert torch.equal(entry["tokens"], page.sequence)
+    assert entry["prev_hash"] is None
+    assert page.phash in cpc  # fetch is non-consuming


### PR DESCRIPTION
The CPU tier currently stores any complete content-hashed page, including pages whose K/V depends on multimodal embeddings. Those entries can't do useful work and can do harm:

- Page hashes key on MM token IDs, which are embedding *indices*, not image content. Fresh embeddings always draw new indices from `MMTokenAllocator`, so a re-uploaded identical image never produces a hit — the entries just occupy slots.
- Embeddings deserialized via `MMEmbedding(imp=...)` carry externally assigned indices. If a serving layer reuses an index range for different content, a hit restores K/V from the wrong image — and the tier's retention window is much longer than the GPU pool's, so the aliasing exposure is much larger.
- The dependency propagates: through attention, every page *downstream* of an MM page carries image-dependent K/V under a hash that only commits to token IDs, and the dedup path refreshes recency without replacing bytes. So the whole descendant chain has to be excluded, not just the page containing the MM tokens.

This PR adds `CPUPageCache.mm_tainted()`: a page is rejected if its own tokens contain an MM index or if any ancestor's do, walking ancestry through live VRAM pages and terminating clean at the chain root or at an existing tier entry (entries are only admitted untainted, so their ancestry is pre-verified). Unverifiable chains are rejected conservatively. Verdicts are memoized by page hash — taint is a pure function of the chained hash, so cached verdicts never go stale — keeping an N-page chain teardown O(N) under leaf-first eviction (measured 25 ms for a 1000-page chain, stores included). Rejections are counted in a new `mm_rejects` metric.

Tests included (`tests/test_cpu_cache.py`): taint propagation through text-only descendants, clean-ancestry admission via a tier entry, conservative rejection of a broken chain, a structural assertion that the memo eliminates repeat chain walks, and a store/fetch roundtrip byte-comparison test for the tier itself.
