### PR TITLE
Asynchronous recurrent tail stashing

### DIFF
--- a/exllamav3/cache/cache.py
+++ b/exllamav3/cache/cache.py
@@ -157,6 +157,8 @@ class Cache:
         self.num_slots = max_batch_size
         self.max_history = max_history
         self.free_list = deque(range(self.num_slots))
+        # Slots whose release is gated on side-stream stash events: (slot, [events]), oldest first
+        self.pending_slot_releases = []
         self.recurrent_state_cls = model.recurrent_state_cls
 
         rl = self.model.get_recurrent_layers()
@@ -321,7 +323,7 @@ class Cache:
         """
         Allocate a new, empty state
         """
-        assert len(self.free_list) > 0, "Cannot create new state: no available slots"
+        self._ensure_free_slot()
         handle = self.free_list.popleft()
         return self.recurrent_state_cls(
             self,
@@ -336,7 +338,7 @@ class Cache:
         Allocate a new state for given position, for testing/benchmarking purposes. If position > 0 this will
         not be a valid recurrent state for the model.
         """
-        assert len(self.free_list) > 0, "Cannot create new state: no available slots"
+        self._ensure_free_slot()
         handle = self.free_list.popleft()
         return self.recurrent_state_cls(
             self,
@@ -351,7 +353,10 @@ class Cache:
         """
         Allocate a new state from a stashed state
         """
-        assert len(self.free_list) > 0, "Cannot create new state: no available slots"
+        # Entries written through the pinned-staging path may still be finalizing on a background worker
+        from .recurrent import wait_stash_ready
+        wait_stash_ready(stashed_state)
+        self._ensure_free_slot()
         handle = self.free_list.popleft()
         return self.recurrent_state_cls(
             self,
@@ -367,6 +372,48 @@ class Cache:
         Return state to the pool
         """
         self.free_list.appendleft(state.slot)
+
+
+    def release_state_deferred(self, state, events):
+        """
+        Return the state's slot to the pool only once the given CUDA events have fired. Until then, side
+        streams are still reading the slot's tensors for a tail stash, and a new job claiming the slot would
+        overwrite them mid-copy. Reclaimed by reclaim_slots (polled) or _ensure_free_slot (blocking).
+        """
+        self.pending_slot_releases.append((state.slot, events))
+
+
+    def reclaim_slots(self, wait_all = False):
+        """
+        Move deferred slots whose stash events have fired back to the free pool. With wait_all, synchronize
+        every pending event (teardown).
+        """
+        remaining = []
+        for slot, events in self.pending_slot_releases:
+            if wait_all:
+                for ev in events:
+                    ev.synchronize()
+                ready = True
+            else:
+                ready = all(ev.query() for ev in events)
+            if ready:
+                self.free_list.appendleft(slot)
+            else:
+                remaining.append((slot, events))
+        self.pending_slot_releases = remaining
+
+
+    def _ensure_free_slot(self):
+        # Backpressure: with every slot either live or awaiting stash events, block on the oldest pending
+        # release (bounded by one side-stream D2H) rather than failing the allocation
+        if not self.free_list:
+            self.reclaim_slots()
+        if not self.free_list and self.pending_slot_releases:
+            slot, events = self.pending_slot_releases.pop(0)
+            for ev in events:
+                ev.synchronize()
+            self.free_list.appendleft(slot)
+        assert len(self.free_list) > 0, "Cannot create new state: no available slots"
 
 
     def get_recurrent_layer(

--- a/exllamav3/cache/recurrent.py
+++ b/exllamav3/cache/recurrent.py
@@ -1,5 +1,68 @@
 from collections import OrderedDict
+import torch
 from ..constants import PAGE_SIZE
+
+
+def stage_tensors_pinned(owner, tensors):
+    """
+    Copy tensors into reusable pinned host buffers. The caller must synchronize the source device streams before
+    reading or cloning the returned buffers.
+    """
+    single = isinstance(tensors, torch.Tensor)
+    tensors = (tensors,) if single else tensors
+    staging = getattr(owner, "_pinned_stash_staging", None)
+    if staging is None or len(staging) != len(tensors) or any(
+        b.shape != t.shape or b.dtype != t.dtype for b, t in zip(staging, tensors)
+    ):
+        staging = tuple(
+            torch.empty(t.shape, dtype = t.dtype, device = "cpu", pin_memory = True)
+            for t in tensors
+        )
+        owner._pinned_stash_staging = staging
+    for buffer, tensor in zip(staging, tensors):
+        buffer.copy_(tensor, non_blocking = True)
+    return staging[0] if single else staging
+
+
+def clone_staged_tensors(tensors):
+    """
+    Move a completed pinned staging copy into ordinary pageable storage owned by a recurrent-cache entry.
+    """
+    single = isinstance(tensors, torch.Tensor)
+    tensors = (tensors,) if single else tensors
+    cloned = tuple(
+        torch.empty(t.shape, dtype = t.dtype, device = "cpu").copy_(t)
+        for t in tensors
+    )
+    return cloned[0] if single else cloned
+
+
+def stash_recurrent_layers(cache, slot: int, position: int = 0, pinned_staging: bool = False, cursor: int | None = None):
+    """
+    Stash all recurrent layers for one state slot. For the completion-tail path, enqueue D2H copies for every
+    layer into reusable pinned buffers, synchronize once per source device, then clone the staged values into the
+    pageable tensors retained by RecurrentCache. cursor carries the SWA ring's true content extent; state types
+    without a ring ignore it.
+    """
+    layers = cache.get_all_recurrent_layers()
+    if not pinned_staging:
+        return {key: layer.stash(slot, position, cursor = cursor) for key, layer in layers.items()}
+
+    staged = {
+        key: layer.stash(slot, position, pinned_staging = True, cursor = cursor)
+        for key, layer in layers.items()
+    }
+    devices = {
+        device
+        for layer in layers.values()
+        if getattr(layer, "device", None) is not None
+        for device in (torch.device(layer.device),)
+        if device.type == "cuda"
+    }
+    for device in devices:
+        torch.cuda.current_stream(device).synchronize()
+    return {key: clone_staged_tensors(value) for key, value in staged.items()}
+
 
 class RecurrentCache(OrderedDict):
     def __init__(
@@ -32,14 +95,14 @@ class RecurrentCache(OrderedDict):
         return default
 
 
-    def put(self, key, state):
+    def put(self, key, state, pinned_staging: bool = False):
         """
         Add state to cache
         """
         if key in self:
             self.move_to_end(key)
         else:
-            stashed_state = state.stash()
+            stashed_state = state.stash(pinned_staging = True) if pinned_staging else state.stash()
             state_size = stashed_state["checkpoint_size"]
             while self.update_total_size() + state_size > self.max_size:
                 assert self.current_size >= 0, "Not enough space in cache for single state"

--- a/exllamav3/cache/recurrent.py
+++ b/exllamav3/cache/recurrent.py
@@ -1,6 +1,34 @@
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 import torch
 from ..constants import PAGE_SIZE
+
+
+def wait_stash_ready(stashed: dict):
+    """
+    Block until a recurrent-cache entry's background finalization (pinned -> pageable clone) has completed.
+    Entries written through the pinned-staging path carry a "pending" future until their layer tensors are
+    owned pageable copies; restoring from such an entry must join it first. A completed future is a no-op.
+    """
+    fut = stashed.get("pending")
+    if fut is not None:
+        fut.result()
+
+
+def _finalize_stash(stashed: dict, events: list = None):
+    """
+    Background-clone every staged layer value into pageable storage. Runs on the RecurrentCache worker thread;
+    layer values are keyed by module instance (non-string keys), metadata by string keys. The events gate the
+    side-stream D2H copies into staging: they must fire before the staged bytes are valid to read. Reading
+    pinned inference tensors from a plain thread is safe; only in-place mutation requires inference mode.
+    """
+    if events:
+        for ev in events:
+            ev.synchronize()
+    for k in list(stashed.keys()):
+        if isinstance(k, str):
+            continue
+        stashed[k] = clone_staged_tensors(stashed[k])
 
 
 def stage_tensors_pinned(owner, tensors):
@@ -39,29 +67,61 @@ def clone_staged_tensors(tensors):
 
 def stash_recurrent_layers(cache, slot: int, position: int = 0, pinned_staging: bool = False, cursor: int | None = None):
     """
-    Stash all recurrent layers for one state slot. For the completion-tail path, enqueue D2H copies for every
-    layer into reusable pinned buffers, synchronize once per source device, then clone the staged values into the
-    pageable tensors retained by RecurrentCache. cursor carries the SWA ring's true content extent; state types
-    without a ring ignore it.
+    Stash all recurrent layers for one state slot. For the completion-tail path, enqueue D2H copies into reusable
+    pinned buffers on per-device side streams and return events that gate both the pageable clone and slot reuse.
+    cursor carries the SWA ring's true content extent; state types without a ring ignore it.
     """
     layers = cache.get_all_recurrent_layers()
     if not pinned_staging:
         return {key: layer.stash(slot, position, cursor = cursor) for key, layer in layers.items()}
 
-    staged = {
-        key: layer.stash(slot, position, pinned_staging = True, cursor = cursor)
-        for key, layer in layers.items()
-    }
-    devices = {
-        device
-        for layer in layers.values()
-        if getattr(layer, "device", None) is not None
-        for device in (torch.device(layer.device),)
-        if device.type == "cuda"
-    }
-    for device in devices:
-        torch.cuda.current_stream(device).synchronize()
-    return {key: clone_staged_tensors(value) for key, value in staged.items()}
+    # Group layers by device and stage each device's D2H copies on a dedicated side stream that waits on the
+    # main stream (which last wrote the ring state). The copies then overlap ongoing main-stream compute; the
+    # recorded events gate both the background clone and the release of the state's slot back to the pool.
+    by_device = {}
+    for key, layer in layers.items():
+        device = getattr(layer, "device", None)
+        device = torch.device(device) if device is not None else None
+        if device is not None and device.type != "cuda":
+            device = None
+        by_device.setdefault(device, []).append((key, layer))
+
+    side_streams = getattr(cache, "_stash_side_streams", None)
+    if side_streams is None:
+        side_streams = {}
+        cache._stash_side_streams = side_streams
+
+    staged = {}
+    events = []
+    started_sides = []
+    try:
+        for device, dev_layers in by_device.items():
+            if device is None:
+                for key, layer in dev_layers:
+                    staged[key] = layer.stash(slot, position, pinned_staging = True, cursor = cursor)
+                continue
+            side = side_streams.get(device)
+            if side is None:
+                side = torch.cuda.Stream(device = device)
+                side_streams[device] = side
+            started_sides.append(side)
+            side.wait_stream(torch.cuda.current_stream(device))
+            with torch.cuda.stream(side):
+                for key, layer in dev_layers:
+                    staged[key] = layer.stash(slot, position, pinned_staging = True, cursor = cursor)
+            ev = torch.cuda.Event()
+            ev.record(side)
+            events.append(ev)
+    except Exception:
+        # The caller cannot defer its slot release without a returned event list. Make the failure path
+        # synchronous so any copies queued before the exception have stopped reading the slot.
+        for side in started_sides:
+            side.synchronize()
+        raise
+
+    # Staged pinned references become valid once the events fire, and stay valid until the next stash
+    # reuses the staging buffers. The caller (RecurrentCache.put) clones them out on its background worker.
+    return staged, events
 
 
 class RecurrentCache(OrderedDict):
@@ -74,6 +134,10 @@ class RecurrentCache(OrderedDict):
         self.max_size = max_size
         self.current_size = 0
         self.model = model
+        # Single worker serializes background clones, which also serializes reuse of the shared pinned
+        # staging buffers: put() joins the previous stash's future before staging the next one
+        self._clone_executor = None
+        self._last_stash_future = None
 
         # Optionally set by the Generator; enables stranded-first eviction and staleness metrics
         self.pagetable = None
@@ -97,12 +161,28 @@ class RecurrentCache(OrderedDict):
 
     def put(self, key, state, pinned_staging: bool = False):
         """
-        Add state to cache
+        Add state to cache. With pinned_staging, the D2H copies are enqueued on side streams and gated by CUDA
+        events; the clone into the entry's own pageable storage runs on a background worker after the events
+        fire. The entry is inserted immediately with a "pending" future that wait_stash_ready joins before the
+        entry can be restored. Returns the staging events (empty/None when nothing was staged): the caller must
+        not release the state's slot until they have fired, since the side streams are still reading it.
         """
         if key in self:
             self.move_to_end(key)
-        else:
-            stashed_state = state.stash(pinned_staging = True) if pinned_staging else state.stash()
+            return None
+        events = None
+        fut = None
+        try:
+            if pinned_staging:
+                # The pinned staging buffers are owned by the Cache's layer states, which multiple
+                # RecurrentCache instances can share, so the reuse guard must live on the Cache: whichever
+                # put() staged last must have finished cloning out of the buffers before they are overwritten
+                guard = getattr(state.cache, "_stash_staging_guard", None)
+                if guard is not None:
+                    guard.result()
+                stashed_state, events = state.stash(pinned_staging = True)
+            else:
+                stashed_state, events = state.stash(), None
             state_size = stashed_state["checkpoint_size"]
             while self.update_total_size() + state_size > self.max_size:
                 assert self.current_size >= 0, "Not enough space in cache for single state"
@@ -132,8 +212,43 @@ class RecurrentCache(OrderedDict):
                 if self.model.loaded_tp:
                     self.model.tp_dispatch_all(mp_cache_recurrent_del, (id(self), popped["tp_handle"]))
 
+            if pinned_staging:
+                if self._clone_executor is None:
+                    self._clone_executor = ThreadPoolExecutor(max_workers = 1)
+                fut = self._clone_executor.submit(_finalize_stash, stashed_state, events)
+                # Install the shared-buffer guard immediately after submission, before publishing the entry
+                state.cache._stash_staging_guard = fut
+                self._last_stash_future = fut
+                # The completed future stays in the entry; wait_stash_ready treats it as a no-op. Evicting a
+                # still-pending entry is safe: the worker fills an orphaned dict nobody will read
+                stashed_state["pending"] = fut
             self[key] = stashed_state
             self.update_total_size()
+            return events
+        except Exception:
+            # cleanup_completed_jobs releases the state in a finally block. If staging has already begun,
+            # make that immediate release safe before allowing the exception to escape.
+            if fut is not None:
+                try:
+                    fut.result()
+                except Exception:
+                    pass
+            elif events:
+                for ev in events:
+                    ev.synchronize()
+            raise
+
+
+    def drain(self):
+        """
+        Join any in-flight background clone, for deterministic teardown. Errors surface to readers of the
+        affected entry, not here.
+        """
+        if self._last_stash_future is not None:
+            try:
+                self._last_stash_future.result()
+            except Exception:
+                pass
 
 
     def prune_stranded(self) -> int:

--- a/exllamav3/generator/async_generator.py
+++ b/exllamav3/generator/async_generator.py
@@ -25,7 +25,12 @@ class AsyncGenerator:
                 # is notified by enqueue() or close(), so this background task does not spin between requests.
                 async with self.condition:
                     # Wake when the first job arrives or when close() has cancelled the iteration task.
-                    await self.condition.wait_for(lambda: len(self.jobs) > 0 or self.iteration_task.cancelled())
+                    await self.condition.wait_for(
+                        lambda:
+                            len(self.jobs) > 0 or
+                            self.generator.has_deferred_cleanup() or
+                            self.iteration_task.cancelled()
+                    )
 
                 # Drive exactly one synchronous generator step and fan out any returned events to the owning
                 # AsyncJob queues. Missing jobs can happen if a job was cancelled after iterate() started.
@@ -58,6 +63,14 @@ class AsyncGenerator:
             for async_job in self.jobs.values():
                 async_job.put_result(e)
             self.jobs.clear()
+            # Release the dead generator's held resources (deferred completions retain pages and recurrent
+            # slots). Strictly best-effort and strictly after error delivery: cleanup deallocates and
+            # defragments, either of which can fail again after a CUDA/generator failure, and a second
+            # exception here must not escape and leave consumers waiting forever.
+            try:
+                self.generator.clear_queue()
+            except Exception:
+                pass
 
     def enqueue(self, job: AsyncJob):
         # The iteration task died on a generator exception; surface it to the new job's consumer immediately
@@ -88,11 +101,15 @@ class AsyncGenerator:
             await self.iteration_task
         except asyncio.CancelledError:
             pass
-
-        # Wake any consumers still parked on job queues; no more results will be produced
-        for async_job in self.jobs.values():
-            async_job.put_result(_CANCELLED_SENTINEL)
-        self.jobs.clear()
+        try:
+            self.generator.clear_queue()
+        finally:
+            # Wake any consumers still parked on job queues; no more results will be produced. Guaranteed even
+            # if cleanup fails (it deallocates and defragments, both fallible after a generator failure), so a
+            # failing close() cannot leave consumers waiting forever.
+            for async_job in self.jobs.values():
+                async_job.put_result(_CANCELLED_SENTINEL)
+            self.jobs.clear()
 
     async def cancel(self, job: AsyncJob):
         # Remove the underlying Job from the synchronous generator first so no new tokens are produced, then drop

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -282,9 +282,12 @@ class Generator:
         Runs under inference mode: the state rewind and stash copies mutate inference tensors, and this
         method is reachable from enqueue(), which unlike iterate() has no inference-mode decorator of its own.
 
-        Tail stashes use reusable pinned staging buffers. The staging transfer and host clone finish before the
-        recurrent slot is released, so a newly activated job cannot overwrite a slot while D2H is reading it.
+        Tail stashes stage D2H on side streams gated by CUDA events; the recurrent slot's release is deferred
+        until those events fire (Cache.release_state_deferred), so a newly activated job cannot overwrite a
+        slot while a side stream is still reading it.
         """
+        # Return any deferred slots whose stash events have fired to the free pool (cheap event polls)
+        self.cache.reclaim_slots()
         if not self.deferred_completed_jobs:
             return
         while self.deferred_completed_jobs:
@@ -310,6 +313,9 @@ class Generator:
         self.active_jobs.clear()
         self.pending_jobs.clear()
         self.deferred_completed_jobs.clear()
+        if self.recurrent_cache is not None:
+            self.recurrent_cache.drain()
+        self.cache.reclaim_slots(wait_all = True)
         if num_jobs and not self.num_remaining_jobs():
             self.on_queue_drained()
 

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -187,6 +187,10 @@ class Generator:
         self.job_serial = 0
         self.pending_jobs = []
         self.active_jobs = []
+        # Completed recurrent jobs remain here for one iteration after their EOS result is returned. Holding their
+        # pages and recurrent slots until the next entry to iterate() keeps the large tail-stash copy out of the
+        # result-delivery path without allowing another job to overwrite the source state in the meantime.
+        self.deferred_completed_jobs = []
 
         # Filter threads
         self.filter_pool = ThreadPoolExecutor(max_workers = 16)
@@ -257,7 +261,7 @@ class Generator:
 
 
     def num_remaining_jobs(self):
-        return len(self.pending_jobs) + len(self.active_jobs)
+        return len(self.pending_jobs) + len(self.active_jobs) + len(self.deferred_completed_jobs)
 
     def num_active_jobs(self):
         return len(self.active_jobs)
@@ -266,16 +270,46 @@ class Generator:
         return len(self.pending_jobs)
 
 
+    def has_deferred_cleanup(self):
+        return bool(self.deferred_completed_jobs)
+
+
+    @torch.inference_mode
+    def cleanup_completed_jobs(self):
+        """
+        Stash and release jobs whose EOS events were returned by the previous iterate() call.
+
+        Runs under inference mode: the state rewind and stash copies mutate inference tensors, and this
+        method is reachable from enqueue(), which unlike iterate() has no inference-mode decorator of its own.
+
+        Tail stashes use reusable pinned staging buffers. The staging transfer and host clone finish before the
+        recurrent slot is released, so a newly activated job cannot overwrite a slot while D2H is reading it.
+        """
+        if not self.deferred_completed_jobs:
+            return
+        while self.deferred_completed_jobs:
+            job = self.deferred_completed_jobs.pop(0)
+            try:
+                if self.recurrent_cache is not None:
+                    job.stash_recurrent_tail(self.recurrent_cache, pinned_staging = True)
+            finally:
+                # A failed host copy makes the generator iteration fail, but must not strand the GPU state slot.
+                job.deallocate_pages()
+        if not self.pending_jobs and not self.active_jobs:
+            self.on_queue_drained()
+
+
     def clear_queue(self):
         """
         Abort all active and pending jobs
         """
 
         num_jobs = self.num_remaining_jobs()
-        for job in self.active_jobs + self.pending_jobs:
+        for job in self.active_jobs + self.pending_jobs + self.deferred_completed_jobs:
             job.deallocate_pages()
         self.active_jobs.clear()
         self.pending_jobs.clear()
+        self.deferred_completed_jobs.clear()
         if num_jobs and not self.num_remaining_jobs():
             self.on_queue_drained()
 
@@ -297,6 +331,10 @@ class Generator:
         returns:
             int: (List of) unique serial number(s) for job(s)
         """
+
+        # A caller may stop driving iterate() as soon as it receives EOS. Clean up that completed job here before
+        # accepting a follow-up request, so the deferred state cannot occupy a recurrent slot indefinitely.
+        self.cleanup_completed_jobs()
 
         if isinstance(job, list):
             serials = []
@@ -330,6 +368,9 @@ class Generator:
         elif job in self.active_jobs:
             job.deallocate_pages()
             self.active_jobs.remove(job)
+        elif job in self.deferred_completed_jobs:
+            job.deallocate_pages()
+            self.deferred_completed_jobs.remove(job)
         if num_jobs and not self.num_remaining_jobs():
             self.on_queue_drained()
 
@@ -399,6 +440,10 @@ class Generator:
                 "logits": torch.Tensor  - shape (1, n, vocab_size)
             }
         """
+
+        # Completion-tail stashes from the previous call happen only after that call's EOS results were returned.
+        # This also releases the held recurrent slots and page references before new jobs are activated.
+        self.cleanup_completed_jobs()
 
         results = []
         self.iterate_start_jobs(results)
@@ -1107,15 +1152,20 @@ class Generator:
                     a_idx:b_idx, accepted_length - 1:accepted_length, :
                 ].clone()
 
-        # Release pages for completed jobs. Finished and requeued jobs no longer need their active page references.
-        # Requeued recurrent jobs may stash the last checkpoint first so the next queued job can resume from cached
-        # recurrent state.
-        num_jobs = self.num_remaining_jobs()
-        for job in completed_jobs + requeuing_jobs:
-            if job in requeuing_jobs and self.recurrent_cache is not None:
+        # Requeued jobs stash and release immediately because their replacement needs the checkpoint now. Completed
+        # recurrent jobs leave active_jobs immediately but retain their state/page references until the next
+        # iterate() entry, after this call's EOS events have been returned to the caller.
+        for job in requeuing_jobs:
+            if self.recurrent_cache is not None:
                 job.maybe_stash_recurrent(self.recurrent_cache, PAGE_SIZE)
             job.deallocate_pages()
             self.active_jobs.remove(job)
+        for job in completed_jobs:
+            self.active_jobs.remove(job)
+            if self.recurrent_cache is None:
+                job.deallocate_pages()
+            else:
+                self.deferred_completed_jobs.append(job)
 
         # Requeue jobs. Puts replacement jobs at the front so long generations continue promptly after they yield
         # their cache pages.
@@ -1123,8 +1173,8 @@ class Generator:
             rq_job = job.prepare_for_requeue()
             self.pending_jobs.insert(0, rq_job)
 
-        # Defrag. Physical page indices can only be compacted when no active block tables are using them.
-        if num_jobs and not self.num_remaining_jobs():
+        # Defrag. Recurrent completions still hold page references until the deferred cleanup pass.
+        if not self.num_remaining_jobs():
             self.on_queue_drained()
 
 

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -1382,6 +1382,46 @@ class Job:
             self.last_recurrent_checkpoint_pos = seq.kv_position
 
 
+    def stash_recurrent_tail(self, cache, pinned_staging: bool = False):
+        """
+        On normal job completion, stash the recurrent state at the last full page of forwarded tokens, so a
+        follow-up request extending this sequence resumes within about a page of its end instead of at the last
+        interval checkpoint. The state is rewound in place to the page boundary; ring-cursor-aware stashing
+        (SWAState.stash) serializes it correctly at any decode alignment. States without in-place rollback
+        (e.g. GDN) keep the default checkpoint behavior.
+        """
+        if self.recurrent_state is None or len(self.sequences) != 1:
+            return
+        if not getattr(type(self.recurrent_state), "guaranteed_rollback", 0):
+            return
+        if self.generator.model.loaded_tp:
+            return
+        seq = self.sequences[0]
+        # The final sampled token's K/V is never forwarded; when it exactly completes a page, target the
+        # previous boundary instead (a rewind of PAGE_SIZE - 1, within the guaranteed rollback window)
+        boundary = len(seq.sequence_ids) // PAGE_SIZE * PAGE_SIZE
+        if len(seq.sequence_ids) == boundary:
+            boundary -= PAGE_SIZE
+        if boundary <= 0:
+            return
+        # last_recurrent_checkpoint_pos == boundary is deliberately NOT a shortcut here: the shared
+        # RecurrentCache may have evicted that entry since it was written, and put() on a still-present key
+        # only refreshes its LRU position without copying
+        last_page = boundary // PAGE_SIZE - 1
+        if last_page >= len(seq.allocated_pages):
+            return
+        page = seq.allocated_pages[last_page]
+        if page.kv_position != PAGE_SIZE or page.phash[:8] == bytes(8):
+            return
+        rewind = self.recurrent_state.position - boundary
+        if rewind < 0 or rewind > self.recurrent_state.rollback_capacity():
+            return
+        if rewind:
+            self.recurrent_state.rewind(rewind)
+        self.last_recurrent_checkpoint_pos = boundary
+        cache.put(page.phash, self.recurrent_state, pinned_staging = pinned_staging)
+
+
     def find_recurrent_stash(self, target_pos: int):
         """
         Return the most recent page-aligned recurrent state stash at or before target_pos, refreshing its LRU

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -287,6 +287,9 @@ class Job:
         # Recurrent state
         self.recurrent_state = None
         self.last_recurrent_checkpoint_pos = None
+        # Set when a completion tail stash staged this state's slot on side streams: the slot's release is
+        # gated on these events (Cache.release_state_deferred)
+        self._stash_release_events = None
 
         # Loop detector
         self.loop_detector = None
@@ -1419,7 +1422,9 @@ class Job:
         if rewind:
             self.recurrent_state.rewind(rewind)
         self.last_recurrent_checkpoint_pos = boundary
-        cache.put(page.phash, self.recurrent_state, pinned_staging = pinned_staging)
+        events = cache.put(page.phash, self.recurrent_state, pinned_staging = pinned_staging)
+        if events:
+            self._stash_release_events = events
 
 
     def find_recurrent_stash(self, target_pos: int):
@@ -1438,7 +1443,13 @@ class Job:
 
     def free_recurrent_state(self):
         if self.recurrent_state is not None:
-            self.recurrent_state.free()
+            if self._stash_release_events:
+                # Side streams are still reading this slot for the tail stash; the pool reclaims it once
+                # the events fire
+                self.generator.cache.release_state_deferred(self.recurrent_state, self._stash_release_events)
+                self._stash_release_events = None
+            else:
+                self.recurrent_state.free()
             self.recurrent_state = None
 
 

--- a/exllamav3/modules/gated_delta_net.py
+++ b/exllamav3/modules/gated_delta_net.py
@@ -17,6 +17,8 @@ from ..cache.recurrent import (
     mp_cache_recurrent_unstash,
     mp_cache_recurrent_clear,
     new_checkpoint_handle,
+    stage_tensors_pinned,
+    stash_recurrent_layers,
 )
 from ..util import profile_opt
 from .attention_fn.bc_attn import MAX_BSZ as _BC_MAX_BSZ, MAX_QLEN as _BC_MAX_QLEN
@@ -121,14 +123,17 @@ class GDNState:
         return 0
 
 
-    def stash(self):
+    def stash(self, pinned_staging: bool = False):
         stashed = {
             "position": self.position,
             "checkpoint_size": self.checkpoint_size
         }
         if not self.cache.model.loaded_tp:
-            for k, l in self.cache.get_all_recurrent_layers().items():
-                stashed[k] = l.stash(self.slot)
+            stashed.update(stash_recurrent_layers(
+                self.cache,
+                self.slot,
+                pinned_staging = pinned_staging,
+            ))
         else:
             cp_handle = new_checkpoint_handle()
             self.cache.model.tp_dispatch_all(mp_cache_recurrent_stash, (id(self.cache), cp_handle, self.slot))
@@ -187,6 +192,7 @@ class GDNLayerState:
         self.max_history = max_history
         self.max_batch_size = max_batch_size
         self.cache_id = cache_id
+        self._pinned_stash_staging = None
 
 
     def get_checkpoint_size(self):
@@ -211,6 +217,7 @@ class GDNLayerState:
     def free(self):
         self.conv_state = torch.empty_like(self.conv_state, device = "meta")
         self.recurrent_state = torch.empty_like(self.recurrent_state, device = "meta")
+        self._pinned_stash_staging = None
         self.device = None
 
 
@@ -270,12 +277,15 @@ class GDNLayerState:
         )
 
 
-    def stash(self, slot, position: int = 0):
+    def stash(self, slot, position: int = 0, pinned_staging: bool = False, cursor: int | None = None):
         cdim = self.module.conv_kernel_size
-        return (
-            self.recurrent_state[slot, :1].cpu(),
-            self.conv_state[slot, :, :cdim].cpu()
+        tensors = (
+            self.recurrent_state[slot, :1],
+            self.conv_state[slot, :, :cdim],
         )
+        if pinned_staging:
+            return stage_tensors_pinned(self, tensors)
+        return tuple(t.cpu() for t in tensors)
 
 
     def unstash(self, slot, stashed, position: int = 0):

--- a/exllamav3/modules/gated_delta_net.py
+++ b/exllamav3/modules/gated_delta_net.py
@@ -129,11 +129,16 @@ class GDNState:
             "checkpoint_size": self.checkpoint_size
         }
         if not self.cache.model.loaded_tp:
-            stashed.update(stash_recurrent_layers(
+            result = stash_recurrent_layers(
                 self.cache,
                 self.slot,
                 pinned_staging = pinned_staging,
-            ))
+            )
+            if pinned_staging:
+                staged, events = result
+                stashed.update(staged)
+                return stashed, events
+            stashed.update(result)
         else:
             cp_handle = new_checkpoint_handle()
             self.cache.model.tp_dispatch_all(mp_cache_recurrent_stash, (id(self.cache), cp_handle, self.slot))

--- a/exllamav3/modules/short_conv.py
+++ b/exllamav3/modules/short_conv.py
@@ -12,6 +12,8 @@ from ..cache.recurrent import (
     mp_cache_recurrent_unstash,
     mp_cache_recurrent_clear,
     new_checkpoint_handle,
+    stage_tensors_pinned,
+    stash_recurrent_layers,
 )
 
 
@@ -81,14 +83,17 @@ class ShortConvState:
         return 0
 
 
-    def stash(self):
+    def stash(self, pinned_staging: bool = False):
         stashed = {
             "position": self.position,
             "checkpoint_size": self.checkpoint_size
         }
         if not self.cache.model.loaded_tp:
-            for k, l in self.cache.get_all_recurrent_layers().items():
-                stashed[k] = l.stash(self.slot)
+            stashed.update(stash_recurrent_layers(
+                self.cache,
+                self.slot,
+                pinned_staging = pinned_staging,
+            ))
         else:
             cp_handle = new_checkpoint_handle()
             self.cache.model.tp_dispatch_all(mp_cache_recurrent_stash, (id(self.cache), cp_handle, self.slot))
@@ -142,6 +147,7 @@ class ShortConvLayerState:
         self.max_history = max_history
         self.max_batch_size = max_batch_size
         self.cache_id = cache_id
+        self._pinned_stash_staging = None
 
 
     def get_checkpoint_size(self):
@@ -160,6 +166,7 @@ class ShortConvLayerState:
 
     def free(self):
         self.conv_state = torch.empty_like(self.conv_state, device = "meta")
+        self._pinned_stash_staging = None
         self.device = None
 
 
@@ -183,9 +190,10 @@ class ShortConvLayerState:
             c_state.copy_(temp)
 
 
-    def stash(self, slot, position: int = 0):
+    def stash(self, slot, position: int = 0, pinned_staging: bool = False, cursor: int | None = None):
         cdim = self.module.conv_kernel_size
-        return self.conv_state[slot, :, :cdim].cpu()
+        tensor = self.conv_state[slot, :, :cdim]
+        return stage_tensors_pinned(self, tensor) if pinned_staging else tensor.cpu()
 
 
     def unstash(self, slot, stashed, position: int = 0):

--- a/exllamav3/modules/short_conv.py
+++ b/exllamav3/modules/short_conv.py
@@ -89,11 +89,16 @@ class ShortConvState:
             "checkpoint_size": self.checkpoint_size
         }
         if not self.cache.model.loaded_tp:
