### PR TITLE
Cache statistics for production sizing (Generator.get_cache_stats)

### DIFF
--- a/exllamav3/cache/recurrent.py
+++ b/exllamav3/cache/recurrent.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import time
 from ..constants import PAGE_SIZE
 
 class RecurrentCache(OrderedDict):
@@ -21,6 +22,37 @@ class RecurrentCache(OrderedDict):
             "stash_pruned": 0,              # stranded checkpoints dropped by prune_stranded()
         }
 
+        # Eviction ages measure the retention window this budget provides under live traffic; a young
+        # minimum means checkpoints are being discarded before their conversations return. Only restorable
+        # (LRU) evictions are recorded: dropping a stranded checkpoint frees dead weight, not retention.
+        self.evicted_count = 0
+        self.evicted_age_sum = 0.0
+        self.evicted_age_min_window = None
+        # Bounded memory of recently LRU-evicted keys, so restore-time misses can distinguish "checkpoint
+        # was evicted" (budget problem) from "checkpoint never existed or was stranded" (interval, state
+        # policy or KV eviction — more recurrent memory cannot help). ~10k keys of 16 bytes.
+        self._evicted_keys = OrderedDict()
+        self._evicted_keys_max = 10000
+
+
+    def was_evicted(self, key) -> bool:
+        return key in self._evicted_keys
+
+
+    def stats(self, reset_window: bool = False) -> dict:
+        s = {
+            "entries": len(self),
+            "bytes_used": self.current_size,
+            "bytes_max": self.max_size,
+            "evicted_count": self.evicted_count,
+            "evicted_age_sum": self.evicted_age_sum,
+            "evicted_age_min_window": self.evicted_age_min_window,
+        }
+        s.update(self.metrics)
+        if reset_window:
+            self.evicted_age_min_window = None
+        return s
+
 
     def get_stashed(self, key, default = None):
         """
@@ -40,6 +72,7 @@ class RecurrentCache(OrderedDict):
             self.move_to_end(key)
         else:
             stashed_state = state.stash()
+            stashed_state["stash_time"] = time.time()
             state_size = stashed_state["checkpoint_size"]
             while self.update_total_size() + state_size > self.max_size:
                 assert self.current_size >= 0, "Not enough space in cache for single state"
@@ -64,12 +97,23 @@ class RecurrentCache(OrderedDict):
                         page = pt.referenced_pages.get(popped_key) or pt.unreferenced_pages.get(popped_key)
                         if page is not None and page.kv_position == PAGE_SIZE:
                             self.metrics["stash_evictions_live_kv"] += 1
+                    # Retention-window accounting and the evicted-key memory cover only this restorable
+                    # (LRU pressure) path; see __init__
+                    age = time.time() - popped.get("stash_time", time.time())
+                    self.evicted_count += 1
+                    self.evicted_age_sum += age
+                    if self.evicted_age_min_window is None or age < self.evicted_age_min_window:
+                        self.evicted_age_min_window = age
+                    self._evicted_keys[popped_key] = None
+                    while len(self._evicted_keys) > self._evicted_keys_max:
+                        self._evicted_keys.popitem(last = False)
 
                 self.metrics["stash_evictions"] += 1
                 if self.model.loaded_tp:
                     self.model.tp_dispatch_all(mp_cache_recurrent_del, (id(self), popped["tp_handle"]))
 
             self[key] = stashed_state
+            self._evicted_keys.pop(key, None)
             self.update_total_size()
 
 

--- a/exllamav3/cache/recurrent.py
+++ b/exllamav3/cache/recurrent.py
@@ -22,9 +22,13 @@ class RecurrentCache(OrderedDict):
             "stash_pruned": 0,              # stranded checkpoints dropped by prune_stranded()
         }
 
-        # Eviction ages measure the retention window this budget provides under live traffic; a young
-        # minimum means checkpoints are being discarded before their conversations return. Only restorable
-        # (LRU) evictions are recorded: dropping a stranded checkpoint frees dead weight, not retention.
+        # Eviction ages measure the retention window this budget provides under live traffic: seconds since
+        # the evicted checkpoint was LAST USED (stashed, refreshed or restored), not since it was created - a
+        # long-lived but recently-needed checkpoint evicted under churn must read as a young age, or the
+        # metric hides exactly the "conversations return faster than the budget retains them" condition it
+        # exists to reveal. A young minimum means checkpoints are being discarded before their conversations
+        # return. Only restorable (LRU) evictions are recorded: dropping a stranded checkpoint frees dead
+        # weight, not retention. Monotonic clock, so wall-clock adjustments cannot produce invalid ages.
         self.evicted_count = 0
         self.evicted_age_sum = 0.0
         self.evicted_age_min_window = None
@@ -60,7 +64,9 @@ class RecurrentCache(OrderedDict):
         """
         if key in self:
             self.move_to_end(key)
