### PR TITLE
Add DRY sampler stage (SS_DRY)

### DIFF
--- a/exllamav3/generator/sampler/__init__.py
+++ b/exllamav3/generator/sampler/__init__.py
@@ -15,11 +15,14 @@ from .custom import (
     SS_NoOp,
     SS_RepP,
     SS_PresFreqP,
+    SS_DRY,
     SS_AdaptiveP,
     SS_BanTokens,
     SS_LogitBias,
     SS_XTC,
     xtc_default_protected_token_ids,
+    dry_default_sequence_breaker_tokens,
+    dry_sequence_breaker_tokens,
 )
 from .presets import (
     DefaultSampler,

--- a/exllamav3/generator/sampler/custom.py
+++ b/exllamav3/generator/sampler/custom.py
@@ -45,6 +45,7 @@ class SamplingState:
     probs: torch.Tensor | None = None
     indices: torch.Tensor | None = None
     past_ids: torch.Tensor | None = None
+    tokenizer: Tokenizer | None = None
     state: SS = SS.INIT
     # Logit mask deferred into the fused kernel (fused-only stacks); fused_dim bounds the vocab
     # scan and doubles as the -inf padding of a mask narrower than the logits
@@ -861,6 +862,233 @@ class SS_PresFreqP(SS_Base):
         return True
 
 
+@lru_cache(64)
+def dry_sequence_breaker_tokens(
+    tokenizer: Tokenizer,
+    sequence_breakers: tuple[str, ...]
+) -> frozenset[int]:
+    """
+    Resolve sequence breaker strings for SS_DRY to token IDs, being every token whose piece
+    contains one of the strings. llama.cpp resolves breaker strings the same way for its
+    single-token breakers (get_overlapping_token_sequences); the multi-token restart sequences
+    it additionally builds from partially overlapping tokens are not supported here.
+    """
+    pieces = tokenizer.get_id_to_piece_list(include_special_tokens = True)
+    return frozenset(
+        t for t, piece in enumerate(pieces) if any(s in piece for s in sequence_breakers)
+    )
+
+
+@lru_cache(10)
+def dry_default_sequence_breaker_tokens(tokenizer: Tokenizer) -> frozenset[int]:
+    """
+    Default set of sequence breaker token IDs for SS_DRY, being every piece containing one of
+    the characters .,!?<>[](){}\\n\\t" plus every extended token. Matches
+    ExLlamaV2Sampler.get_dry_default_sequence_breaker_tokens in exllamav2.
+    """
+    breakers = dry_sequence_breaker_tokens(tokenizer, tuple('.,!?<>[](){}\n\t"'))
+    return frozenset(breakers | set(tokenizer.extended_id_to_piece.keys()))
+
+
+# llama.cpp's FLOAT_MAX_LOG: ln of the largest float32
+_DRY_FLOAT_MAX_LOG = 88.7228391
+
+# Matches at or beyond the exponent clamp all produce the same penalty, so the match scan stops
+# there. _DRY_MATCH_CAP bounds the scan where the clamp cannot (dry_base near 1), and
+# _DRY_CHUNK_NUMEL bounds the [offsets, match cap] comparison transients
+_DRY_MATCH_CAP = 2048
+_DRY_CHUNK_NUMEL = 8 * 1024 * 1024
+
+
+@lru_cache(10)
+def _dry_default_breaker_mask(tokenizer: Tokenizer) -> TokenMask | None:
+    """
+    Default breaker set for a tokenizer as a shared TokenMask, so samplers built without
+    explicit breakers resolve them per tokenizer at sampling time.
+    """
+    ids = dry_default_sequence_breaker_tokens(tokenizer)
+    return TokenMask(ids) if ids else None
+
+
+def _dry_max_exponent(base: float) -> int:
+    """
+    llama.cpp's exponent clamp: FLOAT_MAX_LOG / log(dry_base) computed entirely in float32,
+    truncated to int, with 0 (no clamp) for bases too close to 1. The float32 arithmetic decides
+    which side of the truncation the quotient lands on: base = 2.0 gives exactly 128 in float32
+    where float64 gives 127.99999998 -> 127.
+    """
+    base_f = torch.tensor(base, dtype = torch.float)
+    if not (base_f > torch.tensor(1.000001, dtype = torch.float)).item():
+        return 0
+    return int(torch.tensor(_DRY_FLOAT_MAX_LOG, dtype = torch.float) / base_f.log())
+
+
+class SS_DRY(SS_Base):
+    """
+    Apply the DRY (Don't Repeat Yourself) repetition penalty based on past token IDs. Must be one
+    of the first steps in the sampler chain, before the logits are transformed.
+
+    A token that would extend a sequence already seen in the context is penalized by
+    multiplier * base ** (match_length - allowed_length), subtracted from its logit, where
+    match_length is the length of the longest context suffix whose earlier repetition the token
+    would continue. The matching semantics and the float32 exponent clamp follow llama.cpp's
+    llama_sampler_dry_apply (ported to koboldcpp-derived runtimes by pi6am; the scheme was
+    designed by p-e-w), with two divergences: sequence breakers are single tokens, where
+    llama.cpp additionally builds multi-token restart sequences from partially overlapping
+    tokens, and match lengths are capped at 2048, so where allowed_length plus llama.cpp's
+    exponent clamp exceeds 2048 (dry_base below ~1.044 at the default allowed_length) a verbatim
+    repeat longer than the cap is penalized as a 2048-token repeat. The parameter surface
+    follows exllamav2, including dry_range = 0 meaning the whole context. exllamav2's own DRY is
+    a different algorithm (an occurrence-counting trie), so outputs are not expected to match it.
+
+    The scan runs on the device holding past_ids and costs
+    O(window * min(allowed_length + clamp, 2048)) comparisons per sampled token (160 per window
+    token at the default base), which is why dry_range should be capped for very long contexts.
+    """
+    def __init__(
+        self,
+        dry_multiplier: float = 0.0,
+        dry_base: float = 1.75,
+        dry_allowed_length: int = 2,
+        dry_range: int = 0,
+        dry_sequence_breakers: frozenset[int] | set[int] | list[int] | None = None,
+        tokenizer: Tokenizer | None = None,
+    ):
+        """
+        :param dry_multiplier:
+            Scale of the penalty. 0.0 disables the step. Negative values are not accepted (they
+            would reward repetition)
+        :param dry_base:
+            Base of the exponential penalty growth per token of match length. Values below 1.0
+            disable the step, matching llama.cpp
+        :param dry_allowed_length:
+            Longest repeated sequence that goes unpenalized; a token extending a repeat beyond
+            this length is penalized
+        :param dry_range:
+            Number of most recent past tokens to consider. 0 or negative considers the whole
+            context, following the exllamav2 convention for this parameter
+        :param dry_sequence_breakers:
+            Token IDs that repeated sequences cannot span, so that e.g. punctuation or chat
+            template markers do not count as repetition. Breaker tokens are never penalized.
+            None derives the default set via dry_default_sequence_breaker_tokens, from the
+            tokenizer given here or from the one passed to forward() at sampling time (the
+            generator passes its tokenizer); pass an empty set to disable breakers. Custom
+            breaker strings resolve to IDs via dry_sequence_breaker_tokens
+        :param tokenizer:
+            Used to derive the default breaker set when dry_sequence_breakers is None. Ignored
+            if dry_sequence_breakers is given
+        """
+        assert dry_multiplier >= 0.0, "dry_multiplier must be non-negative"
+        assert isinstance(dry_allowed_length, int) or dry_allowed_length.is_integer(), \
+            "dry_allowed_length must be integer"
+        assert dry_allowed_length >= 0, "dry_allowed_length must be non-negative"
+        assert isinstance(dry_range, int) or dry_range.is_integer(), "dry_range must be integer"
+        # With no explicit breakers and no tokenizer bound here, the default set is resolved
+        # per tokenizer at sampling time instead
+        self.default_breakers = dry_sequence_breakers is None and tokenizer is None
+        if dry_sequence_breakers is None and tokenizer is not None:
+            dry_sequence_breakers = dry_default_sequence_breaker_tokens(tokenizer)
+        # llama.cpp stores dry_multiplier and dry_base as float32 and computes the penalty from
+        # the rounded values; round here so identical settings give identical penalties
+        self.dry_multiplier = float(torch.tensor(dry_multiplier, dtype = torch.float))
+        self.dry_base = float(torch.tensor(dry_base, dtype = torch.float))
+        self.dry_allowed_length = int(dry_allowed_length)
+        self.dry_range = int(dry_range)
+        self.max_exponent = _dry_max_exponent(self.dry_base)
+        self.breakers = TokenMask(dry_sequence_breakers) if dry_sequence_breakers else None
+        self.base_t = {}
+
+    def _apply_row(self, logits: torch.Tensor, past: torch.Tensor, dim: int, breakers: TokenMask | None):
+        n = past.shape[-1]
+        m = n if self.dry_range <= 0 else min(n, self.dry_range)
+        if m <= self.dry_allowed_length:
+            return
+        # Reversed window, r[0] being the most recent token
+        r = past[n - m:].flip(0)
+        device = r.device
+
+        # The nearest breaker caps a match at its distance from the end of the context. Matches
+        # without breakers are bounded by the window itself, so no cap is needed then
+        if breakers is not None:
+            mask = breakers.get(dim, device)
+            rb = mask[r.clamp(min = 0, max = dim - 1)] & (r >= 0) & (r < dim)
+            rep_limit = torch.where(rb, torch.arange(m, device = device), m).min()
+        else:
+            mask = None
+            rep_limit = None
+
+        # For each offset k into the past, the length of the match between the window suffix
+        # and the sequence ending k tokens earlier is the run of leading True in
+        # r[j] == r[j + k]. The token that followed the earlier sequence is charged with the
+        # longest match it would extend. Offsets are chunked to bound the [C, J] transients.
+        # Uncharged offsets scatter into an extra slot at dim so the loop stays free of
+        # host-device syncs
+        j_cap = min(self.dry_allowed_length + self.max_exponent, _DRY_MATCH_CAP) \
+            if self.max_exponent > 0 else _DRY_MATCH_CAP
+        J = max(1, min(m - 1, j_cap))
+        suffix = r[:J]
+        jj = torch.arange(J, device = device)
+        l_max = torch.full((dim + 1,), -1, dtype = torch.long, device = device)
+        chunk = max(1, _DRY_CHUNK_NUMEL // J)
+        for k0 in range(1, m, chunk):
+            ks = torch.arange(k0, min(k0 + chunk, m), device = device)
+            idx = ks[:, None] + jj[None, :]
+            eq = (r[idx.clamp(max = m - 1)] == suffix[None, :]) & (idx < m)
+            length = eq.cumprod(dim = 1, dtype = torch.int8).sum(dim = 1, dtype = torch.long)
+            if rep_limit is not None:
+                length = torch.minimum(length, rep_limit)
+            followers = r[ks - 1]
+            charge = (length >= self.dry_allowed_length) & (followers >= 0) & (followers < dim)
+            l_max.scatter_reduce_(
+                0,
+                torch.where(charge, followers, dim),
+                torch.where(charge, length, -1),
+                reduce = "amax"
+            )
+
+        l_max = l_max[:dim]
+        charged = l_max >= 0
+        if mask is not None:
+            charged &= ~mask
+        exponent = l_max - self.dry_allowed_length
+        if self.max_exponent > 0:
+            exponent = exponent.clamp(max = self.max_exponent)
+        base_t = self.base_t.get(device)
+        if base_t is None:
+            base_t = torch.tensor(self.dry_base, dtype = torch.double, device = device)
+            self.base_t[device] = base_t
+        # llama.cpp's std::pow promotes to double and the result saturates when converted to
+        # float32, so an oversized penalty lands the logit at -inf rather than overflowing early
+        penalty = self.dry_multiplier * torch.pow(base_t, exponent.to(torch.double))
+        penalty = torch.where(charged, penalty, torch.zeros_like(penalty))
+        logits -= penalty.to(device = logits.device, dtype = torch.float)
+
+    def run(self, state: SamplingState):
+        match state.state:
+            case SS.INIT:
+                state.logits = state.in_logits.to(torch.float, copy = True)
+            case SS.LOGITS:
+                pass
+            case _:
+                raise ValueError("Sampling logic error")
+        breakers = self.breakers
+        if self.default_breakers and state.tokenizer is not None:
+            breakers = _dry_default_breaker_mask(state.tokenizer)
+        assert state.past_ids is not None, "SS_DRY requires past token IDs"
+        assert state.past_ids.shape[0] == state.bsz
+        for i in range(state.bsz):
+            self._apply_row(state.logits[i], state.past_ids[i], state.dim, breakers)
+        state.state = SS.LOGITS
+
+    def alt(self):
+        if self.dry_multiplier == 0.0 or self.dry_base < 1.0:
+            return SS_NoOp()
+        return None
+
+    def reqs_past_ids(self):
+        return True
+
+
 class SS_AdaptiveP(SS_Base):
     """
     Implements Adaptive-P sampler. Maintains state but does not remember past states (keeps future state in case
@@ -965,7 +1193,7 @@ class CustomSampler(Sampler):
         fused_tail = None
         if fused_sampler_enable:
             i = 0
-            while i < len(simplified) and type(simplified[i]) in (SS_RepP, SS_PresFreqP, SS_BanTokens, SS_LogitBias):
+            while i < len(simplified) and type(simplified[i]) in (SS_RepP, SS_PresFreqP, SS_DRY, SS_BanTokens, SS_LogitBias):
                 i += 1
             fused_tail = _match_fused_tail(simplified[i:])
             if fused_tail is not None:
@@ -1059,6 +1287,7 @@ class CustomSampler(Sampler):
             bsz = bsz,
             in_logits = logits.view(bsz, dim),
             past_ids = sequence_ids,
+            tokenizer = tokenizer,
             fused_mask = fused_mask,
             fused_dim = fused_dim,
         )

--- a/exllamav3/generator/sampler/presets.py
+++ b/exllamav3/generator/sampler/presets.py
@@ -90,6 +90,11 @@ class ComboSampler(CustomSampler):
         pres_p: float = 0.0,
         rep_sustain_range: int = int(10e7),
         rep_decay_range: int = 0,
+        dry_multiplier: float = 0.0,
+        dry_base: float = 1.75,
+        dry_allowed_length: int = 2,
+        dry_range: int = 0,
+        dry_sequence_breakers: frozenset[int] | set[int] | list[int] | None = None,
         temperature: float = 1.0,
         min_p: float = 0.0,
         top_k: int = 0,
@@ -99,11 +104,14 @@ class ComboSampler(CustomSampler):
         adaptive_decay: float = 0.9,
         logit_bias: dict[int, float] | None = None,
     ):
-        # Steps with default parameters become no-ops
+        # Steps with default parameters become no-ops. dry_sequence_breakers takes token IDs
+        # (see dry_sequence_breaker_tokens); left as None, the default set is derived from the
+        # tokenizer at sampling time
         stack = [
             SS_LogitBias(logit_bias or {}),
             SS_RepP(rep_p, rep_sustain_range, rep_decay_range),
             SS_PresFreqP(pres_p, freq_p, rep_sustain_range, rep_decay_range),
+            SS_DRY(dry_multiplier, dry_base, dry_allowed_length, dry_range, dry_sequence_breakers),
         ]
 
         if temperature == 0.0 or top_k == 1:

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,6 +1,7 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pytest
+import numpy as np
 import torch
 from exllamav3.ext import exllamav3_ext as ext
 from exllamav3 import (
@@ -253,6 +254,125 @@ custom_test_cases = [
         # nan and +inf biases are dropped (tokens 0 and 3 unchanged); 4.0 adds to token 1
         "expect_logits": [[1.0, 5.0, ni, 1.0]],
     },
+    {
+        # DRY: the context suffix [1, 2, 3] repeats earlier, so token 1, which would extend that
+        # repeat to length 4, is penalized by multiplier * base ** (3 - allowed_length) = 1.75
+        "name": "dry",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 1.75, 2, 0, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 8],
+        "input_seq": [[0, 1, 2, 3, 1, 2, 3]],
+        "expect_logits": [[2, 0.25, 2, 2, 2, 2, 2, 2]],
+    },
+    {
+        # A repeat no longer than allowed_length is not penalized
+        "name": "dry, allowed length",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 1.75, 4, 0, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 8],
+        "input_seq": [[0, 1, 2, 3, 1, 2, 3]],
+        "expect_logits": [[2] * 8],
+    },
+    {
+        # dry_range bounds the window: the earlier occurrence of [1, 2, 3] falls outside the
+        # last 4 tokens
+        "name": "dry, range",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 1.75, 2, 4, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 8],
+        "input_seq": [[1, 2, 3, 1, 2, 3]],
+        "expect_logits": [[2] * 8],
+    },
+    {
+        # Same context without the range cap
+        "name": "dry, full range",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 1.75, 2, 0, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 8],
+        "input_seq": [[1, 2, 3, 1, 2, 3]],
+        "expect_logits": [[2, 0.25, 2, 2, 2, 2, 2, 2]],
+    },
+    {
+        # A sequence breaker (9) caps the match at its distance from the end of the context:
+        # the full repeat of [1, 2, 9, 3] has length 4, but rep_limit is 1, so the exponent is
+        # 1 - allowed_length = 0 and token 1 is penalized by the bare multiplier, not by
+        # multiplier * base ** 3
+        "name": "dry, breaker caps match",
+        "sampler": CustomSampler([
+            SS_DRY(0.5, 2.0, 1, 0, [9]),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 10],
+        "input_seq": [[1, 2, 9, 3, 1, 2, 9, 3]],
+        "expect_logits": [[2, 1.5, 2, 2, 2, 2, 2, 2, 2, 2]],
+    },
+    {
+        # A breaker token (9) is never penalized, even where it would extend a repeat
+        "name": "dry, breaker not penalized",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 1.75, 2, 0, [9]),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 10],
+        "input_seq": [[1, 2, 9, 1, 2]],
+        "expect_logits": [[2] * 10],
+    },
+    {
+        # Control for the case above: without breakers the same context penalizes token 9
+        "name": "dry, no breakers control",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 1.75, 2, 0, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 10],
+        "input_seq": [[1, 2, 9, 1, 2]],
+        "expect_logits": [[2, 2, 2, 2, 2, 2, 2, 2, 2, 1]],
+    },
+    {
+        # Two rows with independent histories; the second row's run of token 4 gives the
+        # longest match 6 and penalty base ** (6 - 2)
+        "name": "dry, batch",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 1.75, 2, 0, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 8] * 2,
+        "input_seq": [[0, 1, 2, 3, 1, 2, 3], [4, 4, 4, 4, 4, 4, 4]],
+        "expect_logits": [[2, 0.25, 2, 2, 2, 2, 2, 2], [2, 2, 2, 2, -7.37890625, 2, 2, 2]],
+    },
+    {
+        # The exponent clamp: llama.cpp computes FLOAT_MAX_LOG / log(base) in float32, which
+        # for base = 2.0 is exactly 128, so the penalty is 2 ** 128 and saturates the float32
+        # logit to -inf. A float64 clamp would land on 127 and a finite logit
+        "name": "dry, exponent clamp",
+        "sampler": CustomSampler([
+            SS_DRY(1.0, 2.0, 2, 0, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 8],
+        "input_seq": [[3] * 200],
+        "expect_logits": [[2, 2, 2, ni, 2, 2, 2, 2]],
+    },
+    {
+        # DRY after another logits step exercises the SS.LOGITS branch
+        "name": "dry, after ban_tokens",
+        "sampler": CustomSampler([
+            SS_BanTokens([0]),
+            SS_DRY(1.0, 1.75, 2, 0, []),
+            SS_Sample_mn()
+        ]),
+        "input": [[2] * 8],
+        "input_seq": [[1, 2, 3, 1, 2, 3]],
+        "expect_logits": [[ni, 0.25, 2, 2, 2, 2, 2, 2]],
+    },
 ]
 
 
@@ -410,17 +530,26 @@ def test_fused_collapse():
     assert fused_mode(ComboSampler(
         temperature = 0.8, min_p = 0.05, logit_bias = {1: 5.0}
     )) == SS_Fused.MODE_SAMPLE_MINP
+    # As does a leading DRY step, standalone or through ComboSampler
+    assert fused_mode(CustomSampler([
+        SS_DRY(0.8, 1.75, 2, 0, [1]), SS_Temperature(0.8), SS_MinP(0.05), SS_Sample()
+    ])) == SS_Fused.MODE_SAMPLE_MINP
+    assert fused_mode(ComboSampler(dry_multiplier = 0.8, temperature = 0.8, min_p = 0.05)) \
+        == SS_Fused.MODE_SAMPLE_MINP
     # Reference/multinomial nodes and non-canonical filter orders stay on the eager path
     assert fused_mode(CustomSampler([SS_MinP(0.1), SS_Sample_mn()])) is None
     assert fused_mode(CustomSampler([SS_TopP(0.9), SS_MinP(0.1), SS_Temperature(0.8), SS_Sample()])) is None
     # XTC needs the sorted distribution, so it has no fused form
     assert fused_mode(CustomSampler([SS_Temperature(0.8), SS_XTC(0.5, 0.1), SS_Sample()])) is None
-    # An empty ban list, a zero XTC probability and an XTC threshold above half are no-ops, and a
-    # no-op does not keep the tail off the fused path
+    # An empty ban list, a zero XTC probability, an XTC threshold above half, a zero DRY
+    # multiplier and a DRY base below 1 are no-ops, and a no-op does not keep the tail off the
+    # fused path
     for neutral in [
         SS_BanTokens([]),
         SS_XTC(0.0, 0.1),
         SS_XTC(0.5, 0.6),
+        SS_DRY(0.0),
+        SS_DRY(0.5, 0.5),
     ]:
         assert fused_mode(CustomSampler([
             neutral, SS_Temperature(0.8), SS_MinP(0.05), SS_Sample()
@@ -573,6 +702,151 @@ def test_argmax_sorted():
             assert sample.tolist() == expected, (steps, sample.tolist(), expected)
     finally:
         sampler_custom.fused_sampler_enable = enabled
+
+
+def dry_reference_penalties(window, breakers, multiplier, base, allowed_length):
+    """
+    Brute-force DRY oracle: computes each match length by direct comparison of the window with
+    the sequence ending at every earlier position, rather than SS_DRY's chunked run-length scan,
+    so the two cannot share an indexing bug. The penalty arithmetic follows
+    llama_sampler_dry_apply, with the exponent clamp computed in float32 via numpy.
+    """
+    m = len(window)
+    mult = float(np.float32(multiplier))
+    b = float(np.float32(base))
+    if np.float32(b) > np.float32(1.000001):
+        max_exp = int(np.float32(88.7228391) / np.log(np.float32(b)))
+    else:
+        max_exp = 0
+    rep_limit = m
+    for i in range(m):
+        if window[m - 1 - i] in breakers:
+            rep_limit = i
+            break
+    if rep_limit < allowed_length:
+        return {}
+    best = {}
+    for i in range(m - 1):
+        length = 0
+        while length <= i and window[i - length] == window[m - 1 - length]:
+            length += 1
+        length = min(length, rep_limit)
+        tok = window[i + 1]
+        if length >= allowed_length and tok not in breakers:
+            best[tok] = max(best.get(tok, 0), length)
+    penalties = {}
+    for tok, length in best.items():
+        exponent = length - allowed_length
+        if max_exp and exponent > max_exp:
+            exponent = max_exp
+        penalties[tok] = mult * float(np.float64(b) ** exponent)
+    return penalties
+
+
+@pytest.mark.parametrize("past_device", ["cpu", device])
+@torch.inference_mode()
+def test_dry_oracle(past_device):
+    """
+    Randomized differential test of SS_DRY against the brute-force oracle, exact to the bit
+    since both sides compute the penalty in float64 and round once to float32. The scan runs on
+    the device holding past_ids, so both placements are covered; a slice of the cases shrinks
+    the chunk budget to force the offset loop across chunk boundaries, and another injects
+    out-of-vocabulary and negative past IDs, which match as ordinary tokens but are never
+    penalized or treated as breakers.
+    """
+    rng = random.Random(11)
+    chunk_numel = sampler_custom._DRY_CHUNK_NUMEL
+    try:
+        for case in range(200):
+            dim = rng.choice([16, 33, 64])
+            n = rng.randint(3, 60)
+            alphabet = rng.randint(2, 8)
+            seq = [rng.randrange(alphabet) for _ in range(n)]
+            if case % 5 == 0:
+                seq[rng.randrange(n)] = rng.choice([-1, dim, dim + 7])
+            multiplier = rng.choice([0.5, 1.0, 2.7])
+            base = rng.choice([1.0, 1.05, 1.75, 2.0, 3.0])
+            allowed = rng.choice([0, 1, 2, 5])
+            dry_range = rng.choice([0, 3, 7, 100])
+            breakers = frozenset(rng.sample(range(alphabet + 2), rng.randint(0, 3)))
+            sampler_custom._DRY_CHUNK_NUMEL = 64 if case % 4 == 0 else chunk_numel
+
+            sampler = CustomSampler([SS_DRY(multiplier, base, allowed, dry_range, breakers or None)])
+            logits = torch.zeros((1, dim), dtype = torch.float, device = device)
+            seq_t = torch.tensor([seq], dtype = torch.long, device = past_device)
+            if past_device == "cpu":
+                seq_t = seq_t.pin_memory()
+            state = sampler.forward(logits, sequence_ids = seq_t, rand_u32 = 0, return_state = True)
+
+            m = n if dry_range <= 0 else min(n, dry_range)
+            window = seq[-m:]
+            if m <= allowed:
+                penalties = {}
+            else:
+                penalties = dry_reference_penalties(window, breakers, multiplier, base, allowed)
+            expect = torch.zeros(dim)
+            for tok, val in penalties.items():
+                if 0 <= tok < dim:
+                    expect[tok] = torch.tensor(val, dtype = torch.float64).to(torch.float32)
+            assert torch.equal(state.logits[0].cpu(), -expect), \
+                (seq, multiplier, base, allowed, dry_range, sorted(breakers))
+    finally:
+        sampler_custom._DRY_CHUNK_NUMEL = chunk_numel
+
+
+def test_dry_validation():
+    with pytest.raises(AssertionError):
+        SS_DRY(-0.5)
+    with pytest.raises(AssertionError):
+        SS_DRY(1.0, 1.75, 2.5)
+    with pytest.raises(AssertionError):
+        SS_DRY(1.0, 1.75, 2, 0.5)
+
+
+class _DryStubTokenizer:
+    """
+    Minimal stand-in for the breaker-derivation interface of Tokenizer, matching what
+    dry_default_sequence_breaker_tokens reads.
+    """
+    def __init__(self, breaker_pieces = True):
+        self.extended_id_to_piece = {7: "<x>"} if breaker_pieces else {}
+        self.actual_vocab_size = 12
+        self.breaker_pieces = breaker_pieces
+
+    def get_id_to_piece_list(self, include_special_tokens = False):
+        # IDs 1 and 3 contain default breaker characters
+        if self.breaker_pieces:
+            return ["a", "b.", "c", "d\n", "e", "f", "g"]
+        return ["a", "b", "c", "d", "e", "f", "g"]
+
+
+@torch.inference_mode()
+def test_dry_default_breakers():
+    """
+    With dry_sequence_breakers = None the default set derives per tokenizer from the one passed
+    to forward(), as the generator does: token 3 is a breaker for the stub, so it caps the match
+    at rep_limit 2 and is itself not penalized, while the tokenizer-less call penalizes it, and
+    a later tokenizer without breaker pieces penalizes it again through the same sampler
+    """
+    logits = torch.zeros((1, 12), dtype = torch.float, device = device)
+    seq_t = torch.tensor([[0, 5, 2, 3, 5, 2]], dtype = torch.long, device = "cpu", pin_memory = True)
+    sampler = CustomSampler([SS_DRY(1.0, 1.75, 2, 0)])
+
+    state = sampler.forward(logits.clone(), sequence_ids = seq_t, rand_u32 = 0, return_state = True)
+    assert state.logits[0, 3].item() == -1.0, state.logits
+
+    state = sampler.forward(
+        logits.clone(), sequence_ids = seq_t, rand_u32 = 0, return_state = True,
+        tokenizer = _DryStubTokenizer(),
+    )
+    assert torch.equal(state.logits[0], logits[0]), state.logits
+
+    # Not latched to the first tokenizer seen: a vocabulary without breaker pieces penalizes
+    state = sampler.forward(
+        logits.clone(), sequence_ids = seq_t, rand_u32 = 0, return_state = True,
+        tokenizer = _DryStubTokenizer(breaker_pieces = False),
+    )
+    assert state.logits[0, 3].item() == -1.0, state.logits
 
 
 @pytest.mark.parametrize("dim", dims)


### PR DESCRIPTION
Adds the DRY (Don't Repeat Yourself) repetition penalty as `SS_DRY`, the `dry_multiplier` half
of #270 (the `logit_bias` half is #274). TabbyAPI currently warns "Ignoring sampler params not
supported by the exllamav3 backend: dry_multiplier"; I'll open the companion TabbyAPI PR to pass
the parameters through once this lands.

`SS_DRY` penalizes a token that would extend a sequence already present in the context by
`multiplier * base ** (match_length - allowed_length)`, so verbatim loops get exponentially
expensive while short incidental repeats are untouched. It is modeled on `SS_RepP`: it runs
among the first steps on raw logits, participates in the fused-sampler fast path as a leading
step, no-ops when `dry_multiplier == 0` or `dry_base < 1`, and is wired into `ComboSampler` as
`dry_*`. The scan is pure torch on whatever device holds `past_ids`, with no host-device sync,
so there is no extension change.

The matching semantics and the float32 exponent-overflow clamp follow llama.cpp's
`llama_sampler_dry_apply` (the koboldcpp implementation by pi6am, scheme by p-e-w), including
never penalizing breaker tokens and the `base = 1.75` / `allowed_length = 2` defaults. The
parameter surface follows exllamav2: `dry_multiplier`, `dry_base`, `dry_allowed_length`,
`dry_range` (0 = whole context, where llama.cpp's equivalent defaults to 64), and
`dry_sequence_breakers` as token IDs (TabbyAPI's breaker strings resolve to IDs with the
exported `dry_sequence_breaker_tokens`). Left as None, the breaker set derives from the
tokenizer at sampling time with exllamav2's charset rule
(`get_dry_default_sequence_breaker_tokens`).

Divergences, also stated in the docstrings:

- exllamav2's own DRY is a different algorithm (an incremental trie that weights the penalty by
  occurrence count and caps matches at `dry_max_ngram = 20`). This port follows llama.cpp
  instead, since that is what circulating DRY presets are tuned against. If you would rather
  match the exl2 behavior, I can rework it.
- Sequence breakers are single tokens. llama.cpp additionally builds multi-token restart
  sequences out of partially overlapping tokens; that machinery is not ported.
- Match lengths are capped at 2048 tokens. Where `dry_allowed_length` plus llama.cpp's exponent
  clamp exceeds 2048 (`dry_base` below ~1.044 at the default `dry_allowed_length`), a verbatim
  repeat longer than the cap is penalized as a 2048-token repeat. The cap is what keeps the
  scan bounded for bases near 1.

Cost, measured on an RTX 5050 with a 128k vocabulary: 0.5 ms per sampled token at 1k-8k token
windows with the default `dry_base = 1.75`, 6.6 ms at a 128k-token window. A small base widens
the scan up to the 2048 cap (`dry_base = 1.1` gives 2.6 ms at 8k, 37 ms at 128k). Transients
are chunked, ~200 MiB worst case. The docstring says to cap `dry_range` for very long contexts.

Tests: ten deterministic cases (window bounds, breaker capping and exclusion, batch rows, the
float32 exponent-clamp boundary), a randomized differential against a brute-force oracle on
both CPU and CUDA `past_ids` (200 cases each, covering chunk-boundary crossings and
out-of-vocabulary IDs), default-breaker derivation through a stub tokenizer, and fused-collapse
assertions. Outputs were also cross-checked against the DRY port in vllm#50584: 1200/1200
randomized cases match. Sampler suite: 151 passed vs 137 on master, and clean with
`EXL3_FUSED_SAMPLER=0`.