-            stashed.update(stash_recurrent_layers(
+            result = stash_recurrent_layers(
                 self.cache,
                 self.slot,
                 pinned_staging = pinned_staging,
-            ))
+            )
+            if pinned_staging:
+                staged, events = result
+                stashed.update(staged)
+                return stashed, events
+            stashed.update(result)
         else:
             cp_handle = new_checkpoint_handle()
             self.cache.model.tp_dispatch_all(mp_cache_recurrent_stash, (id(self.cache), cp_handle, self.slot))

--- a/exllamav3/modules/sliding_attn.py
+++ b/exllamav3/modules/sliding_attn.py
@@ -15,6 +15,8 @@ from ..cache.recurrent import (
     mp_cache_recurrent_stash,
     mp_cache_recurrent_unstash,
     new_checkpoint_handle,
+    stage_tensors_pinned,
+    stash_recurrent_layers,
 )
 from ..model.model_tp_alloc import TPAllocation
 from ..util import profile_opt
@@ -89,15 +91,27 @@ class SWAState:
         return self.position - self.window_beg
 
 
-    def stash(self):
+    def stash(self, pinned_staging: bool = False):
         stashed = {
             "position": self.position,
             "checkpoint_size": self.checkpoint_size,
             "window_beg": self.window_beg,
         }
         if not self.cache.model.loaded_tp:
