### PR TITLE
Tensor-parallel support for the CPU page cache tier

### DIFF
--- a/exllamav3/generator/cpu_cache.py
+++ b/exllamav3/generator/cpu_cache.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import heapq
+import itertools
 import threading
+import weakref
 import torch
 from collections import deque
 from ..constants import PAGE_SIZE
@@ -8,6 +10,87 @@ from ..constants import PAGE_SIZE
 
 def _align(n: int, a: int) -> int:
     return (n + a - 1) // a * a
+
+
+# Distinguishes worker-side pool generations across sequential CPUPageCache instances (see tp_caches)
+_pool_id_serial = itertools.count()
+
+
+class _SlabAllocState:
+    """
+    Shared state between a CPUPageCache and its slab-pinning worker. Holds no reference back to the cache,
+    so an abandoned cache - reference cycles and all - stays collectable at every instant of preallocation;
+    the cache's finalizer stops the worker instead of the worker noticing the cache is gone.
+    """
+    def __init__(self, slot_size, layouts, target):
+        self.slot_size = slot_size
+        self.layouts = layouts   # (offset, nbytes, dtype, shape) per segment; no tensors
+        self.target = target     # total slabs that may ever exist (worker-made + cold-allocated)
+        self.reserved = 0        # slabs made or being made; incremented before pinning starts
+        self.spare = deque()
+        self.cond = threading.Condition()
+        self.stopped = False
+
+    def stop(self):
+        with self.cond:
+            self.stopped = True
+            self.cond.notify_all()
+
+
+def _make_slab(slot_size, layouts):
+    slab = torch.empty((slot_size,), dtype = torch.uint8, pin_memory = True)
+    views = []
+    for offset, nbytes, dtype, shape in layouts:
+        views.append(slab[offset : offset + nbytes].view(dtype).view(shape))
+    return slab, views
+
+
+def _alloc_worker(state):
+    """
+    Pin slabs up to state.target, then exit. Receives only the shared allocation state - never the
+    CPUPageCache, a bound method, or anything else referencing it - so the worker cannot delay collection of
+    an abandoned cache at any point. The cache's finalizer sets state.stopped to end the thread early; cold
+    allocations by the cache reserve against the same target, so the combined slab count never overshoots.
+    """
+    while True:
+        with state.cond:
+            if state.stopped or state.reserved >= state.target:
+                return
+            state.reserved += 1
+        try:
+            sv = _make_slab(state.slot_size, state.layouts)  # slow part, outside the lock
+        except BaseException:
+            # Return the reservation so a foreground allocation cannot wait forever for a slab that will
+            # never be published. It will retry synchronously and surface the allocation error to the caller.
+            with state.cond:
+                state.reserved -= 1
+                state.cond.notify_all()
+            return
+        with state.cond:
+            if state.stopped:
+                state.reserved -= 1
+                state.cond.notify_all()
+                return
+            state.spare.append(sv)
+            state.cond.notify_all()
+
+
+def _finalize_tier(state, tp_frees):
+    """
+    Runs exactly once, when the CPUPageCache is collected (reference counting or cyclic GC) or explicitly
+    via close(). Stops the slab-pinning worker and queues the worker-side TP pools for release. Queue only:
+    this can run at any GC point, even mid-fan-out with a rank blocked in a collective, so no pipe I/O here;
+    the frees drain at the next quiet boundary (another tier's dispatches, or a forward/prefill fan-out).
+    Best effort at interpreter shutdown, when the TP context may already be gone.
+    """
+    if state is not None:
+        state.stop()
+    for model, pool_id in tp_frees:
+        try:
+            if model.loaded_tp:
+                model.tp_host_cache_free_deferred(pool_id)
+        except Exception:
+            pass
 
 
 class CPUPageCache:
@@ -30,6 +113,13 @@ class CPUPageCache:
     first, pruned tail-first. A chain whose parent page is still live in the GPU page table counts as rooted.
     The order is consumed as a snapshot and rebuilt after at most max(64, max_slots/8) evictions, so recency
     updates between rebuilds are approximated.
+
+    For a tensor-parallel model, the cache tensors live sharded across the TP worker processes, so the data
+    plane moves there too: each rank allocates pinned pools covering its own shard up front, and store/fetch
+    dispatch per-page commands to every rank under the same global slot index. All metadata (hashes, eviction
+    order, token ids) stays in this class; the per-rank command pipes preserve ordering against forward passes
+    exactly as the shared stream does in the single-process case. Local (non-TP) and TP caches can be mixed,
+    e.g. a TP-loaded model with a single-device draft model.
     """
 
     def __init__(
@@ -48,10 +138,20 @@ class CPUPageCache:
         """
 
         # Segment table: one entry per paged cache tensor. Every cache tensor is page-major, so one page is the
-        # contiguous slice tensor[page_index]
+        # contiguous slice tensor[page_index]. TP-loaded caches contribute no local segments; their per-rank
+        # pools live in the worker processes, keyed as (model, cache_id, pool_id). pool_id is unique per store
+        # generation: a predecessor store over the same cache may have its finalizer deferred by cyclic GC
+        # until after this store has allocated, and its queued free must then target only its own dead pools.
         self.segments = []
+        self.tp_caches = []
         offset = 0
+        tp_page_bytes = 0
         for cache in caches:
+            if getattr(getattr(cache, "model", None), "loaded_tp", False):
+                cache.model.tp_host_cache_process_frees()
+                self.tp_caches.append((cache.model, id(cache), next(_pool_id_serial)))
+                tp_page_bytes += cache.model.tp_host_cache_page_bytes(id(cache))
+                continue
             for layer in cache.layers.values():
                 for t in layer.get_tensors():
                     if t is None:
@@ -62,12 +162,19 @@ class CPUPageCache:
                     nbytes = t[0].numel() * t.element_size()
                     self.segments.append((t, offset, page_shape, t.dtype))
                     offset = _align(offset + nbytes, 256)
-        assert self.segments, "No paged cache layers to attach CPU page cache tier to."
+        assert self.segments or self.tp_caches, "No paged cache layers to attach CPU page cache tier to."
 
-        self.slot_size = _align(offset, 4096)
-        self.max_slots = int(max_size) // self.slot_size
+        self.slot_size = _align(offset, 4096) if self.segments else 0
+        page_bytes = self.slot_size + tp_page_bytes
+        self.max_slots = int(max_size) // page_bytes
         assert self.max_slots >= 2, \
-            f"CPU page cache of {max_size} bytes is smaller than two pages ({self.slot_size} bytes per page)."
+            f"CPU page cache of {max_size} bytes is smaller than two pages ({page_bytes} bytes per page)."
+
+        # Per-rank pools are committed up front for the full slot count (pinning happens in the workers, in
+        # parallel across ranks); the local slabs below stay lazily allocated as before
+        for model, cache_id, pool_id in self.tp_caches:
+            model.tp_host_cache_alloc(cache_id, pool_id, self.max_slots)
+        self._slots_used = 0  # slots handed out when no local slabs exist to count
 
         self.pagetable = None
 