-            return self[key]
+            stashed = self[key]
+            stashed["last_access"] = time.monotonic()
+            return stashed
         return default
 
 
@@ -70,9 +76,10 @@ class RecurrentCache(OrderedDict):
         """
         if key in self:
             self.move_to_end(key)
+            self[key]["last_access"] = time.monotonic()
         else:
             stashed_state = state.stash()
-            stashed_state["stash_time"] = time.time()
+            stashed_state["last_access"] = time.monotonic()
             state_size = stashed_state["checkpoint_size"]
             while self.update_total_size() + state_size > self.max_size:
                 assert self.current_size >= 0, "Not enough space in cache for single state"
@@ -98,8 +105,8 @@ class RecurrentCache(OrderedDict):
                         if page is not None and page.kv_position == PAGE_SIZE:
                             self.metrics["stash_evictions_live_kv"] += 1
                     # Retention-window accounting and the evicted-key memory cover only this restorable
-                    # (LRU pressure) path; see __init__
-                    age = time.time() - popped.get("stash_time", time.time())
+                    # (LRU pressure) path; see __init__. Age is measured from last use, not creation.
+                    age = time.monotonic() - popped.get("last_access", time.monotonic())
                     self.evicted_count += 1
                     self.evicted_age_sum += age
                     if self.evicted_age_min_window is None or age < self.evicted_age_min_window:

--- a/exllamav3/generator/cpu_cache.py
+++ b/exllamav3/generator/cpu_cache.py
@@ -93,7 +93,10 @@ class CPUPageCache:
         }
 
         # Eviction ages measure the retention window the configured capacity actually provides under live
-        # traffic; a young minimum means pages are dropped before their conversations return
+        # traffic: seconds since the evicted entry was LAST USED (pushed, deduplicated or restored), not
+        # since it was created, so an entry that was needed recently but still lost the LRU race reads as a
+        # young age. A young minimum means pages are dropped before their conversations return. Monotonic
+        # clock, so wall-clock adjustments cannot produce invalid ages.
         self.evicted_age_sum = 0.0
         self.evicted_age_min_window = None
 
@@ -190,7 +193,7 @@ class CPUPageCache:
             e = self.entries.pop(h, None)
             if e is not None:
                 self.metrics["evictions"] += 1
-                age = time.time() - e["stored_at"]
+                age = time.monotonic() - e["last_access"]
                 self.evicted_age_sum += age
                 if self.evicted_age_min_window is None or age < self.evicted_age_min_window:
                     self.evicted_age_min_window = age
@@ -256,6 +259,7 @@ class CPUPageCache:
         e = self.entries.get(page.phash)
         if e is not None:
             e["access_serial"] = serial
+            e["last_access"] = time.monotonic()
             self.metrics["dedup_hits"] += 1
             return
         slot = self._new_slot(protect)
@@ -266,7 +270,7 @@ class CPUPageCache:
             "prev_hash": page.prev_hash,
             "access_serial": serial,
             "tokens": page.sequence.clone(),
-            "stored_at": time.time(),
+            "last_access": time.monotonic(),
         }
         self.metrics["pushes"] += 1
 
@@ -279,6 +283,7 @@ class CPUPageCache:
         """
         e = self.entries[phash]
         e["access_serial"] = serial
+        e["last_access"] = time.monotonic()
         for v, (t, _, _, _) in zip(self.slot_views[e["slot"]], self.segments):
             t[page_index].copy_(v, non_blocking = True)
         self.metrics["restores"] += 1

--- a/exllamav3/generator/cpu_cache.py
+++ b/exllamav3/generator/cpu_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import heapq
 import threading
+import time
 import torch
 from collections import deque
 from ..constants import PAGE_SIZE
@@ -86,9 +87,15 @@ class CPUPageCache:
             "pushes": 0,        # pages copied to the tier on GPU eviction
             "dedup_hits": 0,    # pushes skipped because the page was already stored
             "restores": 0,      # pages copied back into the GPU cache at allocation
