### PR TITLE
docs: fix non-existent `-eb` flag in convert.py multi-GPU example

### DIFF
--- a/doc/convert.md
+++ b/doc/convert.md
@@ -82,14 +82,14 @@ python convert.py -i /mnt/models/llama3.1-70b-instruct \
                   -d 0,1,2
 ```
 
-Convert a model on the first three devices, using CUDA:2 as the primary device and distributing 3/12, 4/12 and 5/12 of the workload to CUDA:2, CUDA:0 and CUDA:1, respectively. Also keep attention etc. in higher precision with `-eb`. Final model size will be slightly larger than the 4.00 bpw requested in this example, but since this is an MoE model, the increase will be on the order of 0.05 - 0.1 bpw:
+Convert a model on the first three devices, using CUDA:2 as the primary device and distributing 3/12, 4/12 and 5/12 of the workload to CUDA:2, CUDA:0 and CUDA:1, respectively. Also keep attention etc. in higher precision with `-hq`. Final model size will be slightly larger than the 4.00 bpw requested in this example, but since this is an MoE model, the increase will be on the order of 0.05 - 0.1 bpw:
 
 ```sh
 python convert.py -i /mnt/models/qwen3.5-35b-a3b \
                   -o /mnt/models/qwen3.5-35b-a3b-4.00bpw-plus \
                   -w /mnt/temp/exl3 \
                   -b 4.00 \
-                  -eb \
+                  -hq \
                   -d 2,0,1 \
                   -dr 3,4,5
 ```


### PR DESCRIPTION
The **Multi-GPU quant** example in `doc/convert.md` (and the sentence above it) tells users to pass `-eb` to keep attention/expert layers at higher precision:

```sh
python convert.py -i /mnt/models/qwen3.5-35b-a3b \
                  -o /mnt/models/qwen3.5-35b-a3b-4.00bpw-plus \
                  -w /mnt/temp/exl3 \
                  -b 4.00 \
                  -eb \        # <- no such argument
                  -d 2,0,1 \
                  -dr 3,4,5
```

But `convert.py` (`exllamav3/conversion/convert_model.py`) defines no `-eb` / `--eb`, and the parser is created with `allow_abbrev=False`, so copy-pasting the documented command aborts:

```
error: unrecognized arguments: -eb
```
(exit code 2 — before any work starts.)

The intended flag is **`-hq / --hq`**. Its description in this same doc matches the `-eb` sentence essentially word-for-word — *"Increase the bitrate of select layers, such as attention and shared-expert layers ... very small increase in size (0.05 - 0.10 bpw) ... for MoE models"* — so this is a stale/renamed flag name in the example, not a missing feature. (It is **not** `-hb / --head_bits`, which controls the output head layer.)

This PR updates both occurrences (the prose on line 85 and the command on line 92) to `-hq`. Docs-only, no code change.