@@ -92,12 +199,36 @@ class CPUPageCache:
 
         # Transfers run at PCIe speed, but pinning host memory only manages ~2.5 GB/s and serializes with copy
         # submission on the driver, so the full configured capacity is pinned up front by a background thread
-        # (mirroring the GPU cache, whose full allocation is also committed at load). Pushes that outrun the
-        # pinning thread early in the process fall back to pinning synchronously.
-        self._spare = deque()
-        self._spare_cond = threading.Condition()
-        self._alloc_thread = threading.Thread(target = self._alloc_worker, daemon = True)
-        self._alloc_thread.start()
+        # (mirroring the GPU cache, whose full allocation is also committed at load), which exits once the
+        # target is reached. Pushes that outrun it early in the process fall back to pinning synchronously.
+        # With no local segments (pure-TP store) there are no slabs to pin and the thread is not started.
+        self._alloc_state = None
+        self._alloc_thread = None
+        if self.segments:
+            layouts = [
+                (offset, t[0].numel() * t.element_size(), dtype, page_shape)
+                for t, offset, page_shape, dtype in self.segments
+            ]
+            self._alloc_state = _SlabAllocState(self.slot_size, layouts, self.max_slots)
+            self._alloc_thread = threading.Thread(
+                target = _alloc_worker, args = (self._alloc_state,), daemon = True)
+            self._alloc_thread.start()
+
+        # The finalizer keeps itself alive, fires exactly once on any form of collection or via close(), and
+        # captures no reference to self, so the worker thread and TP pool cleanup never depend on __del__
+        # semantics or on when cyclic GC happens to run
+        self._finalizer = weakref.finalize(
+            self, _finalize_tier, self._alloc_state,
+            [(model, pool_id) for model, cache_id, pool_id in self.tp_caches])
+
+
+    def close(self):
+        """
+        Deterministically release this tier's background resources: stop the slab-pinning worker and queue
+        any worker-side TP pools for release in the rank processes. Idempotent; runs automatically when the
+        object is collected.
+        """
+        self._finalizer()
 
 
     def attach(self, pagetable):
@@ -112,43 +243,48 @@ class CPUPageCache:
         return len(self.entries)
 
 
-    def _make_slab(self):
-        slab = torch.empty((self.slot_size,), dtype = torch.uint8, pin_memory = True)
-        views = []
-        for t, offset, page_shape, dtype in self.segments:
-            nbytes = t[0].numel() * t.element_size()
-            views.append(slab[offset : offset + nbytes].view(dtype).view(page_shape))
-        return slab, views
-
-
-    def _alloc_worker(self):
-        while True:
-            with self._spare_cond:
-                while len(self.slot_slabs) + len(self._spare) >= self.max_slots:
-                    self._spare_cond.wait()
-            sv = self._make_slab()  # slow part, outside the lock
-            with self._spare_cond:
-                self._spare.append(sv)
-
-
     def _new_slot(self, protect: set | None):
         if self.free_slots:
             return self.free_slots.popleft()
+        if not self.segments:
+            # No local slabs to materialize; slot indices only key the per-rank TP pools
+            if self._slots_used < self.max_slots:
+                self._slots_used += 1
+                return self._slots_used - 1
+            return self._evict_one(protect)
         if len(self.slot_slabs) < self.max_slots:
-            with self._spare_cond:
-                if self._spare:
-                    sv = self._spare.popleft()
-                    self.slot_slabs.append(sv[0])
-                    self.slot_views.append(sv[1])
-                    self._spare_cond.notify()
-                    return len(self.slot_slabs) - 1
-            sv = self._make_slab()
+            state = self._alloc_state
+            with state.cond:
+                while True:
+                    if state.stopped:
+                        raise RuntimeError("CPU page cache tier is closed.")
+                    if state.spare:
+                        sv = state.spare.popleft()
+                        self.slot_slabs.append(sv[0])
+                        self.slot_views.append(sv[1])
+                        return len(self.slot_slabs) - 1
+                    if state.reserved < state.target:
+                        state.reserved += 1
+                        break
+                    # The worker has reserved the remaining capacity but has not published its in-flight slab
+                    # yet. Wait for that slab instead of exceeding the configured pinned-memory budget.
+                    state.cond.wait()
+            try:
+                sv = _make_slab(state.slot_size, state.layouts)
+            except BaseException:
+                with state.cond:
+                    state.reserved -= 1
+                    state.cond.notify_all()
+                raise
+            with state.cond:
+                if state.stopped:
+                    state.reserved -= 1
+                    state.cond.notify_all()
+                    raise RuntimeError("CPU page cache tier was closed during slab allocation.")
             self.metrics["cold_allocs"] += 1
-            with self._spare_cond:
-                self.slot_slabs.append(sv[0])
-                self.slot_views.append(sv[1])
-                self._spare_cond.notify()
-                return len(self.slot_slabs) - 1
+            self.slot_slabs.append(sv[0])
+            self.slot_views.append(sv[1])
+            return len(self.slot_slabs) - 1
         return self._evict_one(protect)
 
 
@@ -234,8 +370,12 @@ class CPUPageCache:
             self.metrics["dedup_hits"] += 1
             return
         slot = self._new_slot(protect)