+            "misses": 0,        # restorable allocation positions that had no tier entry (see PageTable)
             "evictions": 0,     # tier entries dropped to make room
             "cold_allocs": 0,   # pushes that had to pin a slab synchronously (spare pool was empty)
         }
+
+        # Eviction ages measure the retention window the configured capacity actually provides under live
+        # traffic; a young minimum means pages are dropped before their conversations return
+        self.evicted_age_sum = 0.0
+        self.evicted_age_min_window = None
 
         # Transfers run at PCIe speed, but pinning host memory only manages ~2.5 GB/s and serializes with copy
         # submission on the driver, so the full configured capacity is pinned up front by a background thread
@@ -102,6 +109,20 @@ class CPUPageCache:
 
     def attach(self, pagetable):
         self.pagetable = pagetable
+
+
+    def stats(self, reset_window: bool = False) -> dict:
+        s = {
+            "slots": self.max_slots,
+            "entries": len(self.entries),
+            "slot_bytes": self.slot_size,
+            "evicted_age_sum": self.evicted_age_sum,
+            "evicted_age_min_window": self.evicted_age_min_window,
+        }
+        s.update(self.metrics)
+        if reset_window:
+            self.evicted_age_min_window = None
+        return s
 
 
     def __contains__(self, phash: bytes):
@@ -169,6 +190,10 @@ class CPUPageCache:
             e = self.entries.pop(h, None)
             if e is not None:
                 self.metrics["evictions"] += 1
+                age = time.time() - e["stored_at"]
+                self.evicted_age_sum += age
+                if self.evicted_age_min_window is None or age < self.evicted_age_min_window:
+                    self.evicted_age_min_window = age
                 return e["slot"]
 
 
@@ -241,6 +266,7 @@ class CPUPageCache:
             "prev_hash": page.prev_hash,
             "access_serial": serial,
             "tokens": page.sequence.clone(),
+            "stored_at": time.time(),
         }
         self.metrics["pushes"] += 1
 

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -6,7 +6,7 @@ from ..cache.recurrent import RecurrentCache
 from ..tokenizer.tokenizer import Tokenizer
 from ..constants import PAGE_SIZE
 from ..util import cuda_sync_active
-from .pagetable import PageTable
+from .pagetable import PageTable, is_content_hash
 from .cpu_cache import CPUPageCache
 from .job import Job
 from .filter import Filter
@@ -241,6 +241,13 @@ class Generator:
         if recurrent_checkpoint_interval is None:
             recurrent_checkpoint_interval = model.caps.get("default_recurrent_checkpoint_interval", 2048)
 
+        # Cumulative request statistics for get_cache_stats
+        self.stats_requests = 0
+        self.stats_prompt_tokens = 0
+        self.stats_cached_tokens = 0
+        self.stats_prefill_time = 0.0
+        self.stats_cached_ratio_min_window = None
+
         assert recurrent_checkpoint_interval % PAGE_SIZE == 0 and recurrent_checkpoint_interval % PAGE_SIZE == 0, \
             "checkpoint interval must be a multiple of the page size (256)"
         def ceil_span(a, b):
@@ -264,6 +271,47 @@ class Generator:
 
     def num_pending_jobs(self):
         return len(self.pending_jobs)
+
+
+    def get_cache_stats(self, reset_window: bool = False) -> dict:
+        """
+        Snapshot of cache and prefix-reuse statistics, intended for periodic production logging to guide
+        cache_size / cpu_cache_size / recurrent_cache_size tuning. Counters are cumulative; callers compute
+        deltas between snapshots. Fields suffixed _window are minima observed since the last snapshot taken
+        with reset_window = True. Ages and times are in seconds.
+
+        On hybrid recurrent models the single most actionable signal is gpu_cache.recurrent_capped_evicted:
+        it counts allocations whose K/V was available in the CPU tier but whose unlocking recurrent
+        checkpoint had been EVICTED, i.e. the recurrent cache budget is undersized relative to the tier and
+        warm resumes are silently degrading to prefill. recurrent_uncovered counts allocations where no such
+        checkpoint ever existed (checkpoint interval, non-rollback state types) - a policy property, not a
+        sizing one.
+        """
+        pt = self.pagetable
+        retired_valid = sum(
+            1 for p in pt.unreferenced_pages.values()
+            if p.kv_position == PAGE_SIZE and is_content_hash(p.phash)
+        )
+        stats = {
+            "requests": {
+                "completed": self.stats_requests,
+                "prompt_tokens": self.stats_prompt_tokens,
+                "cached_tokens": self.stats_cached_tokens,
+                "cached_ratio_min_window": self.stats_cached_ratio_min_window,
+                "prefill_time_sum": self.stats_prefill_time,
+            },
+            "gpu_cache": {
+                "pages": pt.max_pages,
+                "referenced": len(pt.referenced_pages),
+                "retired_valid": retired_valid,
+                **pt.metrics,
+            },
+            "cpu_cache": self.cpu_page_cache.stats(reset_window) if self.cpu_page_cache is not None else None,
+            "recurrent_cache": self.recurrent_cache.stats(reset_window) if self.recurrent_cache is not None else None,
+        }
+        if reset_window:
+            self.stats_cached_ratio_min_window = None
+        return stats
 
 
     def clear_queue(self):
