### PR TITLE
Fix ds4 stop condition: look up full-width <｜User｜>, not ASCII <|User|>

### DIFF
--- a/examples/chat_templates.py
+++ b/examples/chat_templates.py
@@ -1031,7 +1031,7 @@ class PromptFormat_ds4(PromptFormat):
 
     def stop_conditions(self, tokenizer):
         return tokenizer.config.eos_token_id_list + [
-            tokenizer.single_id("<|User|>")
+            tokenizer.single_id("<｜User｜>")
         ]
 
 


### PR DESCRIPTION
Fixes #279.

`PromptFormat_ds4.format()` emits the full-width `<｜User｜>` (U+FF5C), which is what the
DeepSeek-V4 tokenizer has as an added token (id `128803`). `stop_conditions()` looked up the ASCII
`<|User|>` (U+007C), which is in neither `added_tokens` nor `vocab`, so `Tokenizer.single_id()`
returned `None` and the stop condition was never installed.

Verified against `turboderp/DeepSeek-V4-Flash-0731-exl3` (rev `b5526ba`) on 1.4.0, tokenizer only:

```
ASCII     '<|User|>'   -> None
FULLWIDTH '<｜User｜>'  -> 128803

before: stop_conditions(tokenizer) = [1, None]
after:  stop_conditions(tokenizer) = [1, 128803]
```

Two effects before the fix:

- callers passing the returned list straight to `Job` hit
  `ValueError: Unsupported type in stop_conditions` (`job.py:230`)
- `examples/chat.py:96` filters falsy values, so it did not crash — it silently dropped the token
  and ran with EOS as its only stop condition

`PromptFormat_deepseek` uses the ASCII spelling too, but is internally consistent with its own
template, so it's left alone here — flagged in #279 as unverified against a DeepSeek-V3/R1
tokenizer.

Full repro script and logs are in #279.