-        for v, (t, _, _, _) in zip(self.slot_views[slot], self.segments):
-            v.copy_(t[page.page_index], non_blocking = True)
+        if self.segments:
+            for v, (t, _, _, _) in zip(self.slot_views[slot], self.segments):
+                v.copy_(t[page.page_index], non_blocking = True)
+        for model, cache_id, pool_id in self.tp_caches:
+            model.tp_host_cache_process_frees()
+            model.tp_host_cache_store(pool_id, slot, page.page_index)
         self.entries[page.phash] = {
             "slot": slot,
             "prev_hash": page.prev_hash,
@@ -253,7 +393,11 @@ class CPUPageCache:
         """
         e = self.entries[phash]
         e["access_serial"] = serial
-        for v, (t, _, _, _) in zip(self.slot_views[e["slot"]], self.segments):
-            t[page_index].copy_(v, non_blocking = True)
+        if self.segments:
+            for v, (t, _, _, _) in zip(self.slot_views[e["slot"]], self.segments):
+                t[page_index].copy_(v, non_blocking = True)
+        for model, cache_id, pool_id in self.tp_caches:
+            model.tp_host_cache_process_frees()
+            model.tp_host_cache_restore(pool_id, e["slot"], page_index)
         self.metrics["restores"] += 1
         return e

--- a/exllamav3/generator/cpu_cache.py
+++ b/exllamav3/generator/cpu_cache.py
@@ -170,10 +170,46 @@ class CPUPageCache:
         assert self.max_slots >= 2, \
             f"CPU page cache of {max_size} bytes is smaller than two pages ({page_bytes} bytes per page)."
 
-        # Per-rank pools are committed up front for the full slot count (pinning happens in the workers, in
-        # parallel across ranks); the local slabs below stay lazily allocated as before
-        for model, cache_id, pool_id in self.tp_caches:
-            model.tp_host_cache_alloc(cache_id, pool_id, self.max_slots)
+        # Everything from the first worker-side pool allocation to finalizer registration is transactional:
+        # no finalizer exists yet, so a failure part-way (e.g. host memory exhausted while pinning a second
+        # cache's pools, or the local slab thread failing to start) must roll back here or already-pinned
+        # worker pools and an orphaned pinning thread would survive until model teardown.
+        attempted_pools = []
+        try:
+            # Per-rank pools are committed up front for the full slot count (pinning happens in the workers,
+            # in parallel across ranks); the local slabs below stay lazily allocated as before
+            for model, cache_id, pool_id in self.tp_caches:
+                # Record the pool before dispatch. A failed fan-out can still have allocated this ID on some
+                # ranks, and freeing a missing ID is harmless.
+                attempted_pools.append((model, pool_id))
+                model.tp_host_cache_alloc(cache_id, pool_id, self.max_slots)
+            self._init_tail()
+        except BaseException as exc:
+            if getattr(self, "_alloc_state", None) is not None:
+                self._alloc_state.stop()
+            cleanup_errors = []
+            for model, pool_id in attempted_pools:
+                try:
+                    model.tp_host_cache_free_deferred(pool_id)
+                except Exception as cleanup_exc:
+                    cleanup_errors.append(cleanup_exc)
+            # Constructor rollback runs in main-line control flow, not GC context, so release the queued pools
+            # immediately. tp_host_cache_alloc() drains every rank before raising on an allocation failure,
+            # leaving the command pipes synchronized for this cleanup dispatch.
+            for model, _ in attempted_pools:
+                try:
+                    model.tp_host_cache_process_frees()
+                except Exception as cleanup_exc:
+                    cleanup_errors.append(cleanup_exc)
+            if cleanup_errors and hasattr(exc, "add_note"):
+                exc.add_note(
+                    "CPU page cache rollback also encountered cleanup errors: " +
+                    "; ".join(repr(e) for e in cleanup_errors)
+                )
+            raise
+
+
+    def _init_tail(self):
         self._slots_used = 0  # slots handed out when no local slabs exist to count
 
         self.pagetable = None
@@ -225,7 +261,8 @@ class CPUPageCache:
     def close(self):
         """
         Deterministically release this tier's background resources: stop the slab-pinning worker and queue
-        any worker-side TP pools for release in the rank processes. Idempotent; runs automatically when the
+        any worker-side TP pools for release in the rank processes. Idempotent, terminal (subsequent store()
+        and fetch() raise rather than dispatch against released pools), and runs automatically when the
         object is collected.
         """
         self._finalizer()
@@ -364,6 +401,8 @@ class CPUPageCache:
         Copy a dying page's cache state into the tier (device-to-host, async on the current stream). Duplicate
         hashes only refresh the entry's recency.
         """
+        if not self._finalizer.alive:
+            raise RuntimeError("CPU page cache tier is closed.")
         e = self.entries.get(page.phash)
         if e is not None:
             e["access_serial"] = serial
@@ -391,6 +430,8 @@ class CPUPageCache:
         The entry remains in the tier; the restored copy may well be evicted again before this one goes stale.
         Returns the entry so the caller can restore page metadata (token IDs).
         """
+        if not self._finalizer.alive:
+            raise RuntimeError("CPU page cache tier is closed.")
         e = self.entries[phash]
         e["access_serial"] = serial
         if self.segments:

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -122,7 +122,8 @@ class Generator:
         :param cpu_cache_size:
             Size in bytes of a second-tier page cache in pinned system memory, 0 (default) to disable. Complete
             K/V pages evicted from the GPU cache are stored there and restored on prompt-cache hits instead of
-            being recomputed by prefill. Not currently supported in tensor-parallel mode
+            being recomputed by prefill. With tensor-parallel loading, each TP rank pins host memory for its
+            own cache shard; the budget covers the total across ranks
 
         :param recurrent_cache_size:
             Size of recurrent cache, in bytes. Recurrent cache resides in system RAM. Default is 4 GB.
@@ -212,9 +213,6 @@ class Generator:
         # CPU page cache tier
         self.cpu_page_cache = None
         if cpu_cache_size:
-            # TODO: Add TP support for CPU cache
-            assert not model.loaded_tp, \
-                "CPU page cache tier is not currently supported in tensor-parallel mode."
             tier_caches = [cache] + ([draft_cache] if draft_cache is not None else [])
             self.cpu_page_cache = CPUPageCache(tier_caches, cpu_cache_size)
             self.cpu_page_cache.attach(self.pagetable)

--- a/exllamav3/model/model_tp.py
+++ b/exllamav3/model/model_tp.py
@@ -670,9 +670,27 @@ class Model_TPMixin:
     def tp_host_cache_alloc(self, cache_id: int, pool_id: int, num_slots: int):
         """
         Allocate per-rank pinned host pools for a TP host page store. The rank pools jointly hold num_slots
-        pages of the full (unsharded) cache.
+        pages of the full (unsharded) cache. The worker function returns allocation errors as ordinary status
+        values so every rank's reply is drained before an error is raised. If any rank fails, remove this pool
+        ID everywhere before returning control to the caller.
         """
-        self.tp_worker_dispatch_wait_multi(self.active_devices, mp_host_cache_alloc, (cache_id, pool_id, num_slots))
+        results = self.tp_worker_dispatch_wait_multi(
+            self.active_devices,
+            mp_host_cache_alloc,
+            (cache_id, pool_id, num_slots),
+        )
+        errors = [r for r in results if r is not None]
+        if errors:
+            self.tp_worker_dispatch_wait_multi(
+                self.active_devices,
+                mp_host_cache_free,
+                (pool_id,),
+            )
+            detail = "; ".join(
+                f"device {e['device']}: {e['type']}: {e['message']}"
+                for e in errors
+            )
+            raise RuntimeError(f"Failed to allocate TP host-cache pool {pool_id}: {detail}")
 
 
     def tp_host_cache_free_deferred(self, pool_id: int):
@@ -693,8 +711,9 @@ class Model_TPMixin:
         even when no live host store remains.
         """
         while self.tp_pending_host_cache_frees:
-            pool_id = self.tp_pending_host_cache_frees.pop()
+            pool_id = self.tp_pending_host_cache_frees[-1]
             self.tp_worker_dispatch_wait_multi(self.active_devices, mp_host_cache_free, (pool_id,))
+            self.tp_pending_host_cache_frees.pop()
 
 
     def tp_host_cache_store(self, pool_id: int, slot: int, page_index: int):

--- a/exllamav3/model/model_tp.py
+++ b/exllamav3/model/model_tp.py
@@ -35,6 +35,12 @@ class Model_TPMixin:
         # command yet when forward_tp returns
         self.tp_pending_acks = []
         self.tp_pending_refs = None
+        # Host-cache pools whose HostPageStore was garbage-collected; freed in workers by
+        # tp_host_cache_process_frees, which live HostPageStore code calls from main-line control flow.
+        # __del__ may run at any GC point - even between a fan-out's individual sends, when a child rank can
+        # already be blocked in a collective - so it must never touch the pipes itself, and nothing on the
+        # drain/dispatch path may process this queue.
+        self.tp_pending_host_cache_frees = []
 
     def create_tp_context(self, tp_backend: str):
         """
@@ -168,6 +174,8 @@ class Model_TPMixin:
         self.mp_children = []
         self.mp_parent_conn = []
         self.mp_child_conn = []
+        # Worker processes are gone, and with them any pools still queued for release
+        self.tp_pending_host_cache_frees = []
 
         self.tp_producer.close()
         self.tp_producer = None
@@ -583,6 +591,10 @@ class Model_TPMixin:
         last_kv_module_idx: int,
         modules: list,
     ):
+        # Quiet top-level boundary: release pools of any garbage-collected host store before fanning out.
+        # Without this, an application that drops its last host-cached generator but keeps forwarding
+        # through this model would pin the dead pools until model unload.
+        self.tp_host_cache_process_frees()
         self.tp_worker_dispatch(-1, mp_cpu_reduce, ())
 
         x, reserve = self.prepare_inputs_for_tp(x, params)
@@ -617,6 +629,8 @@ class Model_TPMixin:
         last_kv_module_idx: int,
         modules: list,
     ):
+        # See prefill_tp: free dead host-cache pools at this quiet boundary
+        self.tp_host_cache_process_frees()
         self.tp_worker_dispatch(-1, mp_cpu_reduce, ())
 
         x, reserve = self.prepare_inputs_for_tp(x, params)
@@ -643,6 +657,60 @@ class Model_TPMixin:
         self.tp_pending_refs = (args, params.get("recurrent_states"))
         self.restore_tp_params(params, reserve)
         return out
+
+
+    def tp_host_cache_page_bytes(self, cache_id: int) -> int:
+        """
+        Total bytes of one cache page summed across every rank's shard of the given cache.
+        """
+        r = self.tp_worker_dispatch_wait_multi(self.active_devices, mp_host_cache_page_bytes, (cache_id,))
+        return sum(r)
+
+
+    def tp_host_cache_alloc(self, cache_id: int, pool_id: int, num_slots: int):
+        """
+        Allocate per-rank pinned host pools for a TP host page store. The rank pools jointly hold num_slots
+        pages of the full (unsharded) cache.
+        """
+        self.tp_worker_dispatch_wait_multi(self.active_devices, mp_host_cache_alloc, (cache_id, pool_id, num_slots))
+
+
+    def tp_host_cache_free_deferred(self, pool_id: int):
+        """
+        Queue the per-rank pinned host pools of a dying host page store for release. Safe to call from
+        __del__/GC context: this only appends to a list. The actual worker dispatch happens at the next
+        call to tp_host_cache_process_frees from main-line control flow - a live HostPageStore's
+        alloc/store/restore, or the top of the next forward/prefill fan-out.
+        """
+        self.tp_pending_host_cache_frees.append(pool_id)
+
+
+    def tp_host_cache_process_frees(self):
+        """
+        Release any queued dead pools. Callers guarantee main-line context (no fan-out partially dispatched,
+        no rank inside a collective): HostPageStore invokes this before its own alloc/store/restore
+        dispatches, and forward_tp/prefill_tp invoke it before fanning out, so dead pools are released
+        even when no live host store remains.
+        """
+        while self.tp_pending_host_cache_frees:
+            pool_id = self.tp_pending_host_cache_frees.pop()
+            self.tp_worker_dispatch_wait_multi(self.active_devices, mp_host_cache_free, (pool_id,))
+
+
+    def tp_host_cache_store(self, pool_id: int, slot: int, page_index: int):
+        """
+        Offload one GPU cache page (all ranks' shards) into host pool slot. active_devices keeps the
+        output-device pseudo-worker last, so spawned workers receive the command before the main process
+        blocks in the synchronous pseudo-worker call.
+        """
+        self.tp_dispatch_all(mp_host_cache_store, (pool_id, slot, page_index))
+
+
+    def tp_host_cache_restore(self, pool_id: int, slot: int, page_index: int):
+        """
+        Restore one page from host pool slot into the given GPU page across all ranks.
+        """
+        self.tp_dispatch_all(mp_host_cache_restore, (pool_id, slot, page_index))
 
 
     def tp_rotate_cache_pages(self, cache_id: int, all_rotations: torch.Tensor):

--- a/exllamav3/model/model_tp_fn.py
+++ b/exllamav3/model/model_tp_fn.py
@@ -415,12 +415,26 @@ def mp_host_cache_alloc(
     a given page, each covering only its own shard. Pools are keyed by the store's unique pool_id, not the
     cache_id: two HostPageStore generations can briefly coexist over the same cache (a finalizer deferred
     by cyclic GC outliving its replacement), and a stale free must only ever remove its own dead pool.
+
+    Returns None on success or a serializable error description on failure instead of raising. This lets the
+    parent drain every rank's reply before freeing any successful rank's copy of the pool and surfacing the
+    aggregate allocation failure.
     """
+    host_cache_pools = local_context.setdefault("host_cache_pools", {})
     pools = []
-    for t in _host_cache_shard_tensors(local_context, cache_id):
-        pool = torch.empty((num_slots, *t.shape[1:]), dtype = t.dtype, pin_memory = True)
-        pools.append((t, pool))
-    local_context.setdefault("host_cache_pools", {})[pool_id] = pools
+    host_cache_pools[pool_id] = pools
+    try:
+        for t in _host_cache_shard_tensors(local_context, cache_id):
+            pool = torch.empty((num_slots, *t.shape[1:]), dtype = t.dtype, pin_memory = True)
+            pools.append((t, pool))
+    except Exception as exc:
+        host_cache_pools.pop(pool_id, None)
+        return {
+            "device": local_context.get("device"),
+            "type": type(exc).__name__,
+            "message": str(exc),
+        }
+    return None
 
 
 def mp_host_cache_free(

--- a/exllamav3/model/model_tp_fn.py
+++ b/exllamav3/model/model_tp_fn.py
@@ -378,6 +378,90 @@ def mp_rotate_cache_pages(
         ext.cache_rotate(cache, all_rotations, buffer)
 
 
+def _host_cache_shard_tensors(local_context: dict, cache_id: int):
+    """
+    This rank's shard of a TP-split cache, as a flat tensor list in deterministic module order. Ranks
+    holding no KV heads for a module contribute nothing for it.
+    """
+    tensors = []
+    for module in local_context["kv_modules"]:
+        cache_layer = module.tp_cache_lookup[cache_id]
+        for t in cache_layer.get_tensors():
+            if t is not None:
+                tensors.append(t)
+    return tensors
+
+
+def mp_host_cache_page_bytes(
+    local_context: dict,
+    cache_id: int
+):
+    """
+    Size in bytes of one cache page across this rank's shard of the given cache. The main process sums
+    the per-rank sizes to compute how many page slots a host_cache_size budget provides.
+    """
+    return sum(t[0].numel() * t.element_size() for t in _host_cache_shard_tensors(local_context, cache_id))
+
+
+def mp_host_cache_alloc(
+    local_context: dict,
+    cache_id: int,
+    pool_id: int,
+    num_slots: int
+):
+    """
+    Allocate this rank's pinned host pools for a TP host page store: one pool per shard cache tensor,
+    mirroring its per-page shape. Slot indices are global; every rank stores/restores the same slot for
+    a given page, each covering only its own shard. Pools are keyed by the store's unique pool_id, not the
+    cache_id: two HostPageStore generations can briefly coexist over the same cache (a finalizer deferred
+    by cyclic GC outliving its replacement), and a stale free must only ever remove its own dead pool.
+    """
+    pools = []
+    for t in _host_cache_shard_tensors(local_context, cache_id):
+        pool = torch.empty((num_slots, *t.shape[1:]), dtype = t.dtype, pin_memory = True)
+        pools.append((t, pool))
+    local_context.setdefault("host_cache_pools", {})[pool_id] = pools
+
+
+def mp_host_cache_free(
+    local_context: dict,
+    pool_id: int
+):
+    """
+    Release this rank's pinned host pools for the given store. The stream still holding queued copies keeps
+    the tensors alive until they complete; nothing reads the pools afterwards.
+    """
+    local_context.get("host_cache_pools", {}).pop(pool_id, None)
+
+
+def mp_host_cache_store(
+    local_context: dict,
+    pool_id: int,
+    slot: int,
+    page_index: int
+):
+    """
+    Offload this rank's shard of one GPU cache page into host pool slot. Enqueued on the rank's current
+    stream, which also carries its forward passes, so stream order alone protects the page contents until
+    the copy completes (same discipline as the non-TP HostPageStore).
+    """
+    for t, pool in local_context["host_cache_pools"][pool_id]:
+        pool[slot].copy_(t[page_index], non_blocking = True)
+
+
+def mp_host_cache_restore(
+    local_context: dict,
+    pool_id: int,
+    slot: int,
+    page_index: int
+):
+    """
+    Copy this rank's shard of a stored page from host pool slot back into the given GPU page.
+    """
+    for t, pool in local_context["host_cache_pools"][pool_id]:
+        t[page_index].copy_(pool[slot], non_blocking = True)
+
+
 class PseudoParentConn:
     """
     Standin for a Pipe to dispatch functions on the main device rather than a dedicated child process running

--- a/tests/cpu_cache_tp.py
+++ b/tests/cpu_cache_tp.py
@@ -1,0 +1,315 @@
+"""
+Integration test for the CPU page cache tier, including tensor-parallel mode. Script-only (not collected
+by pytest: everything here needs a real model):
+
+    python tests/cpu_cache_tp.py --model <exl3 model dir>              # single-device tier
+    python tests/cpu_cache_tp.py --model <exl3 model dir> --tensor_p   # per-rank pools in TP workers
+
+Verifies, with greedy sampling:
+
+1. GPU prompt cache sanity: an immediate re-run of a multi-page prompt reuses cached pages.
+2. Tier restore after eviction: flooding a small GPU cache pushes evicted pages to the tier; a re-run
+   restores them, and every restored page's K/V is byte-identical to what was offloaded. The byte
+   comparison runs through the same data plane as the feature (local tensor reads, or per-rank worker
+   dispatch under TP), so it validates the offload/restore path independently of token outputs.
+3. Mixed batch: a restored-prefix job, a fresh job and a recently flooded job generated concurrently
+   reproduce their solo outputs.
+4. Lifecycle: replacing a tier-backed generator without an intervening collection must not leak or
+   double-free the worker-side pools (deferred frees drain at the next tier's allocation).
+
+Output-identity checks are gated by a determinism probe: linear-attention models (e.g. GDN) are not
+run-to-run deterministic, so correctness there rests on the byte-level fidelity checks, which do not
+depend on determinism. On hybrid recurrent models the restorable prefix is capped by stashed recurrent
+checkpoints, so restore counts are asserted loosely (> 0) rather than exactly.
+"""
+
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import argparse
+import torch
+from exllamav3 import Model, Config, Cache, Tokenizer, Generator, GreedySampler
+from exllamav3.constants import PAGE_SIZE
+
+checks_passed = 0
+checks_failed = 0
+
+def check(name, cond, detail = ""):
+    global checks_passed, checks_failed
+    if cond:
+        checks_passed += 1
+        print(f"  PASS  {name}")
+    else:
+        checks_failed += 1
+        print(f"  FAIL  {name}")
+        if detail:
+            print(f"        {detail}")
+
+
+def mp_test_fetch_page_bytes(local_context, cache_id, page_index):
+    """
+    Worker-side helper: raw bytes of this rank's shard of one GPU cache page, in deterministic tensor order.
+    Runs in the TP worker processes; .cpu() serializes against the rank's stream, so pending tier copies
+    ordered before this command are reflected.
+    """
+    from exllamav3.model.model_tp_fn import _host_cache_shard_tensors
+    return b"".join(
+        t[page_index].contiguous().cpu().view(torch.uint8).numpy().tobytes()
+        for t in _host_cache_shard_tensors(local_context, cache_id)
+    )
+
+
+def fetch_page_bytes(cpc, page_index):
+    """
+    Raw bytes of one GPU cache page across every cache the tier covers - local tensors directly, TP shards
+    via worker dispatch. Byte-compare of store-time vs fetch-time snapshots is the architecture-independent
+    fidelity check for the offload/restore data plane.
+    """
+    parts = []
+    for t, _, _, _ in cpc.segments:
+        parts.append(t[page_index].contiguous().cpu().view(torch.uint8).numpy().tobytes())
+    for model, cache_id, pool_id in cpc.tp_caches:
+        for device in model.active_devices:
+            parts.append(model.tp_worker_dispatch_single(
+                device, mp_test_fetch_page_bytes, (cache_id, page_index)))
+    return b"".join(parts)
+
+
+def install_kv_fidelity_hooks(cpc, max_snapshots = 8):
+    """
+    Wrap store()/fetch() to snapshot page bytes at offload time and byte-compare them at restore time.
+    Returns the dict of phash -> bool comparison results, filled in as restores happen.
+    """
+    snapshots = {}
+    results = {}
+    orig_store = cpc.store
+    orig_fetch = cpc.fetch
+
+    def snap_store(page, serial, protect = None):
+        orig_store(page, serial, protect)
+        # The page's GPU contents survive until the claiming job's prefill, which is dispatched after this
+        # returns, so the fetch below still observes the exact bytes the store offloaded
+        if page.phash in cpc.entries and page.phash not in snapshots and len(snapshots) < max_snapshots:
+            snapshots[page.phash] = fetch_page_bytes(cpc, page.page_index)
+
+    def check_fetch(phash, page_index, serial):
+        e = orig_fetch(phash, page_index, serial)
+        if phash in snapshots:
+            results[phash] = fetch_page_bytes(cpc, page_index) == snapshots[phash]
+        return e
+
+    cpc.store = snap_store
+    cpc.fetch = check_fetch
+    return results
+
+
+def make_long_prompt(tokenizer, seed_text, target_pages):
+    text = seed_text
+    filler = (
+        " The archive records further details, cross-referenced against seasonal observations"
+        " and the incidental notes of several field assistants over many years of study."
+    )
+    while tokenizer.encode(text).shape[-1] < target_pages * PAGE_SIZE + 16:
+        text += filler
+    return text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required = True, help = "exl3 model directory")
+    ap.add_argument("--max_new_tokens", type = int, default = 32)
+    ap.add_argument("--cache_size", type = int, default = 4096)
+    ap.add_argument("--cpu_cache_mb", type = int, default = 1024)
+    ap.add_argument("--tensor_p", action = "store_true",
+                    help = "Load the model tensor-parallel across all visible devices; the tier then "
+                           "offloads/restores per-rank cache shards through the TP workers")
+    args = ap.parse_args()
+
+    print(f" -- Loading model: {args.model}{' (tensor-parallel)' if args.tensor_p else ''}")
+    config = Config.from_directory(args.model)
+    model = Model.from_config(config)
+    cache_a = Cache(model, max_num_tokens = args.cache_size)
+    cache_b = Cache(model, max_num_tokens = args.cache_size)
+    model.load(progressbar = True, tensor_p = args.tensor_p)
+    tokenizer = Tokenizer.from_config(config)
+    sampler = GreedySampler()
+
+    prompt_a = make_long_prompt(
+        tokenizer,
+        "The migration of songbirds across continents follows magnetic fields and stellar cues.", 6)
+    prompt_c = "The most surprising property of liquid helium below the lambda point is"
+    flood_prompts = [
+        make_long_prompt(tokenizer, f"Flood text number {j} concerns the industrial history of a city.", 5)
+        for j in range(10)
+    ]
+    a_tokens = tokenizer.encode(prompt_a).shape[-1]
+    a_pages = a_tokens // PAGE_SIZE
+    flood_tokens = sum(tokenizer.encode(p).shape[-1] for p in flood_prompts)
+    print(f" -- prompt A: {a_tokens} tokens ({a_pages} full pages); "
+          f"flood: {flood_tokens} tokens vs {args.cache_size}-token cache")
+    assert flood_tokens > args.cache_size * 1.5, "flood too small to guarantee eviction"
+
+    def gen(generator, prompts):
+        completions, results = generator.generate(
+            prompt = prompts,
+            max_new_tokens = args.max_new_tokens,
+            sampler = sampler,
+            completion_only = True,
+            return_last_results = True,
+        )
+        if not isinstance(prompts, list):
+            return completions, results["cached_tokens"]
+        return completions, [r["cached_tokens"] for r in results]
+
+    # Determinism probe: byte-identity of generated text across replays assumes a run-to-run deterministic
+    # forward pass. Linear-attention scans are not; their correctness rests on the byte-fidelity checks.
+    if model.caps.get("linear_attn"):
+        deterministic = False
+        print(" -- Determinism probe: skipped (linear-attention scan is not run-to-run deterministic)")
+    else:
+        probe_gen = Generator(model = model, cache = cache_b, tokenizer = tokenizer)
+        det_a, _ = gen(probe_gen, prompt_c)
+        del probe_gen
+        probe_gen = Generator(model = model, cache = cache_b, tokenizer = tokenizer)
+        det_b, _ = gen(probe_gen, prompt_c)
+        del probe_gen
+        deterministic = det_a == det_b
+        print(f" -- Determinism probe: model is {'' if deterministic else 'NOT '}run-to-run deterministic")
+
+    tier_gen = Generator(model = model, cache = cache_a, tokenizer = tokenizer,
+                         cpu_cache_size = args.cpu_cache_mb * 1024**2)
+    cpc = tier_gen.cpu_page_cache
+    fidelity = install_kv_fidelity_hooks(cpc)
+
+    print(" -- Tier generator: reference run")
+    ref_a, cached_first = gen(tier_gen, prompt_a)
+    ref_c, _ = gen(tier_gen, prompt_c)
+    check("first run of prompt A has no cached prefix", cached_first == 0,
+          f"cached_tokens = {cached_first}")
+
+    print(" -- Tier generator: immediate re-run (GPU prompt cache sanity)")
+    rerun_a, cached_rerun = gen(tier_gen, prompt_a)
+    if tier_gen.recurrent_cache is None:
+        check("immediate re-run reuses GPU-cached pages", cached_rerun >= (a_pages - 1) * PAGE_SIZE,
+              f"cached_tokens = {cached_rerun}, expected >= {(a_pages - 1) * PAGE_SIZE}")
+    else:
+        check("immediate re-run reuses GPU-cached pages (hybrid: capped by checkpoints)", cached_rerun > 0,
+              f"cached_tokens = {cached_rerun}")
+    if deterministic:
+        check("immediate re-run output identical", rerun_a == ref_a,
+              f"got: {rerun_a!r}\nref: {ref_a!r}")
+
+    print(f" -- Tier generator: flooding cache with {len(flood_prompts)} prompts")
+    flood_refs = []
+    for p in flood_prompts:
+        fr, _ = gen(tier_gen, p)
+        flood_refs.append(fr)
+    check("flood evictions pushed pages to the tier", cpc.metrics["pushes"] > 0,
+          f"pushes = {cpc.metrics['pushes']}")
+
+    print(" -- Tier generator: post-flood re-run of prompt A")
+    restored_a, cached_restored = gen(tier_gen, prompt_a)
+    check("post-flood re-run restored pages from the tier", cpc.metrics["restores"] > 0,
+          f"restores = {cpc.metrics['restores']}, cached_tokens = {cached_restored}")
+    if deterministic:
+        check("post-flood output identical to reference", restored_a == ref_a,
+              f"got: {restored_a!r}\nref: {ref_a!r}")
+    check("all restored pages byte-identical to their offloaded contents",
+          len(fidelity) > 0 and all(fidelity.values()),
+          f"fidelity = {fidelity}")
+
+    print(" -- Tier generator: mixed batch after flood")
+    batch, _ = gen(tier_gen, [prompt_a, prompt_c, flood_prompts[0]])
+    if deterministic:
+        check("mixed batch: restored-prefix job matches solo output", batch[0] == ref_a)
+        check("mixed batch: fresh job matches solo output", batch[1] == ref_c)
+        check("mixed batch: recent flood job matches solo output", batch[2] == flood_refs[0])
+    else:
+        check("mixed batch: all jobs produced output", all(len(b) > 0 for b in batch))
+
+    # Lifecycle: replace the tier-backed generator without a prompt collection. The fidelity hooks above
+    # form a reference cycle (cpc.store -> closure -> cpc), so the old tier's finalizer only runs at a
+    # cyclic GC point - possibly after the replacement tier has already allocated its pools. Its deferred
+    # frees are keyed by its own pool generation and must never touch the new tier's pools. Regression for
+    # double-free/stale-pool bugs across store generations.
+    print(" -- Lifecycle: replace tier-backed generator, old tier finalized late")
+    import gc
+    import weakref
+    cpc_ref = weakref.ref(cpc)
+    del tier_gen, cpc
+    tier_gen2 = Generator(model = model, cache = cache_b, tokenizer = tokenizer,
+                          cpu_cache_size = args.cpu_cache_mb * 1024**2)
+    lc_a, _ = gen(tier_gen2, prompt_a)
+    for p in flood_prompts[:4]:
+        gen(tier_gen2, p)
+    # Finalize the old tier now; its frees queue against dead pools only. The alloc thread briefly holds a
+    # strong reference once per polling cycle, so allow a couple of retries before declaring it retained.
+    import time as time_mod
+    for _ in range(4):
+        gc.collect()
+        if cpc_ref() is None:
+            break
+        time_mod.sleep(0.6)
+    check("dead tier is collectable (alloc thread must not retain it)", cpc_ref() is None,
+          "the background pinning thread is keeping the abandoned CPUPageCache alive; its pinned slabs "
+          "and any worker-side pools leak until process exit")
+    lc_a2, _ = gen(tier_gen2, prompt_a)   # next dispatches drain the frees, then keep working
+    check("replacement tier generator stores and restores",
+          tier_gen2.cpu_page_cache.metrics["pushes"] > 0,
+          f"pushes = {tier_gen2.cpu_page_cache.metrics['pushes']}")
+    if deterministic:
+        check("replacement tier generator output correct", lc_a == lc_a2 == restored_a)
+
+    # Abandon a tier mid-preallocation: the pinning worker holds no reference to the (cyclic) cache, so
+    # collection must not be deferred until the full budget is pinned. _make_slab is gated after the first
+    # slab, guaranteeing preallocation is provably in flight when the generator is dropped; the finalizer
+    # must stop the worker, which then exits without pinning to capacity.
+    print(" -- Lifecycle: abandon tier mid-preallocation")
+    import threading
+    import exllamav3.generator.cpu_cache as cc_mod
+    if tier_gen2.cpu_page_cache._alloc_state is None:
+        print("        (pure-TP tier: no local slabs to preallocate; covered by the single-device run)")
+    else:
+        del tier_gen2
+        gate = threading.Event()
+        made = []
+        orig_make = cc_mod._make_slab
+        def gated_make(slot_size, layouts):
+            if made:
+                gate.wait(timeout = 30)
+            made.append(1)
+            return orig_make(slot_size, layouts)
+        cc_mod._make_slab = gated_make
+        try:
+            g3 = Generator(model = model, cache = cache_a, tokenizer = tokenizer,
+                           cpu_cache_size = args.cpu_cache_mb * 1024**2)
+            state3 = g3.cpu_page_cache._alloc_state
+            thread3 = g3.cpu_page_cache._alloc_thread
+            ref3 = weakref.ref(g3.cpu_page_cache)
+            del g3
+            collected = False
+            for _ in range(4):
+                gc.collect()
+                if ref3() is None:
+                    collected = True
+                    break
+                time_mod.sleep(0.3)
+            check("tier abandoned mid-preallocation is collectable", collected,
+                  "the pinning worker is retaining the cache; its full budget would pin before cleanup")
+            check("finalizer stopped the pinning worker", state3.stopped)
+            n_before = len(made)
+            gate.set()
+            thread3.join(timeout = 10)
+            check("worker exited without preallocating to capacity",
+                  not thread3.is_alive() and len(made) <= n_before + 1,
+                  f"thread alive = {thread3.is_alive()}, slabs made = {len(made)}, "
+                  f"target = {state3.target}")
+        finally:
+            cc_mod._make_slab = orig_make
+            gate.set()
+
+    print(f"\n -- {checks_passed} passed, {checks_failed} failed")
+    sys.exit(1 if checks_failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cpu_cache_lifecycle.py
+++ b/tests/test_cpu_cache_lifecycle.py
@@ -1,0 +1,182 @@
+"""
+Model-free lifecycle tests for CPUPageCache's tensor-parallel pool management, using fake TP models. The
+pure-TP configuration allocates no local slabs and starts no threads, so construction and teardown can be
+exercised entirely on CPU.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from exllamav3.generator.cpu_cache import CPUPageCache
+from exllamav3.model.model_tp import Model_TPMixin
+from exllamav3.model.model_tp_fn import mp_host_cache_alloc, mp_host_cache_free
+import exllamav3.model.model_tp_fn as model_tp_fn
+
+
+class _FakeTPModel:
+    """Records the worker-side pool commands a real Model_TPMixin would dispatch to its ranks."""
+    loaded_tp = True
+
+    def __init__(self, page_bytes = 4096, fail_alloc = False):
+        self.page_bytes = page_bytes
+        self.fail_alloc = fail_alloc
+        self.allocated_pool_ids = []
+        self.pending_frees = []
+        self.freed_pool_ids = []
+
+    def tp_host_cache_process_frees(self):
+        while self.pending_frees:
+            self.freed_pool_ids.append(self.pending_frees.pop())
+
+    def tp_host_cache_page_bytes(self, cache_id):
+        return self.page_bytes
+
+    def tp_host_cache_alloc(self, cache_id, pool_id, num_slots):
+        # Record before raising to model a TP fan-out where one rank allocated pool_id before another failed.
+        self.allocated_pool_ids.append(pool_id)
+        if self.fail_alloc:
+            raise RuntimeError("injected worker allocation failure")
+
+    def tp_host_cache_free_deferred(self, pool_id):
+        self.pending_frees.append(pool_id)
+
+
+class _FakeTPCache:
+    def __init__(self, model):
+        self.model = model
+        self.layers = {}
+
+
+def test_tp_pool_rollback_on_init_failure():
+    # A failure while allocating the second cache's pools must queue frees for the pools that already
+    # succeeded: no finalizer exists yet at that point, so without explicit rollback the first cache's
+    # worker-side pinned memory would survive until model teardown.
+    model_ok = _FakeTPModel()
+    model_bad = _FakeTPModel(fail_alloc = True)
+    with pytest.raises(RuntimeError, match = "injected worker allocation failure"):
+        CPUPageCache([_FakeTPCache(model_ok), _FakeTPCache(model_bad)], max_size = 1 << 20)
+    assert len(model_ok.allocated_pool_ids) == 1
+    assert model_ok.freed_pool_ids == model_ok.allocated_pool_ids, \
+        f"allocated {model_ok.allocated_pool_ids} but freed {model_ok.freed_pool_ids}"
+    assert model_bad.freed_pool_ids == model_bad.allocated_pool_ids, \
+        f"partially allocated {model_bad.allocated_pool_ids} but freed {model_bad.freed_pool_ids}"
+    assert model_ok.pending_frees == [] and model_bad.pending_frees == []
+
+
+def test_tp_allocation_fanout_is_drained_before_failure():
+    # Worker allocation errors are returned as status values, so the parent sees every rank's reply, frees
+    # the attempted pool everywhere, and only then raises. The fake dispatch returns the complete result list
+    # that a real drain-safe fan-out produces.
+    class _FakeFanout:
+        active_devices = [0, 1]
+
+        def __init__(self):
+            self.commands = []
+
+        def tp_worker_dispatch_wait_multi(self, devices, fn, args):
+            self.commands.append((fn, args))
+            if fn is mp_host_cache_alloc:
+                return [
+                    None,
+                    {
+                        "device": 1,
+                        "type": "RuntimeError",
+                        "message": "injected rank allocation failure",
+                    },
+                ]
+            assert fn is mp_host_cache_free
+            return [None, None]
+
+    model = _FakeFanout()
+    with pytest.raises(RuntimeError, match = "device 1.*injected rank allocation failure"):
+        Model_TPMixin.tp_host_cache_alloc(model, cache_id = 10, pool_id = 20, num_slots = 30)
+    assert model.commands == [
+        (mp_host_cache_alloc, (10, 20, 30)),
+        (mp_host_cache_free, (20,)),
+    ]
+
+
+def test_worker_allocation_failure_removes_partial_local_pool(monkeypatch):
+    # A rank can fail after pinning some of its cache tensors. It must return an ordinary error status and
+    # remove the partially built pool locally; raising would make the parent's multi-rank wait stop early.
+    class _FakeLayer:
+        def get_tensors(self):
+            return [
+                SimpleNamespace(shape = (4, 2), dtype = torch.float16),
+                SimpleNamespace(shape = (4, 3), dtype = torch.float16),
+            ]
+
+    class _FakeModule:
+        tp_cache_lookup = {10: _FakeLayer()}
+
+    allocations = []
+
+    def fake_empty(shape, dtype, pin_memory):
+        if allocations:
+            raise RuntimeError("injected second-tensor allocation failure")
+        pool = SimpleNamespace(shape = shape, dtype = dtype, pin_memory = pin_memory)
+        allocations.append(pool)
+        return pool
+
+    monkeypatch.setattr(model_tp_fn.torch, "empty", fake_empty)
+    local_context = {
+        "device": 1,
+        "kv_modules": [_FakeModule()],
+    }
+    result = mp_host_cache_alloc(local_context, cache_id = 10, pool_id = 20, num_slots = 30)
+    assert result == {
+        "device": 1,
+        "type": "RuntimeError",
+        "message": "injected second-tensor allocation failure",
+    }
+    assert 20 not in local_context["host_cache_pools"]
+
+
+def test_failed_deferred_free_remains_queued():
+    class _FakeFanout:
+        active_devices = [0, 1]
+        tp_pending_host_cache_frees = [20]
+
+        def __init__(self):
+            self.fail = True
+
+        def tp_worker_dispatch_wait_multi(self, devices, fn, args):
+            assert fn is mp_host_cache_free
+            assert args == (20,)
+            if self.fail:
+                raise RuntimeError("injected cleanup failure")
+            return [None, None]
+
+    model = _FakeFanout()
+    with pytest.raises(RuntimeError, match = "injected cleanup failure"):
+        Model_TPMixin.tp_host_cache_process_frees(model)
+    assert model.tp_pending_host_cache_frees == [20]
+
+    model.fail = False
+    Model_TPMixin.tp_host_cache_process_frees(model)
+    assert model.tp_pending_host_cache_frees == []
+
+
+def test_closed_tier_is_terminal():
+    # close() queues the worker pools for release; store()/fetch() afterwards must fail immediately rather
+    # than dispatch page copies against pools the ranks may already have dropped.
+    model = _FakeTPModel()
+    cpc = CPUPageCache([_FakeTPCache(model)], max_size = 1 << 20)
+    cpc.close()
+    assert model.pending_frees == model.allocated_pool_ids
+
+    class _FakePage:
+        phash = b"\x01" * 16
+        prev_hash = None
+        page_index = 0
+        sequence = torch.zeros((1, 4), dtype = torch.long)
+
+    with pytest.raises(RuntimeError, match = "closed"):
+        cpc.store(_FakePage(), serial = 1)
+    with pytest.raises(RuntimeError, match = "closed"):
+        cpc.fetch(b"\x01" * 16, page_index = 0, serial = 2)
+
+    cpc.close()  # idempotent
+    assert model.pending_frees == model.allocated_pool_ids


### PR DESCRIPTION
Fifth and final PR in the series (#264, #265, #266, #267) rebasing my independently developed prefix-cache work onto dev. Independent of the others — applies directly to dev. Closes the `TODO: Add TP support for CPU cache`.

**The change:** with a TP-loaded model the cache tensors live sharded across the worker processes, so the tier's data plane moves there too. Each rank allocates pinned pools covering its own shard up front; `store`/`fetch` dispatch per-page commands to every rank under the same global slot index. All metadata — hashes, eviction order, token ids, dedup — stays in `CPUPageCache`, and the per-rank command pipes preserve ordering against forward passes exactly as the shared stream does in the single-process case, so no events or synchronization are added. Local and TP caches mix freely (e.g. TP target + single-device draft); a pure-TP tier skips the slab machinery entirely.

Worker-side pool lifetime is GC-safe by construction: pools are only ever *queued* for release (a finalizer can run at any GC point, even with a rank blocked in a collective) and the queue drains at known-quiet boundaries — tier dispatches or the top of `forward_tp`/`prefill_tp`. Pools are keyed by a per-store-generation id so a finalizer deferred past its replacement can only free its own dead pools.

**Also fixes a pre-existing leak in the tier's slab preallocation.** On current dev, the background pinning worker is a bound-method thread: it holds a strong reference to the `CPUPageCache` forever, so an abandoned tier (e.g. a replaced generator) is never collected and its pinned slabs leak until process exit — repeated generator replacement accumulates pinned host memory without bound. TP support raises the stakes (the per-rank pools would leak the same way), so this PR restructures preallocation around a small shared allocation-state object that holds no reference back to the cache. The worker sees only that state; shutdown runs through a `weakref.finalize` (fires on any form of collection, including cyclic GC mid-preallocation, or via a new idempotent `close()`) that stops the worker and queues the TP pool frees. Foreground and background allocations reserve against a shared target under one condition variable, so the pinned total can never exceed the configured budget even with a slab in flight, and allocation failures return their reservation. Lifecycle regressions cover both the late-finalizer replacement scenario and abandonment mid-preallocation.

**Tests** (`tests/cpu_cache_tp.py`, script-only — everything needs a model): flood/restore with byte-level KV fidelity hooks that snapshot page bytes at store time and compare after restore *through the same data plane* (local reads, or per-rank worker dispatch under TP); mixed batch; the two lifecycle regressions; and a determinism probe that gates output-identity checks off for linear-attention models (scan kernels are not run-to-run deterministic — byte fidelity carries correctness there). 11/11 single-device and 8/8 tensor-parallel (2 GPUs) on Qwen3.5-4B.