@@ -1111,6 +1159,25 @@ class Generator:
         # Requeued recurrent jobs may stash the last checkpoint first so the next queued job can resume from cached
         # recurrent state.
         num_jobs = self.num_remaining_jobs()
+        for job in completed_jobs:
+            # Request-level reuse accounting. Requeued jobs report the ORIGINAL arriving request (carried
+            # through rq_state): later segments' prompts contain text the job generated itself, which is
+            # trivially self-cached and would inflate the hit ratio. CFG jobs average across their sequences.
+            ns = max(len(job.sequences), 1)
+            if job.is_requeued and job.rq_first_prompt_tokens is not None:
+                prompt_tokens = job.rq_first_prompt_tokens
+                cached = job.rq_first_cached_tokens or 0
+            else:
+                prompt_tokens = sum(len(s.input_ids) for s in job.sequences) // ns
+                cached = (job.cached_pages * PAGE_SIZE + job.cached_tokens) // ns
+            self.stats_requests += 1
+            self.stats_prompt_tokens += prompt_tokens
+            self.stats_cached_tokens += cached
+            ratio = cached / prompt_tokens if prompt_tokens else 1.0
+            if self.stats_cached_ratio_min_window is None or ratio < self.stats_cached_ratio_min_window:
+                self.stats_cached_ratio_min_window = ratio
+            self.stats_prefill_time += job.time_prefill
+
         for job in completed_jobs + requeuing_jobs:
             if job in requeuing_jobs and self.recurrent_cache is not None:
                 job.maybe_stash_recurrent(self.recurrent_cache, PAGE_SIZE)

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -149,6 +149,8 @@ class Job:
         else:
             self.is_requeued = True
             self.rq_new_tokens = rq_state["rq_new_tokens"]
+        self.rq_first_prompt_tokens = rq_state.get("first_prompt_tokens")
+        self.rq_first_cached_tokens = rq_state.get("first_cached_tokens")
 
         self.generator = None
         self.pagetable = None
@@ -898,6 +900,12 @@ class Job:
             "rq_new_tokens": self.new_tokens - 1,
             "sam": self.sam,
             "draft_ema": self.draft_ema,
+            # Cache-stats identity of the ORIGINAL arriving request: later segments' prompts include text
+            # this job generated itself, which is trivially self-cached and would inflate the hit ratio
+            "first_prompt_tokens": self.rq_first_prompt_tokens if self.is_requeued
+                else sum(len(s.input_ids) for s in self.sequences) // max(len(self.sequences), 1),
+            "first_cached_tokens": self.rq_first_cached_tokens if self.is_requeued
+                else (self.cached_pages * PAGE_SIZE + self.cached_tokens) // max(len(self.sequences), 1),
         }
 
         serial_number = self.serial_number

--- a/exllamav3/generator/pagetable.py
+++ b/exllamav3/generator/pagetable.py
@@ -343,6 +343,13 @@ class PageTable:
             "alloc_cached_pages": 0,      # of those, reused as part of a resumable cached prefix
             "alloc_tier_pages": 0,        # of those, restored from the CPU tier rather than found in VRAM
             "alloc_kv_only_pages": 0,     # cached KV pages not resumable because no recurrent stash covers them