-            for k, l in self.cache.get_all_recurrent_layers().items():
-                stashed[k] = l.stash(self.slot, self.position)
+            # The live ring is left-aligned with write cursor position - window_beg. Slicing relative to the
+            # cursor makes stashing valid at any decode-time alignment, not just the exactly-full ring that
+            # page-aligned prefill checkpoints produce. The stash itself keeps the canonical layout unstash
+            # expects, so window_beg is rebased to match (all SWA layers must share one kv_state_size).
+            layers = self.cache.get_all_recurrent_layers()
+            state_size = next(iter(layers.values())).module.kv_state_size
+            stashed["window_beg"] = self.position - min(self.position, state_size)
+            stashed.update(stash_recurrent_layers(
+                self.cache,
+                self.slot,
+                self.position,
+                pinned_staging,
+                cursor = self.position - self.window_beg,
+            ))
         else:
             cp_handle = new_checkpoint_handle()
             self.cache.model.tp_dispatch_all(mp_cache_recurrent_stash, (id(self.cache), cp_handle, self.slot, self.position))
@@ -166,6 +180,7 @@ class SWALayerState:
         self.max_history = max_history
         self.max_batch_size = max_batch_size
         self.cache_id = cache_id
+        self._pinned_stash_staging = None
 
 
     def get_checkpoint_size(self):
