### PR TITLE
Add logit_bias sampler parameter

### DIFF
--- a/exllamav3/generator/sampler/__init__.py
+++ b/exllamav3/generator/sampler/__init__.py
@@ -17,6 +17,7 @@ from .custom import (
     SS_PresFreqP,
     SS_AdaptiveP,
     SS_BanTokens,
+    SS_LogitBias,
     SS_XTC,
     xtc_default_protected_token_ids,
 )

--- a/exllamav3/generator/sampler/custom.py
+++ b/exllamav3/generator/sampler/custom.py
@@ -577,6 +577,63 @@ class SS_BanTokens(SS_Base):
         return None
 
 
+class LogitBias:
+    """
+    Additive per-token logit bias vector with per (vocab size, device) caching. Token IDs outside
+    the vocabulary are ignored.
+    """
+    def __init__(self, logit_bias: dict[int, float]):
+        # keep finite biases and -inf (a hard ban); drop 0, nan and any value that
+        # overflows float32 to +inf (which would poison softmax and crash sampling).
+        # The bound is checked in float32 since the bias vector is float32; -inf and
+        # large negatives fall through as bans.
+        f32_max = torch.finfo(torch.float32).max
+        self.logit_bias = {
+            int(t): float(v) for t, v in logit_bias.items()
+            if float(v) != 0.0 and float(v) == float(v) and float(v) <= f32_max
+        }
+        self.vectors = {}
+
+    def get(self, dim: int, device: torch.device) -> torch.Tensor:
+        key = (dim, device)
+        vector = self.vectors.get(key)
+        if vector is None:
+            vector = torch.zeros((dim,), dtype = torch.float, device = device)
+            items = [(t, v) for t, v in self.logit_bias.items() if 0 <= t < dim]
+            if items:
+                ids = torch.tensor([t for t, _ in items], dtype = torch.long, device = device)
+                vals = torch.tensor([v for _, v in items], dtype = torch.float, device = device)
+                vector[ids] = vals
+            self.vectors[key] = vector
+        return vector
+
+
+class SS_LogitBias(SS_Base):
+    """
+    Add a fixed per-token bias to the logits, OAI style (the logit_bias sampler parameter). Must be
+    among the first steps in the sampler chain, before the logits are transformed. A bias of
+    -inf bans a token; zero, nan and +inf biases are ignored.
+    """
+    def __init__(self, logit_bias: dict[int, float]):
+        self.bias = LogitBias(logit_bias)
+
+    def run(self, state: SamplingState):
+        match state.state:
+            case SS.INIT:
+                state.logits = state.in_logits.to(torch.float, copy = True)
+                state.logits += self.bias.get(state.dim, state.logits.device)
+            case SS.LOGITS:
+                state.logits += self.bias.get(state.dim, state.logits.device)
+            case _:
+                raise ValueError("Sampling logic error")
+        state.state = SS.LOGITS
+
+    def alt(self):
+        if not self.bias.logit_bias:
+            return SS_NoOp()
+        return None
+
+
 @lru_cache(10)
 def xtc_default_protected_token_ids(tokenizer: Tokenizer) -> frozenset[int]:
     """
@@ -907,7 +964,7 @@ class CustomSampler(Sampler):
         fused_tail = None
         if fused_sampler_enable:
             i = 0
-            while i < len(simplified) and type(simplified[i]) in (SS_RepP, SS_PresFreqP, SS_BanTokens):
+            while i < len(simplified) and type(simplified[i]) in (SS_RepP, SS_PresFreqP, SS_BanTokens, SS_LogitBias):
                 i += 1
             fused_tail = _match_fused_tail(simplified[i:])
             if fused_tail is not None:

--- a/exllamav3/generator/sampler/presets.py
+++ b/exllamav3/generator/sampler/presets.py
@@ -97,9 +97,11 @@ class ComboSampler(CustomSampler):
         temp_last: bool = False,
         adaptive_target: float = 1.0,
         adaptive_decay: float = 0.9,
+        logit_bias: dict[int, float] | None = None,
     ):
         # Steps with default parameters become no-ops
         stack = [
+            SS_LogitBias(logit_bias or {}),
             SS_RepP(rep_p, rep_sustain_range, rep_decay_range),
             SS_PresFreqP(pres_p, freq_p, rep_sustain_range, rep_decay_range),
         ]

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -221,6 +221,38 @@ custom_test_cases = [
         "input": [[2.0, 1.0, 0.0, -1.0]],
         "expect_probs": [[0.169081, 0.236883, 0.087144, 0.032059]],
     },
+    {
+        # logit_bias adds a per-token value to the logits; out-of-range IDs are ignored and the
+        # two batch rows share the same bias vector
+        "name": "logit_bias",
+        "sampler": CustomSampler([
+            SS_LogitBias({1: 5.0, 3: -2.0, 100: 9.0}),
+            SS_Sample_mn()
+        ]),
+        "input": [[1.0, 1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0, 0.0]],
+        "expect_logits": [[1.0, 6.0, 1.0, -1.0, 1.0], [0.0, 5.0, 0.0, -2.0, 0.0]],
+    },
+    {
+        # logit_bias with -inf bans a token, matching a hard mask
+        "name": "logit_bias ban",
+        "sampler": CustomSampler([
+            SS_LogitBias({2: -float("inf")})
+        ]),
+        "input": [[1.0, 2.0, 3.0, 4.0]],
+        "expect_logits": [[1.0, 2.0, ni, 4.0]],
+    },
+    {
+        # logit_bias after another logits step exercises the SS.LOGITS branch; zero and
+        # non-finite bias values are dropped, so token 0 (nan) and token 3 (0.0) are unchanged
+        "name": "logit_bias, after ban_tokens",
+        "sampler": CustomSampler([
+            SS_BanTokens([2]),
+            SS_LogitBias({0: float("nan"), 1: 4.0, 3: float("inf")})
+        ]),
+        "input": [[1.0, 1.0, 1.0, 1.0]],
+        # nan and +inf biases are dropped (tokens 0 and 3 unchanged); 4.0 adds to token 1
+        "expect_logits": [[1.0, 5.0, ni, 1.0]],
+    },
 ]
 
 
@@ -374,6 +406,10 @@ def test_fused_collapse():
     assert fused_mode(CustomSampler([
         SS_BanTokens([1, 2]), SS_Temperature(0.8), SS_MinP(0.05), SS_Sample()
     ])) == SS_Fused.MODE_SAMPLE_MINP
+    # A leading logit_bias step also keeps a fused tail
+    assert fused_mode(ComboSampler(
+        temperature = 0.8, min_p = 0.05, logit_bias = {1: 5.0}
+    )) == SS_Fused.MODE_SAMPLE_MINP
     # Reference/multinomial nodes and non-canonical filter orders stay on the eager path
     assert fused_mode(CustomSampler([SS_MinP(0.1), SS_Sample_mn()])) is None
     assert fused_mode(CustomSampler([SS_TopP(0.9), SS_MinP(0.1), SS_Temperature(0.8), SS_Sample()])) is None


### PR DESCRIPTION
Adds the OAI-style `logit_bias` sampler parameter as `SS_LogitBias`. This is the exllamav3-side building block for #270 — the warning the issue quotes (`Ignoring sampler params not supported by the exllamav3 backend: dry_multiplier, logit_bias`) is emitted by TabbyAPI, which also needs a small change to pass the parameter through; I'll open that companion PR against TabbyAPI. (`dry_multiplier` is not included here.)

`SS_LogitBias` adds a fixed per-token bias to the logits, modeled on `SS_RepP`: it runs among the first steps, before the logits are transformed. A bias of `-inf` bans a token; zero, `nan`, and values that overflow float32 to `+inf` are ignored. The bias vector is cached per (vocab size, device) like `TokenMask`, a leading bias step participates in the fused-sampler fast path like `SS_BanTokens`, and it no-ops when empty. Wired into `ComboSampler` as `logit_bias=...`.

Note: exllamav2 applies its token bias *after* the (multiplicative) repetition penalty; this applies `logit_bias` to the raw logits, matching the OAI meaning of the parameter.

Three cases added to `tests/test_sampler.py` (additive with OOB/zero/nan/+inf handling across a batch; `-inf` ban; a chain that exercises the `SS.LOGITS` branch) plus a fused-collapse assertion. The sampler test suite passes (140/140).