+            # Allocations whose K/V sat in the CPU tier but could not be restored for want of a recurrent
+            # checkpoint. capped_evicted: a checkpoint that would have unlocked the restore existed and was
+            # evicted - direct evidence the recurrent cache budget is undersized relative to the tier.
+            # uncovered: no such checkpoint was ever created (checkpoint interval, non-rollback state types)
+            # - more recurrent memory cannot help.
+            "recurrent_capped_evicted": 0,
+            "recurrent_uncovered": 0,
         }
 
 
@@ -562,7 +569,10 @@ class PageTable:
             self.evict(page, protected_hashes)
             return page
 
-        # Allocate whole pages
+        # Allocate whole pages. contiguous tracks whether every page so far extends a complete cached prefix
+        # from position 0: reuse statistics only count positions inside that prefix, since pages beyond the
+        # first miss are rewritten by prefill regardless of what the tiers hold.
+        contiguous = True
         for lp, h in enumerate(page_hashes):
             self.access_serial += 1
 
@@ -571,6 +581,7 @@ class PageTable:
             if rp:
                 rp.add_ref(self.access_serial)
                 allocated_pages.append(rp)
+                contiguous = contiguous and rp.kv_position == PAGE_SIZE
 
             # If possible, reuse an unreferenced page with matching hash
             else:
@@ -578,6 +589,7 @@ class PageTable:
                 if up:
                     up.add_ref(self.access_serial)
                     allocated_pages.append(up)
+                    contiguous = contiguous and up.kv_position == PAGE_SIZE
 
                 # No matching page, allocate the best eviction candidate. If the missing page is stored in the
                 # CPU tier, restore it into the new page; the eviction above may itself push to the tier, and in
@@ -596,6 +608,36 @@ class PageTable:
                         op.prev_hash = page_hashes[lp - 1] if lp > 0 else None
                         op.kv_position = PAGE_SIZE
                         self.metrics["alloc_tier_pages"] += 1
+                    elif self.cpu_tier is not None and contiguous:
+                        if restore_limit is None or lp < restore_limit:
+                            # A restorable position missed both VRAM and the tier: the tier's retention
+                            # window ends before this conversation returned (or it was never stored)
+                            self.cpu_tier.metrics["misses"] += 1
+                        elif recurrent_pages is not None and h in self.cpu_tier:
+                            # K/V for this page is in the tier but the restore is capped for want of a
+                            # recurrent checkpoint. A checkpoint at a later position q unlocks restoring
+                            # through q only if every page from here through q is still available (live in
+                            # VRAM or held by the tier), so scan the remaining hashes only while that K/V
+                            # chain holds: an evicted checkpoint key inside the reachable span is a
+                            # recurrent-budget signal; a span that ends first (K/V retention gap) or holds
+                            # no evicted key (checkpoint never existed: interval, non-rollback state types)
+                            # cannot be fixed with more recurrent memory and counts as uncovered.
+                            rc = self.generator.recurrent_cache
+                            capped = False
+                            if rc is not None:
+                                for ph in page_hashes[lp:]:
+                                    if self.get_live_page(ph) is None and ph not in self.cpu_tier:
+                                        break
+                                    if rc.was_evicted(ph):
+                                        capped = True
+                                        break
+                            if capped:
+                                self.metrics["recurrent_capped_evicted"] += 1
+                            else:
+                                self.metrics["recurrent_uncovered"] += 1
+                        contiguous = False
+                    else:
+                        contiguous = False
                     allocated_pages.append(op)
 
         # Allocate unique pages

