### PR TITLE
TP: Raise instead of looping forever when no device has a positive budget

### DIFF
--- a/exllamav3/model/model_tp_alloc.py
+++ b/exllamav3/model/model_tp_alloc.py
@@ -80,6 +80,8 @@ class TPAllocator:
     ):
         self.num_devices = len(max_mem)
         active_devices = [i for i in range(self.num_devices) if max_mem[i] > 0]
+        if not active_devices:
+            raise RuntimeError("Insufficient VRAM in split for model and cache")
         storage_sum = [0] * self.num_devices
         overhead_max = [0] * self.num_devices
 


### PR DESCRIPTION
`TPAllocator.initial_split` does not terminate when no device has a positive budget. It spins
instead of raising, after the TP workers have already spawned.

The retry loop grows an exhausted budget by 10%:

```python
if sum(rem_mem_s) == 0:
    max_mem = [m * 11 // 10 for m in max_mem]
```

`m * 11 // 10` never lifts a non-positive number above zero, so `sum(rem_mem_s)` stays 0 and the
loop never exits. On negative budgets the values diverge as well, so it also grows integers
without bound.

A caller reaches this through `model_tp.py`, which subtracts the reserve from each device's free
memory with no floor:

```python
if reserve_per_device is not None:
    free -= reserve_per_device[device]
```

so `reserve_per_device` at or above free VRAM on every device produces a non-positive `max_mem`.
A short list will not normally do it, since `model.py` pads the missing entries with 0.5 GB,
though an unlisted device with under 0.5 GB free still goes non-positive.

`initial_split` already builds `active_devices` one line above, uses it only to clamp per
component device limits, and never checks whether it is empty, so the check goes where the list
is built. The message matches what the autosplit loader raises in the same situation
(`model_ls.py`).

This covers the reachable case rather than making the loop terminating in general: `m * 11 // 10`
is also a fixed point for m in 1..9, so a budget of a few bytes per device would still spin. That
needs a different growth term and I left it alone.

Reproducer, pure Python, no GPU and no compiled extension needed. It loads `model_tp_alloc.py`
directly with a stub component, so it can be pointed at either tree:

```
$ python tphang.py dev/exllamav3/model/model_tp_alloc.py
dev/exllamav3/model/model_tp_alloc.py
max_mem is free-minus-reserve, i.e. what model_tp.py produces:

  both devices positive                -> returned
  one positive, one negative           -> returned
  all non-positive (reserve >= free)   -> STILL SPINNING after 4s
  all exactly zero                     -> STILL SPINNING after 4s

$ python tphang.py patched/exllamav3/model/model_tp_alloc.py
patched/exllamav3/model/model_tp_alloc.py
max_mem is free-minus-reserve, i.e. what model_tp.py produces:

  both devices positive                -> returned
  one positive, one negative           -> returned
  all non-positive (reserve >= free)   -> RuntimeError: Insufficient VRAM in split for model and cache
  all exactly zero                     -> RuntimeError: Insufficient VRAM in split for model and cache
```

Valid budgets are unaffected on both trees.

<details>
<summary>tphang.py</summary>

```python
"""TPAllocator.initial_split does not terminate when no device has a positive budget.

model_tp.py does `free -= reserve_per_device[device]` with no floor, so a caller that
reserves at or above free VRAM on every device produces a non-positive max_mem.
initial_split's retry loop then does `max_mem = [m * 11 // 10 for m in max_mem]`,
which never lifts a non-positive number above zero, so the loop spins. On negative
budgets the values also diverge, growing without bound.

initial_split already builds `active_devices` one line above, uses it only to clamp
per-component device limits, and never checks whether it is empty.

Pure Python, no GPU and no compiled extension:
  python tphang.py [path/to/model_tp_alloc.py]
"""
import importlib.util
import sys
import threading
import types

GB = 1024**3
DEFAULT = "exllamav3/model/model_tp_alloc.py"


def load_allocator(path, tag):
    """Load model_tp_alloc.py on its own, stubbing its one relative import."""
    for name in (f"x{tag}", f"x{tag}.util", f"x{tag}.model"):
        mod = types.ModuleType(name)
        mod.__path__ = []
        sys.modules[name] = mod
    misc = types.ModuleType(f"x{tag}.util.misc")

    def ratio_split(channels, mem, chunk_size=1):
        total = sum(m for m in mem if m > 0)
        if total <= 0:
            return [channels] + [0] * (len(mem) - 1)
        return [channels * max(0, m) // total for m in mem]

    misc.ratio_split = ratio_split
    sys.modules[f"x{tag}.util.misc"] = misc

    spec = importlib.util.spec_from_file_location(f"x{tag}.model.model_tp_alloc", path)
    module = importlib.util.module_from_spec(spec)
    module.__package__ = f"x{tag}.model"
    sys.modules[spec.name] = module
    spec.loader.exec_module(module)
    return module.TPAllocator


class Component:
    """One layer's worth of allocation metadata, sized so a valid budget converges."""

    channels_to_split = 4096
    channel_unit = 1
    storage_per_device = 16 << 20
    storage_to_split = 256 << 20
    overhead_per_device = 8 << 20
    overhead_to_split = 1024
    recons_temp = 4 << 20
    max_devices = None
    limit_key = None
    current_split = None


def attempt(allocator_cls, max_mem, seconds=4):
    """Run initial_split in a daemon thread so this works on Windows too."""
    result = {}

    def target():
        try:
            allocator_cls([Component()], num_tokens=16, output_num_tokens=16).initial_split(
                list(max_mem)
            )
            result["outcome"] = "returned"
        except Exception as e:
            result["outcome"] = f"{type(e).__name__}: {str(e)[:52]}"

    thread = threading.Thread(target=target, daemon=True)
    thread.start()
    thread.join(seconds)
    if thread.is_alive():
        return f"STILL SPINNING after {seconds}s"
    return result.get("outcome", "no result")


if __name__ == "__main__":
    path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT
    allocator_cls = load_allocator(path, "a")
    print(f"{path}\nmax_mem is free-minus-reserve, i.e. what model_tp.py produces:\n")
    for label, max_mem in [
        ("both devices positive", [8 * GB, 8 * GB]),
        ("one positive, one negative", [-1 * GB, 8 * GB]),
        ("all non-positive (reserve >= free)", [-1 * GB, -2 * GB]),
        ("all exactly zero", [0, 0]),
    ]:
        print(f"  {label:36s} -> {attempt(allocator_cls, max_mem)}")
```

</details>

Why this has stayed latent: the one mainstream caller could not reach it. tabbyAPI parses
`autosplit_reserve` inside its autosplit branch, so under tensor parallel it always sent the 96 MB
default whenever `gpu_split` was unset, and 96 MB never exhausts a budget. Its own bug was
holding the door shut.

I have a patch there that reads the reserve on every split mode, which opens it: `autosplit_reserve`
is in MB on that side, so a user on 24 GB cards writing `[24576, 24576]` reserves the whole of
both, and under tensor parallel that would hang here rather than report a problem. I would
rather land this first than ship that change against a library that spins.