@@ -199,6 +214,7 @@ class SWALayerState:
     def free(self):
         self.k_state = torch.empty_like(self.k_state, device = "meta")
         self.v_state = torch.empty_like(self.v_state, device = "meta")
+        self._pinned_stash_staging = None
         self.device = None
 
 
@@ -217,13 +233,18 @@ class SWALayerState:
         pass
 
 
-    def stash(self, slot, position):
-        b = min(self.module.kv_state_size, position)
+    def stash(self, slot, position, pinned_staging: bool = False, cursor: int | None = None):
+        # cursor is the ring's true content extent (position - window_beg); without it, fall back to assuming
+        # an exactly-full ring, which only page-aligned prefill checkpoints guarantee
+        b = min(self.module.kv_state_size, position) if cursor is None else cursor
         a = max(0, b - self.module.sliding_window)
-        return (
-            self.k_state[slot, a:b].cpu(),
-            self.v_state[slot, a:b].cpu()
+        tensors = (
+            self.k_state[slot, a:b],
+            self.v_state[slot, a:b],
         )
+        if pinned_staging:
+            return stage_tensors_pinned(self, tensors)
+        return tuple(t.cpu() for t in tensors)
 
 
     def unstash(self, slot, stashed, position):

--- a/exllamav3/modules/sliding_attn.py
+++ b/exllamav3/modules/sliding_attn.py
@@ -105,13 +105,18 @@ class SWAState:
             layers = self.cache.get_all_recurrent_layers()
             state_size = next(iter(layers.values())).module.kv_state_size
             stashed["window_beg"] = self.position - min(self.position, state_size)
-            stashed.update(stash_recurrent_layers(
+            result = stash_recurrent_layers(
                 self.cache,
                 self.slot,
                 self.position,
                 pinned_staging,
                 cursor = self.position - self.window_beg,
-            ))
+            )
+            if pinned_staging:
+                staged, events = result
+                stashed.update(staged)
+                return stashed, events
+            stashed.update(result)
         else:
             cp_handle = new_checkpoint_handle()
             self.cache.model.tp_dispatch_all(mp_cache_recurrent_stash, (id(self.cache), cp_handle, self.slot, self.position))

--- a/tests/test_tail_async.py
+++ b/tests/test_tail_async.py
@@ -1,0 +1,408 @@
+"""
+Tests for asynchronous recurrent tail stashing: background finalization of the pinned->pageable clone
+(RecurrentCache worker) and event-gated recurrent slot release (side-stream D2H, Cache.release_state_deferred).
+
+Unit tests (no model required):
+1. Cross-RecurrentCache staging guard: two caches sharing one Cache's pinned staging buffers must serialize
+   through the shared guard, or the second put() overwrites staging mid-clone.
+2. Event-gated slot reclaim state machine: polling reclaims only fired slots and never blocks; backpressure
+   blocks on the oldest pending release and frees exactly one slot.
+3. Failure paths synchronize: a put() failure after staging joins/synchronizes before propagating, and a
+   partial staging failure synchronizes the side streams it started, so cleanup's finally-block slot release
+   can never recycle a slot still being read.
+
+Integration (requires a hybrid SWA model, e.g. Gemma-4):
+4. Pending-join: a follow-up arriving while its conversation's tail stash is still finalizing must join the
+   pending future before restoring, verified with a slowed clone and a reader-side spy.
+5. Single-slot lifecycle: with one recurrent slot, a second thread's allocation must ride the blocking
+   backpressure path to claim the first thread's slot, and the first thread's stash must survive the slot
+   reuse (byte-matched against cold full prefill).
+
+The unit tests are plain pytest tests:
+
+    pytest tests/test_tail_async.py
+
+The integration tests run in script mode (units included):
+
+    python tests/test_tail_async.py --model <exl3 model dir>
+"""
+
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import argparse
+import torch
+from exllamav3 import Model, Config, Cache, Tokenizer, Generator, Job, GreedySampler
+from exllamav3.constants import PAGE_SIZE
+
+checks_passed = 0
+checks_failed = 0
+
+def check(name, cond, detail = ""):
+    global checks_passed, checks_failed
+    if cond:
+        checks_passed += 1
+        print(f"  PASS  {name}")
+    else:
+        checks_failed += 1
+        print(f"  FAIL  {name}")
+        if detail:
+            print(f"        {detail}")
+
+
+def test_staging_guard():
+    """
+    Multiple RecurrentCache instances can share one Cache and therefore its pinned staging buffers. put()
+    must join the staging guard on the shared Cache before restaging — a guard held only per RecurrentCache
+    lets a second cache overwrite staging while the first one's worker is still cloning from it.
+    """
+    print(" -- Unit: cross-RecurrentCache staging guard")
+    import exllamav3.cache.recurrent as rec
+    import time as time_mod
+
+    class _Dummy:
+        loaded_tp = False
+
+    class _DummyState:
+        def __init__(self, cache, position):
+            self.cache = cache
+            self.position = position
+        def stash(self, pinned_staging = False):
+            stashed = {"position": self.position, "checkpoint_size": 8,
+                       ("layer", 0): torch.full((4,), float(self.position))}
+            return (stashed, []) if pinned_staging else stashed
+
+    shared_cache = _Dummy()
+    order = []
+    orig_finalize = rec._finalize_stash
+    def slow_finalize(stashed, events = None):
+        time_mod.sleep(0.3)
+        order.append(("clone_done", stashed["position"]))
+        orig_finalize(stashed, events)
+    rec._finalize_stash = slow_finalize
+    try:
+        rc_a = rec.RecurrentCache(_Dummy(), max_size = 1024)
+        rc_b = rec.RecurrentCache(_Dummy(), max_size = 1024)
+        rc_a.put(b"a", _DummyState(shared_cache, 1), pinned_staging = True)
+        rc_b.put(b"b", _DummyState(shared_cache, 2), pinned_staging = True)
+        order.append(("put_b_done", None))
+        rc_b.drain()
+        rc_a.drain()
+        assert ("clone_done", 1) in order and order.index(("clone_done", 1)) < order.index(("put_b_done", None)), \
+            f"second cache's put must join the shared staging guard: order = {order}"
+    finally:
+        rec._finalize_stash = orig_finalize
+
+
+def test_slot_reclaim():
+    """
+    State machine for event-gated slot release: slots return to the pool only when their stash events have
+    fired; polling never blocks; backpressure (_ensure_free_slot) blocks on the oldest pending release and
+    frees exactly one slot.
+    """
+    print(" -- Unit: event-gated slot reclaim")
+    from types import SimpleNamespace
+    from exllamav3.cache.cache import Cache
+
+    class _FakeEvent:
+        def __init__(self):
+            self.fired = False
+            self.sync_calls = 0
+        def query(self):
+            return self.fired
+        def synchronize(self):
+            self.sync_calls += 1
+            self.fired = True
+
+    pool = SimpleNamespace(free_list = __import__("collections").deque(), pending_slot_releases = [])
+    pool.reclaim_slots = lambda **kw: Cache.reclaim_slots(pool, **kw)
+    ev_a, ev_b = _FakeEvent(), _FakeEvent()
+    Cache.release_state_deferred(pool, SimpleNamespace(slot = 0), [ev_a])
+    Cache.release_state_deferred(pool, SimpleNamespace(slot = 1), [ev_b])
+
+    Cache.reclaim_slots(pool)
+    assert len(pool.free_list) == 0 and len(pool.pending_slot_releases) == 2, "unfired events keep slots pending"
+
+    ev_b.fired = True
+    Cache.reclaim_slots(pool)
+    assert list(pool.free_list) == [1] and len(pool.pending_slot_releases) == 1, "polling reclaims only fired slots"
+
+    pool.free_list.clear()
+    Cache._ensure_free_slot(pool)
+    assert ev_a.sync_calls == 1 and list(pool.free_list) == [0] and not pool.pending_slot_releases, \
+        f"backpressure must block on the oldest pending release: sync_calls = {ev_a.sync_calls}, free = {list(pool.free_list)}"
+
+
+def test_stash_failure_synchronizes():
+    """
+    Once a pinned stash has returned events, any later put() failure must synchronize them before propagating:
+    cleanup releases the state in a finally block and otherwise could recycle a slot still being read.
+    """
+    print(" -- Unit: failed stash setup synchronizes queued events")
+    import exllamav3.cache.recurrent as rec
+
+    class _Dummy:
+        loaded_tp = False
+
+    class _FakeEvent:
+        def __init__(self):
+            self.sync_calls = 0
+        def synchronize(self):
+            self.sync_calls += 1
+
+    event = _FakeEvent()
+    shared_cache = _Dummy()
+
+    class _DummyState:
+        cache = shared_cache
+        def stash(self, pinned_staging = False):
+            stashed = {"position": 1, "checkpoint_size": 8,
+                       ("layer", 0): torch.zeros(1)}
+            return (stashed, [event]) if pinned_staging else stashed
+
+    # max_size smaller than one checkpoint fails during eviction, after state.stash() returned its events
+    rc = rec.RecurrentCache(_Dummy(), max_size = 0)
+    try:
+        rc.put(b"oversized", _DummyState(), pinned_staging = True)
+    except (AssertionError, KeyError):
+        pass
+    else:
+        raise AssertionError("oversized recurrent stash did not raise")
+    assert event.sync_calls == 1, \
+        f"failed recurrent stash must synchronize queued events: sync_calls = {event.sync_calls}"
+
+    class _FakeSide:
+        def __init__(self):
+            self.sync_calls = 0
+        def wait_stream(self, other):
+            pass
+        def synchronize(self):
+            self.sync_calls += 1
+
+    class _FakeStreamContext:
+        def __enter__(self):
+            pass
+        def __exit__(self, *args):
+            pass
+
+    class _Layer:
+        device = "cuda:0"
+        def __init__(self, fail = False):
+            self.fail = fail
+        def stash(self, *args, **kwargs):
+            if self.fail:
+                raise RuntimeError("injected staging failure")
+            return torch.zeros(1)
+
+    class _LayerCache:
+        def get_all_recurrent_layers(self):
+            return {(0, 0): _Layer(), (1, 0): _Layer(fail = True)}
+
+    fake_side = _FakeSide()
+    orig_stream_ctor = rec.torch.cuda.Stream
+    orig_current_stream = rec.torch.cuda.current_stream
+    orig_stream_context = rec.torch.cuda.stream
+    rec.torch.cuda.Stream = lambda **kwargs: fake_side
+    rec.torch.cuda.current_stream = lambda device = None: object()
+    rec.torch.cuda.stream = lambda side: _FakeStreamContext()
+    try:
+        try:
+            rec.stash_recurrent_layers(_LayerCache(), 0, pinned_staging = True)
+        except RuntimeError as exc:
+            assert str(exc) == "injected staging failure"
+        else:
+            raise AssertionError("partial recurrent staging did not raise")
+    finally:
+        rec.torch.cuda.Stream = orig_stream_ctor
+        rec.torch.cuda.current_stream = orig_current_stream
+        rec.torch.cuda.stream = orig_stream_context
+    assert fake_side.sync_calls == 1, \
+        f"partial recurrent staging must synchronize its side stream: sync_calls = {fake_side.sync_calls}"
+
+
+def make_long_prompt(tokenizer, seed_text, target_pages):
+    text = seed_text
+    filler = (
+        " The archive records further details, cross-referenced against seasonal observations"
+        " and the incidental notes of several field assistants over many years of study."
+    )
+    while tokenizer.encode(text).shape[-1] < target_pages * PAGE_SIZE + 16:
+        text += filler
+    return text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required = True,
+                    help = "exl3 model directory of a hybrid-attention model with recurrent SWA layers "
+                           "(e.g. Gemma-4)")
+    ap.add_argument("--cache_size", type = int, default = 8192)
+    ap.add_argument("--max_batch_size", type = int, default = 16,
+                    help = "Recurrent state slots per cache; the test itself is batch-1, so this can be "
+                           "lowered to fit large hybrid models on smaller GPUs")
+    args = ap.parse_args()
+
+    for unit in (test_staging_guard, test_slot_reclaim, test_stash_failure_synchronizes):
+        try:
+            unit()
+            check(unit.__name__, True)
+        except AssertionError as e:
+            check(unit.__name__, False, str(e))
+
+    print(f" -- Loading model: {args.model}")
+    config = Config.from_directory(args.model)
+    model = Model.from_config(config, swa_full = False)
+    cache_main = Cache(model, max_num_tokens = args.cache_size, max_batch_size = args.max_batch_size)
+    cache_ctrl = Cache(model, max_num_tokens = args.cache_size, max_batch_size = args.max_batch_size)
+    # Single recurrent slot: forces the event-gated slot-release backpressure path in hybrid mode
+    cache_slot = Cache(model, max_num_tokens = args.cache_size, max_batch_size = 1)
+    model.load(progressbar = True)
+    tokenizer = Tokenizer.from_config(config)
+    sampler = GreedySampler()
+
+    generator = Generator(model = model, cache = cache_main, tokenizer = tokenizer)
+    if generator.recurrent_cache is None:
+        print(" -- Model has no recurrent states; tail checkpoints do not apply. Skipping integration.")
+        sys.exit(1 if checks_failed else 0)
+    if not getattr(generator.cache.recurrent_state_cls, "guaranteed_rollback", 0):
+        print(" -- Recurrent state has no guaranteed rollback (e.g. GDN); tail checkpoints keep default")
+        print("    behavior on this architecture by design. Skipping integration.")
+        sys.exit(1 if checks_failed else 0)
+
+    prompt_a = make_long_prompt(
+        tokenizer,
+        "The migration of songbirds across continents follows magnetic fields and stellar cues.", 6)
+    a_ids = tokenizer.encode(prompt_a)
+    extra_ids = tokenizer.encode(" Now summarize the above in one sentence.", add_bos = False)
+    print(f" -- prompt A: {a_ids.shape[-1]} tokens ({a_ids.shape[-1] // PAGE_SIZE} full pages)")
+
+    def drive_enqueued_job(gen, cleanup_tail = True, leave_deferred = False):
+        out, eos_r = [], None
+        while gen.num_remaining_jobs():
+            for r in gen.iterate():
+                t = r.get("token_ids")
+                if t is not None:
+                    out.append(t)
+                if r.get("eos"):
+                    eos_r = r
+            if eos_r is not None and leave_deferred:
+                break
+            if eos_r is not None and not cleanup_tail:
+                # A cold correctness reference does not need to populate the recurrent cache. Release its
+                # deferred state without allocating another model-sized pinned tail-staging buffer.
+                gen.clear_queue()
+                break
+        out_ids = torch.cat(out, dim = -1) if out else torch.empty((1, 0), dtype = torch.long)
+        return out_ids, eos_r
+
+    def run_job_ids(gen, ids, max_new, cleanup_tail = True, leave_deferred = False):
+        # Token-level Job API: continuation prompts are built from exact ids, avoiding tokenization-seam
+        # ambiguity at the prompt/response join
+        job = Job(input_ids = ids, max_new_tokens = max_new, sampler = sampler)
+        gen.enqueue(job)
+        return drive_enqueued_job(gen, cleanup_tail, leave_deferred)
+
+    # Background-clone join: slow the pinned->pageable clone so the follow-up request provably arrives while
+    # its thread's tail stash is still pending. The follow-up's enqueue() submits the clone and the same
+    # request then restores the entry, so wait_stash_ready must block and join.
+    print(" -- Pending-join: restore while background finalization is in flight")
+    import exllamav3.cache.recurrent as recurrent_mod
+    import time as time_mod
+    orig_clone = recurrent_mod.clone_staged_tensors
+    def slow_clone(tensors):
+        time_mod.sleep(0.25)
+        return orig_clone(tensors)
+    recurrent_mod.clone_staged_tensors = slow_clone
+    # Spy on the reader-side join: the warm resume must observe a genuinely pending finalization, otherwise
+    # this test cannot distinguish a working join from no join at all
+    join_saw_pending = []
+    orig_wait = recurrent_mod.wait_stash_ready
+    def spy_wait(stashed):
+        fut = stashed.get("pending")
+        join_saw_pending.append(fut is not None and not fut.done())
+        orig_wait(stashed)
+    recurrent_mod.wait_stash_ready = spy_wait
+    try:
+        pend_base = torch.cat([
+            a_ids, tokenizer.encode(" Pending-join case follows now.", add_bos = False)], dim = -1)
+        gen_n = (pend_base.shape[-1] // PAGE_SIZE + 1) * PAGE_SIZE - pend_base.shape[-1] + 1 + 30
+        resp_p, _ = run_job_ids(generator, pend_base, gen_n)
+        pend_ids = torch.cat([pend_base, resp_p, extra_ids], dim = -1)
+        cold_gen = Generator(model = model, cache = cache_ctrl, tokenizer = tokenizer)
+        cold_p, _ = run_job_ids(cold_gen, pend_ids, 12, cleanup_tail = False)
+        warm_p, eos_p = run_job_ids(generator, pend_ids, 12)
+        pend_boundary = (pend_base.shape[-1] + resp_p.shape[-1]) // PAGE_SIZE * PAGE_SIZE
+        check("pending-join: resumed from the tail checkpoint",
+              eos_p["cached_tokens"] >= pend_boundary,
+              f"cached_tokens = {eos_p['cached_tokens']}, expected >= {pend_boundary}")
+        check("pending-join: resumed output matches cold full-prefill",
+              torch.equal(warm_p, cold_p),
+              f"warm ids = {warm_p.tolist()}\ncold ids = {cold_p.tolist()}")
+        check("pending-join: restore joined a genuinely pending finalization",
+              any(join_saw_pending),
+              f"join_saw_pending = {join_saw_pending} (no restore observed an unfinished clone)")
+    finally:
+        recurrent_mod.clone_staged_tensors = orig_clone
+        recurrent_mod.wait_stash_ready = orig_wait
+
+    # Single-slot lifecycle: make A's release events report pending to nonblocking polls until the allocator
+    # explicitly synchronizes them. B must therefore ride the backpressure path when claiming A's only slot;
+    # resuming A afterwards also proves its stash retained A's ring bytes across the reuse.
+    print(" -- Single-slot lifecycle: blocking backpressure and stash survival across slot reuse")
+    slot_gen = Generator(model = model, cache = cache_slot, tokenizer = tokenizer)
+    sa_ids = torch.cat([
+        a_ids[:, :640], tokenizer.encode(" Single-slot thread A continues here.", add_bos = False)], dim = -1)
+    sb_ids = torch.cat([
+        a_ids[:, :640], tokenizer.encode(" Single-slot thread B differs entirely.", add_bos = False)], dim = -1)
+    gen_a = (sa_ids.shape[-1] // PAGE_SIZE + 1) * PAGE_SIZE - sa_ids.shape[-1] + 1 + 20
+    resp_sa, _ = run_job_ids(slot_gen, sa_ids, gen_a, leave_deferred = True)
+    job_sb = Job(input_ids = sb_ids, max_new_tokens = 24, sampler = sampler)
+    slot_gen.enqueue(job_sb)  # runs A's cleanup and registers its deferred slot release
+    check("single-slot: A's slot release was deferred",
+          len(cache_slot.pending_slot_releases) == 1,
+          f"pending releases = {len(cache_slot.pending_slot_releases)}")
+
+    import threading
+    main_thread = threading.current_thread()
+    backpressure_syncs = []
+
+    class _PendingUntilAllocatorSync:
+        def __init__(self, inner):
+            self.inner = inner
+            self.allocator_synced = False
+        def query(self):
+            return self.allocator_synced and self.inner.query()
+        def synchronize(self):
+            self.inner.synchronize()
+            if threading.current_thread() is main_thread:
+                self.allocator_synced = True
+                backpressure_syncs.append(1)
+
+    # Give the pending-slot queue a wrapped list while leaving the clone future's event list untouched.
+    # Polling reports pending until _ensure_free_slot synchronizes the wrappers on the main thread.
+    if cache_slot.pending_slot_releases:
+        release_slot, release_events = cache_slot.pending_slot_releases[0]
+        wrapped_events = [_PendingUntilAllocatorSync(ev) for ev in release_events]
+        cache_slot.pending_slot_releases[0] = (release_slot, wrapped_events)
+    resp_sb, _ = drive_enqueued_job(slot_gen)
+    check("single-slot: allocation used blocking backpressure",
+          bool(backpressure_syncs),
+          "the only slot was reclaimed without allocator-side event synchronization")
+    check("single-slot: second thread generates through the reused slot", resp_sb.shape[-1] > 0)
+    cont_sa = torch.cat([sa_ids, resp_sa, extra_ids], dim = -1)
+    cold_gen = Generator(model = model, cache = cache_ctrl, tokenizer = tokenizer)
+    cold_sa, _ = run_job_ids(cold_gen, cont_sa, 12, cleanup_tail = False)
+    warm_sa, eos_sa = run_job_ids(slot_gen, cont_sa, 12)
+    sa_boundary = (sa_ids.shape[-1] + resp_sa.shape[-1]) // PAGE_SIZE * PAGE_SIZE
+    check("single-slot: thread A resumes from its tail checkpoint",
+          eos_sa["cached_tokens"] >= sa_boundary,
+          f"cached_tokens = {eos_sa['cached_tokens']}, expected >= {sa_boundary}")
+    check("single-slot: resumed output matches cold full-prefill",
+          torch.equal(warm_sa, cold_sa),
+          f"warm ids = {warm_sa.tolist()}\ncold ids = {cold_sa.tolist()}")
+
+    print(f"\n -- {checks_passed} passed, {checks_failed} failed")
+    sys.exit(1 if checks_failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tail_checkpoints.py
+++ b/tests/test_tail_checkpoints.py
@@ -1,0 +1,247 @@
+"""
+Integration test for completion tail checkpoints on hybrid recurrent models.
+
+Loads a real model with SWA layers in recurrent mode and verifies, with greedy sampling:
+
+1. Continuation matrix: a completed request leaves a page-aligned recurrent tail checkpoint,
+   and a follow-up request extending the same conversation resumes within one page of its end
+   instead of at the last interval checkpoint. Each case compares the resumed output
+   token-for-token against a cold full-prefill reference from a separate page table, which
+   catches a state stored under the right page hash at the wrong ring alignment. The sweep
+   covers rewind distances 1/40/254 across the cursor alignment band, plus the exact-boundary
+   case whose final sampled token is never forwarded (rewind 255, previous-boundary fallback).
+2. Enqueue-triggered cleanup: a caller that stops driving iterate() at EOS leaves the
+   completed job deferred; enqueue() must run the cleanup (under inference mode) without
+   crashing.
+3. Requeue coinciding with EOS: a job whose max_rq_tokens round-trip lands exactly on its
+   max_new_tokens EOS must complete (requeue suppressed), reach the deferred-cleanup path,
+   and leave a usable tail checkpoint.
+
+Requires a GPU and an exl3 model directory of a hybrid-attention model whose recurrent state
+supports in-place rollback (e.g. Gemma-4 with SWA layers in recurrent mode):
+
+    python tests/test_tail_checkpoints.py --model <exl3 model dir>
+
+Note for linear-attention models (e.g. GDN): states without guaranteed_rollback keep default
+checkpoint behavior by design, and their scan kernels are not run-to-run deterministic, so
+this test skips the matrix for them.
+"""
+
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import argparse
+import torch
+from exllamav3 import Model, Config, Cache, Tokenizer, Generator, Job, GreedySampler
+from exllamav3.constants import PAGE_SIZE
+
+checks_passed = 0
+checks_failed = 0
+
+def check(name, cond, detail = ""):
+    global checks_passed, checks_failed
+    if cond:
+        checks_passed += 1
+        print(f"  PASS  {name}")
+    else:
+        checks_failed += 1
+        print(f"  FAIL  {name}")
+        if detail:
+            print(f"        {detail}")
+
+
+def make_long_prompt(tokenizer, seed_text, target_pages):
+    # Tokenize while growing: character-count heuristics undershoot on tokenizers that compress
+    # repetitive filler well, and the test needs a guaranteed number of full pages
+    text = seed_text
+    filler = (
+        " The archive records further details, cross-referenced against seasonal observations"
+        " and the incidental notes of several field assistants over many years of study."
+    )
+    while tokenizer.encode(text).shape[-1] < target_pages * PAGE_SIZE + 16:
+        text += filler
+    return text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required = True,
+                    help = "exl3 model directory of a hybrid-attention model with recurrent SWA layers "
+                           "(e.g. Gemma-4)")
+    ap.add_argument("--cache_size", type = int, default = 8192)
+    ap.add_argument("--max_batch_size", type = int, default = 16,
+                    help = "Recurrent state slots per cache; the test itself is batch-1, so this can be "
+                           "lowered to fit large hybrid models on smaller GPUs")
+    args = ap.parse_args()
+
+    print(f" -- Loading model: {args.model}")
+    config = Config.from_directory(args.model)
+    model = Model.from_config(config, swa_full = False)
+    cache_main = Cache(model, max_num_tokens = args.cache_size, max_batch_size = args.max_batch_size)
+    cache_ctrl = Cache(model, max_num_tokens = args.cache_size, max_batch_size = args.max_batch_size)
+    model.load(progressbar = True)
+    tokenizer = Tokenizer.from_config(config)
+    sampler = GreedySampler()
+
+    generator = Generator(model = model, cache = cache_main, tokenizer = tokenizer)
+    if generator.recurrent_cache is None:
+        print(" -- Model has no recurrent states; tail checkpoints do not apply. Skipping.")
+        sys.exit(0)
+
+    prompt_a = make_long_prompt(
+        tokenizer,
+        "The migration of songbirds across continents follows magnetic fields and stellar cues.", 6)
+    a_ids = tokenizer.encode(prompt_a)
+    print(f" -- prompt A: {a_ids.shape[-1]} tokens ({a_ids.shape[-1] // PAGE_SIZE} full pages)")
+
+    def run_job_ids(gen, ids, max_new, cleanup_tail = True, max_rq_tokens = None):
+        # Token-level Job API: continuation prompts are built from exact ids, avoiding tokenization-seam
+        # ambiguity at the prompt/response join
+        job = Job(input_ids = ids, max_new_tokens = max_new, sampler = sampler,
+                  max_rq_tokens = max_rq_tokens)
+        gen.enqueue(job)
+        out, eos_r = [], None
+        while gen.num_remaining_jobs():
+            for r in gen.iterate():
+                t = r.get("token_ids")
+                if t is not None:
+                    out.append(t)
+                if r.get("eos"):
+                    eos_r = r
+            if eos_r is not None and not cleanup_tail:
+                # A cold correctness reference does not need to populate the recurrent cache. Release its
+                # deferred state without allocating another model-sized pinned tail-staging buffer.
+                gen.clear_queue()
+                break
+        out_ids = torch.cat(out, dim = -1) if out else torch.empty((1, 0), dtype = torch.long)
+        return out_ids, eos_r
+
+    # Tail checkpoints engage only for recurrent state types with guaranteed in-place rollback
+    rollback_ok = getattr(generator.cache.recurrent_state_cls, "guaranteed_rollback", 0) > 0
+    if not rollback_ok:
+        print(" -- Recurrent state has no guaranteed rollback (e.g. GDN); tail checkpoints keep default")
+        print("    behavior on this architecture by design. Skipping matrix.")
+        sys.exit(0)
+
+    mid_case_ids = torch.cat([
+        a_ids,
+        tokenizer.encode(" A separate continuation-check branch follows.", add_bos = False),
+    ], dim = -1)
+    extra_ids = tokenizer.encode(" Now summarize the above in one sentence.", add_bos = False)
+
+    def check_continuation_case(name, base_ids, tail_offset, exact_boundary, expected_rewind,
+                                extra_pages = 1):
+        prompt_boundary = base_ids.shape[-1] // PAGE_SIZE * PAGE_SIZE
+        target_boundary = prompt_boundary + extra_pages * PAGE_SIZE
+        # Job's token-level limit includes the already-pending first decode position, hence the +1.
+        generated_tokens = target_boundary - base_ids.shape[-1] + 1 + tail_offset
+        resp_ids, _ = run_job_ids(generator, base_ids, generated_tokens)
+        prev_ids = torch.cat([base_ids, resp_ids], dim = -1)
+        prev_boundary = prev_ids.shape[-1] // PAGE_SIZE * PAGE_SIZE
+        check(f"{name}: setup crosses a new page boundary", prev_boundary > prompt_boundary,
+              f"prev len = {prev_ids.shape[-1]}, boundary = {prev_boundary}, "
+              f"prompt pages end = {prompt_boundary}")
+        if exact_boundary:
+            check(f"{name}: completion ends exactly on the boundary",
+                  prev_ids.shape[-1] == prev_boundary,
+                  f"prev len = {prev_ids.shape[-1]}, boundary = {prev_boundary}")
+        # Recurrent position at completion is prev len - 1 (the final sampled token is never forwarded)
+        stash_target = prev_boundary - PAGE_SIZE if exact_boundary else prev_boundary
+        actual_rewind = prev_ids.shape[-1] - 1 - stash_target
+        check(f"{name}: exercises the intended rewind distance", actual_rewind == expected_rewind,
+              f"actual rewind = {actual_rewind}, intended = {expected_rewind}")
+
+        cont_ids = torch.cat([prev_ids, extra_ids], dim = -1)
+        # A separate page table has no matching KV pages or recurrent checkpoints, providing a full-prefill
+        # reference. This catches a state stored under the right page hash at the wrong ring alignment.
+        cold_gen = Generator(model = model, cache = cache_ctrl, tokenizer = tokenizer)
+        cold_out, _ = run_job_ids(cold_gen, cont_ids, 16, cleanup_tail = False)
+
+        warm_out, eos_r = run_job_ids(generator, cont_ids, 16)
+        cached_cont = eos_r["cached_tokens"]
+        # The final sampled token's K/V is never forwarded, so a completion landing exactly on a page
+        # boundary stashes at the previous boundary instead
+        resume_floor = prev_boundary - PAGE_SIZE if exact_boundary else prev_boundary
+        check(f"{name}: resumes within a page of the previous request's end",
+              cached_cont >= resume_floor,
+              f"cached_tokens = {cached_cont}, expected >= {resume_floor} "
+              f"(a cap at {prompt_boundary} means no post-generation resume point exists)")
+        check(f"{name}: resumed output matches cold full-prefill",
+              torch.equal(warm_out, cold_out),
+              f"warm ids = {warm_out.tolist()}\ncold ids = {cold_out.tolist()}")
+
+    print(" -- Conversation continuation: hybrid resume granularity after a completed generation")
+    # The exact case proves the previous-boundary fallback for a final sampled token that was never
+    # forwarded: it generates through TWO new pages so the fallback target is itself a post-generation
+    # boundary that only completion cleanup can have stashed (the prompt-tail checkpoint cannot satisfy
+    # it). The mid-page cases prove decode-time stashes are ring-cursor-correct: tail_offset = N yields a
+    # rewind of N - 1, and the sweep covers both edges of the alignment band. Distinct histories per case
+    # so none can silently reuse another case's tail checkpoint.
+    sweep_lo_ids = torch.cat([
+        a_ids, tokenizer.encode(" Cursor sweep low-edge case follows.", add_bos = False)], dim = -1)
+    sweep_hi_ids = torch.cat([
+        a_ids, tokenizer.encode(" Cursor sweep high-edge case instead.", add_bos = False)], dim = -1)
+    check_continuation_case("exact-boundary continuation", a_ids, 0, True, 255, extra_pages = 2)
+    check_continuation_case("mid-page continuation", mid_case_ids, 41, False, 40)
+    check_continuation_case("mid-page continuation (rewind 1)", sweep_lo_ids, 2, False, 1)
+    check_continuation_case("mid-page continuation (rewind 254)", sweep_hi_ids, 255, False, 254)
+
+    # Deferred cleanup must also work when triggered from enqueue() rather than iterate(): a caller that
+    # stops driving iterate() at EOS leaves the completed job deferred, and enqueue() has no inference-mode
+    # decorator of its own. Regression for an unstash inference-tensor crash on that path.
+    print(" -- Enqueue-triggered deferred cleanup")
+    job = Job(input_ids = a_ids, max_new_tokens = 40, sampler = sampler)
+    generator.enqueue(job)
+    eos_seen = False
+    while generator.num_remaining_jobs() and not eos_seen:
+        for r in generator.iterate():
+            if r.get("eos"):
+                eos_seen = True
+    try:
+        follow_up, _ = run_job_ids(generator, a_ids, 8)   # enqueue() triggers the deferred cleanup
+        check("enqueue-triggered deferred cleanup does not crash", follow_up.shape[-1] > 0)
+    except RuntimeError as e:
+        check("enqueue-triggered deferred cleanup does not crash", False, str(e))
+
+    # A requeue that coincides with EOS is suppressed and the job completes; it must then flow through the
+    # deferred-cleanup path like any completion and leave a usable tail checkpoint. On recurrent models
+    # max_rq_tokens snaps up to the next recurrent_checkpoint_interval boundary, so a dedicated generator
+    # pins the interval to PAGE_SIZE, the snapped threshold is recomputed with the Job's own formula, and
+    # max_new_tokens = snapped + 1 makes the EOS step provably the first requeue-trigger step.
+    print(" -- Requeue coinciding with EOS")
+    rq_case_ids = torch.cat([
+        a_ids, tokenizer.encode(" Requeue coincidence case follows here.", add_bos = False)], dim = -1)
+    x = rq_case_ids.shape[-1]
+    # Snap target two boundaries out, so the exact-boundary fallback target (y - PAGE_SIZE) is itself a
+    # post-generation boundary that only completion cleanup can have stashed
+    y = (x - 1 + 8 + PAGE_SIZE + PAGE_SIZE - 1) // PAGE_SIZE * PAGE_SIZE
+    snapped = y - x
+    rq_gen = Generator(model = model, cache = cache_main, tokenizer = tokenizer,
+                       recurrent_checkpoint_interval = PAGE_SIZE)
+    # max_new_tokens includes the already-pending first decode position: the job emits snapped tokens and its
+    # completion lands exactly on the boundary y, while new_tokens reaches snapped + 1 > max_rq_tokens on the
+    # EOS step, making that step the first (and only) requeue trigger
+    resp_ids, eos_r = run_job_ids(rq_gen, rq_case_ids, snapped + 1, max_rq_tokens = 8 + PAGE_SIZE)
+    check("requeue-at-EOS: job completes in one round with EOS",
+          eos_r is not None and resp_ids.shape[-1] == snapped,
+          f"generated = {resp_ids.shape[-1]}, expected {snapped}")
+    # Only the suppression path can have delivered this EOS; the tail checkpoint proves the job then went
+    # through deferred cleanup like any completion (previous-boundary fallback, since the completion ends
+    # exactly on y)
+    cont_ids = torch.cat([rq_case_ids, resp_ids, extra_ids], dim = -1)
+    cold_gen = Generator(model = model, cache = cache_ctrl, tokenizer = tokenizer)
+    cold_out, _ = run_job_ids(cold_gen, cont_ids, 16, cleanup_tail = False)
+    warm_out, w_eos = run_job_ids(rq_gen, cont_ids, 16)
+    check("requeue-at-EOS: suppressed-requeue completion leaves a usable tail checkpoint",
+          w_eos["cached_tokens"] >= y - PAGE_SIZE,
+          f"cached_tokens = {w_eos['cached_tokens']}, expected >= {y - PAGE_SIZE} "
+          f"(prompt pages end at {x // PAGE_SIZE * PAGE_SIZE})")
+    check("requeue-at-EOS: resumed output matches cold full-prefill",
+          torch.equal(warm_out, cold_out),
+          f"warm ids = {warm_out.tolist()}\ncold ids = {cold_out.tolist()}")
+
+    print(f"\n -- {checks_passed} passed, {checks_failed} failed")
+    sys.exit(1 if checks_failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Third PR in the series (#264, #265) rebasing my independently developed prefix-cache work onto dev. **Stacks on #265** — opening as a draft; I'll rebase and mark ready when that merges. The diff to read is the second commit only.

#265 keeps the tail-checkpoint work out of the EOS delivery path but still pays for it synchronously in the deferred-cleanup pass: D2H into pinned staging, device sync, pageable clone — ~100 ms per completed request on Gemma4-31B. This PR makes the whole sequence asynchronous, in two stages:

- **Background finalization:** the pinned→pageable clone runs on a worker owned by the `RecurrentCache`. Entries are inserted immediately with a `pending` future; `Cache.new_from_stashed` joins it before any restore — one choke point for all resume paths. The staging-reuse guard lives on the `Cache` (which owns the pinned buffers), since multiple `RecurrentCache` instances can share one.
- **Event-gated slot release:** the D2H copies stage on per-device side streams gated by CUDA events, and the recurrent slot returns to the pool only once the events fire (`release_state_deferred`) — cheap polls at cleanup entry, blocking backpressure on the oldest pending release when every slot is live or awaiting events.

Deferred cleanup drops to ~1–2 ms steady-state on 31B, with the copies overlapping ongoing compute.

Failure paths are conservative: partial staging failures synchronize the side streams they started, and a `put()` failure after staging joins/synchronizes before propagating, so cleanup's finally-block slot release can never recycle a slot still being read. Evicting a still-pending entry (LRU pressure or `prune_stranded`) is safe — the worker fills an orphaned dict.

**Tests** (`tests/test_tail_async.py`): staging-guard, slot-reclaim state machine, and failure-path units run model-free under plain `pytest`; integration adds a pending-join case (a restore provably joins an in-flight finalization) and a single-slot lifecycle that forces the blocking backpressure path and byte-matches the stash across slot reuse. Script mode 11/11 + pytest 3/3, and the #265 suite re-run 21/21, on gemma-4-31B.