--- a/tests/test_cache_stats.py
+++ b/tests/test_cache_stats.py
@@ -1,0 +1,200 @@
+"""
+Tests for cache statistics (Generator.get_cache_stats).
+
+The unit test is a plain pytest test:
+
+    pytest tests/test_cache_stats.py
+
+Integration runs in script mode and requires an exl3 model (any model for the snapshot checks; the
+recurrent-capped section runs on models with recurrent states, e.g. Gemma-4 with SWA in recurrent mode):
+
+    python tests/test_cache_stats.py --model <exl3 model dir>
+
+The recurrent-capped section reproduces the silent warm-resume degradation: with every KV page held in
+the CPU tier but the unlocking recurrent checkpoint evicted from an undersized recurrent cache, resumes
+fall back to full prefill. get_cache_stats must report this as recurrent_capped_evicted (the budget
+signal) rather than recurrent_uncovered (the policy signal). The recurrent budget is sized at runtime to
+about three checkpoints, so the flood evicts deterministically on any model geometry.
+"""
+
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import argparse
+import torch
+from exllamav3 import Model, Config, Cache, Tokenizer, Generator, Job, GreedySampler
+from exllamav3.constants import PAGE_SIZE
+
+checks_passed = 0
+checks_failed = 0
+
+def check(name, cond, detail = ""):
+    global checks_passed, checks_failed
+    if cond:
+        checks_passed += 1
+        print(f"  PASS  {name}")
+    else:
+        checks_failed += 1
+        print(f"  FAIL  {name}")
+        if detail:
+            print(f"        {detail}")
+
+
+def test_evicted_tracking():
+    """
+    RecurrentCache must remember recently evicted keys so restore-time misses can distinguish an evicted
+    checkpoint (budget undersized) from one that never existed (interval/state policy), and must forget a
+    key again once it is re-stashed.
+    """
+    import exllamav3.cache.recurrent as rec
+
+    class _Dummy:
+        loaded_tp = False
+
+    class _DummyState:
+        def __init__(self, position):
+            self.position = position
+        def stash(self):
+            return {"position": self.position, "checkpoint_size": 8}
+
+    rc = rec.RecurrentCache(_Dummy(), max_size = 20)   # fits two 8-byte checkpoints
+    rc.put(b"a", _DummyState(1))
+    rc.put(b"b", _DummyState(2))
+    rc.put(b"c", _DummyState(3))                        # evicts a
+    assert rc.was_evicted(b"a"), "evicted key must be remembered"
+    assert not rc.was_evicted(b"b") and not rc.was_evicted(b"c"), "resident keys must not be flagged"
+    rc.put(b"a", _DummyState(1))                        # evicts b, re-stashes a
+    assert not rc.was_evicted(b"a"), "re-stashed key must be forgotten"
+    assert rc.was_evicted(b"b"), "newly evicted key must be remembered"
+    assert rc.evicted_count == 2
+    assert rc.stats()["evicted_age_min_window"] is not None
+    assert rc.stats(reset_window = True)["evicted_count"] == 2
+    assert rc.stats()["evicted_age_min_window"] is None, "window reset must clear the age minimum"
+
+
+def make_long_prompt(tokenizer, seed_text, target_pages):
+    text = seed_text
+    filler = (
+        " The archive records further details, cross-referenced against seasonal observations"
+        " and the incidental notes of several field assistants over many years of study."
+    )
+    while tokenizer.encode(text).shape[-1] < target_pages * PAGE_SIZE + 16:
+        text += filler
+    return text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required = True, help = "exl3 model directory")
+    ap.add_argument("--cache_size", type = int, default = 4096)
+    ap.add_argument("--cpu_cache_mb", type = int, default = 1024)
+    ap.add_argument("--max_batch_size", type = int, default = 2,
+                    help = "Recurrent state slots per cache; the test is batch-1")
+    args = ap.parse_args()
+
+    try:
+        test_evicted_tracking()
+        check("test_evicted_tracking", True)
+    except AssertionError as e:
+        check("test_evicted_tracking", False, str(e))
+
+    print(f" -- Loading model: {args.model}")
+    config = Config.from_directory(args.model)
+    model = Model.from_config(config, swa_full = False)
+    cache_a = Cache(model, max_num_tokens = args.cache_size, max_batch_size = args.max_batch_size)
+    cache_b = Cache(model, max_num_tokens = args.cache_size, max_batch_size = args.max_batch_size)
+    model.load(progressbar = True)
+    tokenizer = Tokenizer.from_config(config)
+    sampler = GreedySampler()
+
+    prompt_a = make_long_prompt(
+        tokenizer,
+        "The migration of songbirds across continents follows magnetic fields and stellar cues.", 6)
+    a_ids = tokenizer.encode(prompt_a)
+    flood_prompts = [
+        make_long_prompt(tokenizer, f"Flood text number {j} concerns the industrial history of a city.", 5)
+        for j in range(6)
+    ]
+
+    def run_job_ids(gen, ids, max_new):
+        job = Job(input_ids = ids, max_new_tokens = max_new, sampler = sampler)
+        gen.enqueue(job)
+        out, eos_r = [], None
+        while gen.num_remaining_jobs():
+            for r in gen.iterate():
+                t = r.get("token_ids")
+                if t is not None:
+                    out.append(t)
+                if r.get("eos"):
+                    eos_r = r
+        out_ids = torch.cat(out, dim = -1) if out else torch.empty((1, 0), dtype = torch.long)
+        return out_ids, eos_r
+
+    def gen_prompt(gen, prompt):
+        return run_job_ids(gen, tokenizer.encode(prompt), 16)
+
+    # Snapshot sanity on a generator with the CPU tier: prompt A, flood past cache capacity, re-run A
+    print(" -- Stats snapshot: requests, GPU cache, CPU tier")
+    stats_gen = Generator(model = model, cache = cache_a, tokenizer = tokenizer,
+                          cpu_cache_size = args.cpu_cache_mb * 1024**2)
+    run_job_ids(stats_gen, a_ids, 24)
+    for p in flood_prompts:
+        gen_prompt(stats_gen, p)
+    _, eos_a = run_job_ids(stats_gen, a_ids, 8)
+
+    stats = stats_gen.get_cache_stats(reset_window = True)
+    r, cc, gpu = stats["requests"], stats["cpu_cache"], stats["gpu_cache"]
+    check("stats: requests counted", r["completed"] == 8 and r["prompt_tokens"] > 0,
+          f"requests = {r}")
+    check("stats: cached tokens bounded by prompt tokens", 0 <= r["cached_tokens"] <= r["prompt_tokens"],
+          f"requests = {r}")
+    check("stats: prefill time accumulated", r["prefill_time_sum"] > 0,
+          f"requests = {r}")
+    check("stats: GPU pool accounted", 0 <= gpu["referenced"] + gpu["retired_valid"] <= gpu["pages"],
+          f"gpu_cache = {gpu}")
+    check("stats: CPU tier activity recorded",
+          cc is not None and cc["pushes"] > 0 and 0 <= cc["entries"] <= cc["slots"],
+          f"cpu_cache = {cc}")
+    check("stats: window reset clears minima",
+          stats_gen.get_cache_stats()["requests"]["cached_ratio_min_window"] is None)
+
+    if stats_gen.recurrent_cache is None:
+        print(" -- Model has no recurrent states; skipping recurrent-capped section.")
+        print(f"\n -- {checks_passed} passed, {checks_failed} failed")
+        sys.exit(1 if checks_failed else 0)
+
+    # Probe the model's checkpoint size so the capped scenario's budget (~3 checkpoints) is geometry-independent
+    probe_rc = stats_gen.recurrent_cache
+    checkpoint_bytes = probe_rc.current_size // max(len(probe_rc), 1) if len(probe_rc) else 0
+    del stats_gen
+    torch.cuda.empty_cache()
+    if not checkpoint_bytes:
+        print(" -- No recurrent checkpoints were created by the probe; skipping recurrent-capped section.")
+        print(f"\n -- {checks_passed} passed, {checks_failed} failed")
+        sys.exit(1 if checks_failed else 0)
+
+    # Recurrent-capped detection: an undersized recurrent cache silently degrades warm resumes to full
+    # prefill even with every KV page in the CPU tier. That condition must be visible in stats.
+    print(f" -- Stats: recurrent-capped restore detection (budget = 3 checkpoints of ~{checkpoint_bytes} bytes)")
+    capped_gen = Generator(model = model, cache = cache_b, tokenizer = tokenizer,
+                           cpu_cache_size = args.cpu_cache_mb * 1024**2,
+                           recurrent_cache_size = 3 * checkpoint_bytes + checkpoint_bytes // 2)
+    run_job_ids(capped_gen, a_ids, 40)
+    for p in flood_prompts:
+        gen_prompt(capped_gen, p)
+    _, eos_c = run_job_ids(capped_gen, a_ids, 8)
+    capped_stats = capped_gen.get_cache_stats()
+    check("stats: evicted-checkpoint capped restores detected",
+          capped_stats["gpu_cache"]["recurrent_capped_evicted"] > 0,
+          f"recurrent_capped_evicted = {capped_stats['gpu_cache']['recurrent_capped_evicted']}, "
+          f"uncovered = {capped_stats['gpu_cache']['recurrent_uncovered']}, "
+          f"cached_tokens = {eos_c['cached_tokens']}")
+    check("stats: recurrent evictions aged",
+          capped_stats["recurrent_cache"]["evicted_count"] > 0,
+          f"recurrent_cache = {capped_stats['recurrent_cache']}")
+
+    print(f"\n -- {checks_passed} passed, {checks_failed} failed")
+    sys.exit(1 if checks_failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cache_stats.py
+++ b/tests/test_cache_stats.py
@@ -71,6 +71,44 @@ def test_evicted_tracking():
     assert rc.stats()["evicted_age_min_window"] is None, "window reset must clear the age minimum"
 
 
+def test_eviction_age_reflects_last_access():
+    """
+    Eviction age must measure time since the entry was LAST USED, not since insertion: under churn, LRU can
+    evict an entry that was needed moments ago, and reporting its full lifetime would hide exactly the
+    "conversations return faster than the budget retains them" condition the metric exists to reveal.
+    """
+    import exllamav3.cache.recurrent as rec
+    from types import SimpleNamespace
+
+    class _Dummy:
+        loaded_tp = False
+
+    class _DummyState:
+        def __init__(self, position):
+            self.position = position
+        def stash(self):
+            return {"position": self.position, "checkpoint_size": 8}
+
+    now = [0.0]
+    orig_time = rec.time
+    rec.time = SimpleNamespace(monotonic = lambda: now[0])
+    try:
+        rc = rec.RecurrentCache(_Dummy(), max_size = 20)   # fits two 8-byte checkpoints
+        rc.put(b"a", _DummyState(1))
+        rc.put(b"b", _DummyState(2))
+        now[0] = 100.0
+        rc.get_stashed(b"a")                               # refresh a; LRU order is now b, a
+        rc.get_stashed(b"b")                               # refresh b; LRU order is now a, b
+        now[0] = 101.0
+        rc.put(b"c", _DummyState(3))                       # evicts a, which was last used at t = 100
+        assert rc.evicted_count == 1
+        assert abs(rc.evicted_age_min_window - 1.0) < 1e-6, \
+            f"age must be measured from last use, not insertion " \
+            f"(expected 1.0, got {rc.evicted_age_min_window})"
+    finally:
+        rec.time = orig_time
+
+
 def make_long_prompt(tokenizer, seed_text, target_pages):
     text = seed_text
     filler = (


### PR DESCRIPTION
Fourth PR in the series (#264, #265, #266) rebasing my independently developed prefix-cache work onto dev. Independent of the others — applies directly to dev.

Sizing `cache_size`, `cpu_cache_size` and `recurrent_cache_size` for a real workload currently requires guesswork: the metrics dicts count events, but can't answer "is my budget big enough" or "why did this warm resume degrade to prefill". This PR adds `Generator.get_cache_stats(reset_window=)` — a cheap snapshot for periodic logging by the serving layer, folding in the existing `PageTable`/`CPUPageCache`/`RecurrentCache` metrics and adding the sizing signals on top:

- **Requests:** completed count, prompt/cached token sums, windowed minimum hit ratio, prefill time. Requeued jobs report the *original* arriving request (carried through `rq_state`) — later segments' prompts contain self-generated text that would inflate the hit ratio.
- **Eviction ages** on both the CPU tier and the recurrent cache: count/sum/windowed-minimum age at eviction, measuring the retention window a budget actually provides under live traffic. A young minimum means entries are dropped before their conversations return — the direct "make it bigger" signal.
- **The flagship, for hybrid recurrent models:** when an allocation's K/V sits in the CPU tier but can't be restored for want of a recurrent checkpoint, the miss is classified. `recurrent_capped_evicted`: a checkpoint that would have unlocked the restore existed and was evicted — direct evidence the recurrent budget is undersized relative to the tier, and warm resumes are silently degrading. `recurrent_uncovered`: no such checkpoint ever existed (interval, non-rollback state types) or the K/V chain itself is broken — more recurrent memory cannot help. Classification walks the request's remaining hashes against a bounded (10k-key) memory of recently LRU-evicted checkpoint keys, only while every page's K/V remains reachable in VRAM or the tier. Stranded drops and `prune_stranded` deliberately don't feed the evicted-key memory: freeing dead weight isn't a retention signal.
- A tier `misses` counter (restorable positions with no tier entry), counted only within the contiguous usable prefix so cold prompts don't inflate it.

Counters are cumulative — callers diff snapshots; `_window` minima reset via `reset_window=True`.

**Tests** (`tests/test_cache_stats.py`): evicted-key tracking as a plain pytest unit; script-mode snapshot sanity plus a deterministic regression that recreates the silent warm-resume degradation (recurrent budget probed at runtime and sized to ~3 checkpoints, so the flood evicts on any model geometry) and asserts it's reported as `recurrent_capped_evicted`. 9/9 + 1/1 on gemma-4-31B.
