### PR TITLE
exl3_mgemm: fix out-of-bounds slot list, and allow multi-token reduction with expert-range filtering

### DIFF
--- a/exllamav3/exllamav3_ext/add.cu
+++ b/exllamav3/exllamav3_ext/add.cu
@@ -190,23 +190,16 @@ __global__ void moe_bias_add_kernel
     int k = blockIdx.y;
     if (col >= width) return;
     // Expert-parallel split: sel holds global expert indices but the pointer table only covers the
-    // local range, and the mgemm PACKS its output rows to the local entries of sel (in order). Skip
-    // foreign experts and add each local expert's bias at its packed row, not its position in sel
+    // local range. The mgemm leaves foreign slots untouched at their own row, so skip them here
+    // and rebase the local ones
     int64_t e = sel[k];
-    int row = k;
     if (min_expert >= 0)
     {
         if (e < min_expert || e >= max_expert) return;
         e -= min_expert;
-        row = 0;
-        for (int i = 0; i < k; ++i)
-        {
-            int64_t ei = sel[i];
-            if (ei >= min_expert && ei < max_expert) row++;
-        }
     }
     const half* b = (const half*) bias_ptrs[e];
-    int64_t i = (int64_t) row * stride + col;
+    int64_t i = (int64_t) k * stride + col;
     interm[i] = __hadd(interm[i], b[col]);
 }
 

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
@@ -62,7 +62,7 @@ int* DevCtx::get_locks(int device)
     if (!locks[device])
     {
         cudaSetDevice(device);
-        size_t size = (MAX_TILES_C + MAX_BARRIERS * 2 + MOE_SCHED_INTS) * sizeof(int);
+        size_t size = (MAX_TILES_C + MAX_BARRIERS * 2 + MOE_SCHED_INTS + MGEMM_SLOTS_INTS) * sizeof(int);
         cudaMalloc(&locks[device], size);
         cudaMemset(locks[device], 0, size);
     }

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
@@ -14,6 +14,13 @@
 #define MOE_SCHED_OFFSET (MAX_TILES_C + 2 * MAX_BARRIERS)
 #define MOE_SCHED_INTS (2 + MOE_MAX_GROUPS)
 
+// mgemm active-slot list for expert-range filtering, after the scheduler state: [0] total count,
+// [1 + c] count for compaction chunk c, then the slot positions, in order
+#define MGEMM_MAX_SLOTS 16384
+#define MGEMM_CHUNKS 32
+#define MGEMM_SLOTS_OFFSET (MOE_SCHED_OFFSET + MOE_SCHED_INTS)
+#define MGEMM_SLOTS_INTS (1 + MGEMM_CHUNKS + MGEMM_MAX_SLOTS)
+
 // Workspace size
 #define WORKSPACE_SIZE (16*1024*1024)
 

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
@@ -365,19 +365,21 @@ or q = j otherwise. This supports the following modes:
   the kernel reads its first num_indices entries as q values. Negative indices
   skip that slot.
 - Weighted MoE reduction: weights is a float16 tensor parallel to indices.
-  Each transformed result is multiplied by weights[j], then all active C[j]
-  are summed into C[0]. C therefore also serves as per-expert scratch; only
-  C[0] is the reduced result.
+  Each transformed result is multiplied by weights[j], then the active C[j]
+  are summed per token: slots are split into num_tokens contiguous groups of
+  bszm / num_tokens and group t is summed into C[t]. C therefore also serves
+  as per-expert scratch; only C[0..num_tokens) are reduced results.
 - Expert-range filtering: with min_index >= 0, selections outside
-  [min_index, max_index) are removed and retained indices are rebased by
+  [min_index, max_index) are skipped and retained indices are rebased by
   min_index. This allows B/suh/svh to be local pointer tables for an expert
-  shard. Weights are compacted in the same order.
+  shard. Filtered slots keep their position, so A/C rows and weights line up
+  with indices exactly as they do without filtering.
 
 Without weights, every active C[j] is a separate output. The active slot count
 is max(a_batches, c_batches), capped to num_indices when indices is present.
 
 Limitations: k must be divisible by 16 and n by 128. Range filtering supports
-at most 128 slots (the kernel's index-compaction capacity).
+up to MGEMM_MAX_SLOTS slots.
 */
 
 int exl3_mgemm_gr
@@ -405,10 +407,6 @@ int exl3_mgemm_gr
 {
     const at::cuda::OptionalCUDAGuard device_guard(A.device());
     cudaStream_t stream = graph ? graph->capture_stream : at::cuda::getCurrentCUDAStream().stream();
-
-    TORCH_CHECK(num_tokens == 1 || min_index < 0,
-        "exl3_mgemm: multi-token reduction (num_tokens > 1) is not compatible with expert-range "
-        "filtering (min_index >= 0); TP-sharded experts must use num_tokens == 1");
 
     TORCH_CHECK_DTYPE(A, kHalf);
     TORCH_CHECK_DTYPE(B, kLong);
@@ -446,6 +444,9 @@ int exl3_mgemm_gr
         bszm_out = (int) c_ptrs.value().size(0);
     }
     int bszm = MAX(bszm_in, bszm_out);
+
+    TORCH_CHECK(min_index < 0 || bszm <= MGEMM_MAX_SLOTS,
+                "exl3_mgemm: too many slots for expert-range filtering");
 
     // The kernel writes one hadamard-transformed input slab PER MATRIX (A_had + j * m * k);
     // an undersized scratch is silent OOB corruption (found the hard way)

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
@@ -37,19 +37,6 @@ limitations:
 
 std::set<void*> kernel_attr_set[MAX_DEVICES] = {};
 
-uint64_t roundup_pow2(uint64_t x)
-{
-    if (x == 0) return 1;
-    x--;
-    x |= x >> 1;
-	x |= x >> 2;
-	x |= x >> 4;
-	x |= x >> 8;
-	x |= x >> 16;
-	x |= x >> 32;
-    return x + 1;
-}
-
 uint64_t gemm_autotune_hash
 (
     int size_m,
@@ -69,7 +56,11 @@ uint64_t gemm_autotune_hash
         h ^= v;
         h *= 1099511628211ull;
     };
-    mix((uint64_t) MIN(roundup_pow2(size_m), 16));
+    // Bucket by 16-row MMA blocks. Every TILESIZE_M is a multiple of 16, so two batch sizes
+    // with the same block count run the same number of strips in every candidate shape and
+    // rank the same. Rounding to a power of two instead merges batch sizes whose best shape
+    // differs, e.g. 33 and 64 across a shape set holding both TILESIZE_M 48 and 64
+    mix((uint64_t) MIN(CEIL_DIVIDE(size_m, 16), 24));
     mix((uint64_t) size_k);
     mix((uint64_t) size_n);
     mix((uint64_t) K);

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
@@ -41,9 +41,15 @@ void exl3_gemm_kernel_inner
 
     const int sh_a_stage_size = TILESIZE_M * TILESIZE_K;                         // in halfs
     const int sh_b_stage_size = TILEBLOCKS_K * TILEBLOCKS_N * 256 / 16 * bits;   // in uint16s
+    // Every store/add pair in the k-reduction gets its own staging region. store() ends with a
+    // barrier but add() does not, so a region shared between two pairs would let the later
+    // pair's store overwrite slots the earlier pair's add is still reading. The sequences below
+    // run TILEBLOCKS_K - 1 pairs
+    const int sh_c_red_stride = 4 * EXL3_GEMM_BASE_THREADS * FRAGS_N_PER_WARP;
+    const int sh_c_red_pairs = TILEBLOCKS_K > 1 ? TILEBLOCKS_K - 1 : 0;
     const int sh_c_size = MAX  // in floats
     (
-        4 * EXL3_GEMM_BASE_THREADS * FRAGS_N_PER_WARP,
+        sh_c_red_pairs * sh_c_red_stride,
         shmem_out_had ? TILESIZE_N * TILESIZE_M : 0
     );
 
@@ -314,11 +320,11 @@ void exl3_gemm_kernel_inner
     // Threadblock reduction
     auto threadblock_reduce = [&] ()
     {
-        auto store = [&] (int i)
+        auto store = [&] (int i, int slot)
         {
             if (sub_k == i)
             {
-                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                float* sh_red = sh_c + slot * sh_c_red_stride + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
@@ -329,11 +335,11 @@ void exl3_gemm_kernel_inner
             __syncthreads();
         };
 
-        auto add = [&] (int i)
+        auto add = [&] (int i, int slot)
         {
             if (sub_k == i)
             {
-                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                float* sh_red = sh_c + slot * sh_c_red_stride + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
@@ -343,11 +349,11 @@ void exl3_gemm_kernel_inner
             }
         };
 
-        auto store_small = [&] (int i)
+        auto store_small = [&] (int i, int slot)
         {
             if (sub_k == i && lane_id / 4 < size_m)
             {
-                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                float* sh_red = sh_c + slot * sh_c_red_stride + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
@@ -358,11 +364,11 @@ void exl3_gemm_kernel_inner
             __syncthreads();
         };
 
-        auto add_small = [&] (int i)
+        auto add_small = [&] (int i, int slot)
         {
             if (sub_k == i && lane_id / 4 < size_m)
             {
-                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                float* sh_red = sh_c + slot * sh_c_red_stride + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
@@ -376,48 +382,48 @@ void exl3_gemm_kernel_inner
         {
             if constexpr (TILEBLOCKS_K == 2)
             {
-                store_small(1);
-                add_small(0);
+                store_small(1, 0);
+                add_small(0, 0);
             }
             if constexpr (TILEBLOCKS_K == 3)
             {
-                store_small(1);
-                add_small(0);
-                store_small(2);
-                add_small(0);
+                store_small(1, 0);
+                add_small(0, 0);
+                store_small(2, 1);
+                add_small(0, 1);
             }
             if constexpr (TILEBLOCKS_K == 4)
             {
-                store_small(3);
-                add_small(2);
-                store_small(1);
-                add_small(0);
-                store_small(2);
-                add_small(0);
+                store_small(3, 0);
+                add_small(2, 0);
+                store_small(1, 1);
+                add_small(0, 1);
+                store_small(2, 2);
+                add_small(0, 2);
             }
         }
         else
         {
             if constexpr (TILEBLOCKS_K == 2)
             {
-                store(1);
-                add(0);
+                store(1, 0);
+                add(0, 0);
             }
             if constexpr (TILEBLOCKS_K == 3)
             {
-                store(1);
-                add(0);
-                store(2);
-                add(0);
+                store(1, 0);
+                add(0, 0);
+                store(2, 1);
+                add(0, 1);
             }
             if constexpr (TILEBLOCKS_K == 4)
             {
-                store(3);
-                add(2);
-                store(1);
-                add(0);
-                store(2);
-                add(0);
+                store(3, 0);
+                add(2, 0);
+                store(1, 1);
+                add(0, 1);
+                store(2, 2);
+                add(0, 2);
             }
         }
     };

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
@@ -63,6 +63,10 @@ void exl3_gemm_kernel_inner
     static_assert(EXL3_GEMM_BASE_THREADS == 256);
     static_assert(TILESIZE_M == 16, "Invalid kernel params");                     // strictly assume size_m <= 16
     static_assert(TILESIZE_K % 16 == 0, "Invalid kernel params");
+    // The A-fragment XOR swizzle indexes row m as m * A_COLS + (k ^ x). It only stays inside
+    // the row when A_COLS is a power of two; otherwise the swizzled column runs past the row
+    // and both the store and the ldsm4 read alias neighbouring rows
+    static_assert((A_COLS & (A_COLS - 1)) == 0, "Invalid kernel params (TILESIZE_K / 8 must be a power of two)");
     static_assert(TILESIZE_N % 128 == 0, "Invalid kernel params");
     static_assert
     (

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
@@ -44,13 +44,14 @@ void exl3_gemm_kernel_inner
     // Every store/add pair in the k-reduction gets its own staging region. store() ends with a
     // barrier but add() does not, so a region shared between two pairs would let the later
     // pair's store overwrite slots the earlier pair's add is still reading. The sequences below
-    // run TILEBLOCKS_K - 1 pairs
+    // run TILEBLOCKS_K - 1 pairs per row block. The output-hadamard staging holds one 16-row
+    // block at a time and so does not scale with TILESIZE_M
     const int sh_c_red_stride = 4 * EXL3_GEMM_BASE_THREADS * FRAGS_N_PER_WARP;
     const int sh_c_red_pairs = TILEBLOCKS_K > 1 ? TILEBLOCKS_K - 1 : 0;
     const int sh_c_size = MAX  // in floats
     (
-        sh_c_red_pairs * sh_c_red_stride,
-        shmem_out_had ? TILESIZE_N * TILESIZE_M : 0
+        TILEBLOCKS_M * sh_c_red_pairs * sh_c_red_stride,
+        shmem_out_had ? TILESIZE_N * 16 : 0
     );
 
     // XOR-swizzle constants for bank-conflict-free A fragment loads
@@ -61,7 +62,7 @@ void exl3_gemm_kernel_inner
 
     // Sanity checks
     static_assert(EXL3_GEMM_BASE_THREADS == 256);
-    static_assert(TILESIZE_M == 16, "Invalid kernel params");                     // strictly assume size_m <= 16
+    static_assert(TILESIZE_M % 16 == 0, "Invalid kernel params");                  // size_m <= TILESIZE_M
     static_assert(TILESIZE_K % 16 == 0, "Invalid kernel params");
     // The A-fragment XOR swizzle indexes row m as m * A_COLS + (k ^ x). It only stays inside
     // the row when A_COLS is a power of two; otherwise the swizzled column runs past the row
@@ -210,11 +211,11 @@ void exl3_gemm_kernel_inner
     half* gl_c_ptr_16 = ((half*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
     float* gl_c_ptr_32 = ((float*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
 
-    register FragA frag_a[FRAG_STAGES];
+    register FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
     register FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
-    register FragC frag_c[FRAGS_N_PER_WARP];
+    register FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
     #if EXL3_GEMM_H_ACC
-        register FragC_h frag_c_h[FRAGS_N_PER_WARP];
+        register FragC_h frag_c_h[TILEBLOCKS_M][FRAGS_N_PER_WARP];
     #endif
 
     auto advance2 = [&] ()
@@ -281,7 +282,8 @@ void exl3_gemm_kernel_inner
     {
         if (!slice1_iters) return;
 
-        // A fragments (XOR-swizzled shared memory layout)
+        // A fragments (XOR-swizzled shared memory layout), one per row block. The B fragments
+        // below are decoded once and reused across all of them, which is the point of TILESIZE_M
         {
             int r = (lane_id % 8) + 8 * ((lane_id / 8) % 2);
             int base_c = lane_id / 16 + sub_k * 2;
@@ -290,7 +292,7 @@ void exl3_gemm_kernel_inner
             {
                 int R = r + m * 16;
                 int c_swizzled = base_c ^ ((R >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK);
-                ldsm4(frag_a[buf], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
+                ldsm4(frag_a[buf][m], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
             }
         }
 
@@ -312,19 +314,23 @@ void exl3_gemm_kernel_inner
     auto clear_frag_c = [&] ()
     {
         #pragma unroll
-        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
-            frag_c[n] = {};
-        #if EXL3_GEMM_H_ACC
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
             #pragma unroll
             for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
-                frag_c_h[n] = {};
+                frag_c[m][n] = {};
+        #if EXL3_GEMM_H_ACC
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    frag_c_h[m][n] = {};
         #endif
     };
 
     // Threadblock reduction
     auto threadblock_reduce = [&] ()
     {
-        auto store = [&] (int i, int slot)
+        auto store = [&] (int i, int m, int slot)
         {
             if (sub_k == i)
             {
@@ -333,13 +339,13 @@ void exl3_gemm_kernel_inner
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
                     #pragma unroll
-                    for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[n][j];
+                    for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[m][n][j];
                 }
             }
             __syncthreads();
         };
 
-        auto add = [&] (int i, int slot)
+        auto add = [&] (int i, int m, int slot)
         {
             if (sub_k == i)
             {
@@ -348,142 +354,148 @@ void exl3_gemm_kernel_inner
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
                     #pragma unroll
-                    for (int j = 0; j < 4; ++j) frag_c[n][j] += *sh_red++;
+                    for (int j = 0; j < 4; ++j) frag_c[m][n][j] += *sh_red++;
                 }
             }
         };
 
-        auto store_small = [&] (int i, int slot)
+        auto store_small = [&] (int i, int m, int slot)
         {
-            if (sub_k == i && lane_id / 4 < size_m)
+            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
             {
                 float* sh_red = sh_c + slot * sh_c_red_stride + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
-                    *sh_red++ = frag_c[n][0];
-                    *sh_red++ = frag_c[n][1];
+                    *sh_red++ = frag_c[m][n][0];
+                    *sh_red++ = frag_c[m][n][1];
                 }
             }
             __syncthreads();
         };
 
-        auto add_small = [&] (int i, int slot)
+        auto add_small = [&] (int i, int m, int slot)
         {
-            if (sub_k == i && lane_id / 4 < size_m)
+            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
             {
                 float* sh_red = sh_c + slot * sh_c_red_stride + (FRAGS_N_PER_WARP * 4) * t;
                 #pragma unroll
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
-                    frag_c[n][0] += *sh_red++;
-                    frag_c[n][1] += *sh_red++;
+                    frag_c[m][n][0] += *sh_red++;
+                    frag_c[m][n][1] += *sh_red++;
                 }
             }
         };
 
-        if (size_m <= 8)
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
         {
-            if constexpr (TILEBLOCKS_K == 2)
+            const int s0 = m * sh_c_red_pairs;
+            if (size_m - m * 16 <= 8)
             {
-                store_small(1, 0);
-                add_small(0, 0);
+                if constexpr (TILEBLOCKS_K == 2)
+                {
+                    store_small(1, m, s0);
+                    add_small(0, m, s0);
+                }
+                if constexpr (TILEBLOCKS_K == 3)
+                {
+                    store_small(1, m, s0);
+                    add_small(0, m, s0);
+                    store_small(2, m, s0 + 1);
+                    add_small(0, m, s0 + 1);
+                }
+                if constexpr (TILEBLOCKS_K == 4)
+                {
+                    store_small(3, m, s0);
+                    add_small(2, m, s0);
+                    store_small(1, m, s0 + 1);
+                    add_small(0, m, s0 + 1);
+                    store_small(2, m, s0 + 2);
+                    add_small(0, m, s0 + 2);
+                }
             }
-            if constexpr (TILEBLOCKS_K == 3)
+            else
             {
-                store_small(1, 0);
-                add_small(0, 0);
-                store_small(2, 1);
-                add_small(0, 1);
-            }
-            if constexpr (TILEBLOCKS_K == 4)
-            {
-                store_small(3, 0);
-                add_small(2, 0);
-                store_small(1, 1);
-                add_small(0, 1);
-                store_small(2, 2);
-                add_small(0, 2);
-            }
-        }
-        else
-        {
-            if constexpr (TILEBLOCKS_K == 2)
-            {
-                store(1, 0);
-                add(0, 0);
-            }
-            if constexpr (TILEBLOCKS_K == 3)
-            {
-                store(1, 0);
-                add(0, 0);
-                store(2, 1);
-                add(0, 1);
-            }
-            if constexpr (TILEBLOCKS_K == 4)
-            {
-                store(3, 0);
-                add(2, 0);
-                store(1, 1);
-                add(0, 1);
-                store(2, 2);
-                add(0, 2);
+                if constexpr (TILEBLOCKS_K == 2)
+                {
+                    store(1, m, s0);
+                    add(0, m, s0);
+                }
+                if constexpr (TILEBLOCKS_K == 3)
+                {
+                    store(1, m, s0);
+                    add(0, m, s0);
+                    store(2, m, s0 + 1);
+                    add(0, m, s0 + 1);
+                }
+                if constexpr (TILEBLOCKS_K == 4)
+                {
+                    store(3, m, s0);
+                    add(2, m, s0);
+                    store(1, m, s0 + 1);
+                    add(0, m, s0 + 1);
+                    store(2, m, s0 + 2);
+                    add(0, m, s0 + 2);
+                }
             }
         }
     };
 
     // Pre-hadamard: Write final output tile to shmem
-    auto write_sum_tile_sh = [&]()
+    auto write_sum_tile_sh = [&](int m)
     {
         const int n0 = warp_id * FRAGS_N_PER_WARP;
         const int r0 = lane_id / 4;
         const int r1 = r0 + 8;
-        if (r0 < size_m)
+        if (m * 16 + r0 < size_m)
         {
             const int c = (lane_id % 4) * 2;
             #pragma unroll
             for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
             {
                 float* c_ptr = ((float*) sh_c) + r0 * TILESIZE_N + (n0 + n) * 8 + c;
-                *c_ptr++ = frag_c[n][0];
-                *c_ptr++ = frag_c[n][1];
+                *c_ptr++ = frag_c[m][n][0];
+                *c_ptr++ = frag_c[m][n][1];
             }
         }
-        if (r1 < size_m)
+        if (m * 16 + r1 < size_m)
         {
             const int c = (lane_id % 4) * 2;
             #pragma unroll
             for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
             {
                 float* c_ptr = ((float*) sh_c) + r1 * TILESIZE_N + (n0 + n) * 8 + c;
-                *c_ptr++ = frag_c[n][2];
-                *c_ptr++ = frag_c[n][3];
+                *c_ptr++ = frag_c[m][n][2];
+                *c_ptr++ = frag_c[m][n][3];
             }
         }
     };
 
     // Copy output tile to global with hadamard transform and out scale
-    auto output_had_sh_gl = [&]()
+    auto output_had_sh_gl = [&](int m)
     {
+        int rows = TILEBLOCKS_M == 1 ? size_m : MIN(size_m - m * 16, 16);
         int sh_warp = warp_id;
         constexpr int active_warps = EXL3_GEMM_BASE_THREADS / 32;
         for (;; sh_warp += active_warps)
         {
             int col = sh_warp % (TILESIZE_N / 128);
             int row = sh_warp / (TILESIZE_N / 128);
-            if (row >= size_m) break;
+            if (row >= rows) break;
 
             const float* had_in = sh_c + row * TILESIZE_N + col * 128;
             const half* post_scale_c = post_scale + slice2_n * gl_c_stride_n + col * 128;
 
             if constexpr (c_fp32)
             {
-                float* had_out = gl_c_ptr_32 + row * size_n + col * 128;
+                float* had_out = gl_c_ptr_32 + (m * 16 + row) * size_n + col * 128;
                 had_ff_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
             }
             else
             {
-                half* had_out = gl_c_ptr_16 + row * size_n + col * 128;
+                half* had_out = gl_c_ptr_16 + (m * 16 + row) * size_n + col * 128;
                 had_fh_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
             }
         }
@@ -493,9 +505,11 @@ void exl3_gemm_kernel_inner
     {
         int n0 = warp_id * FRAGS_N_PER_WARP;
         #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        #pragma unroll
         for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
         {
-            int r0 = lane_id / 4;
+            int r0 = m * 16 + lane_id / 4;
             int r1 = r0 + 8;
             int c = (lane_id % 4) * 2;
             if (r0 < size_m)
@@ -503,15 +517,15 @@ void exl3_gemm_kernel_inner
                 if constexpr (c_fp32)
                 {
                     float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
-                    frag_c[n][0] += *c_ptr++;
-                    frag_c[n][1] += *c_ptr++;
+                    frag_c[m][n][0] += *c_ptr++;
+                    frag_c[m][n][1] += *c_ptr++;
                 }
                 else
                 {
                     half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
                     float2 interm = __half22float2(*c_ptr);
-                    frag_c[n][0] += interm.x;
-                    frag_c[n][1] += interm.y;
+                    frag_c[m][n][0] += interm.x;
+                    frag_c[m][n][1] += interm.y;
                 }
             }
             if (r1 < size_m)
@@ -519,15 +533,15 @@ void exl3_gemm_kernel_inner
                 if constexpr (c_fp32)
                 {
                     float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
-                    frag_c[n][2] += *c_ptr++;
-                    frag_c[n][3] += *c_ptr++;
+                    frag_c[m][n][2] += *c_ptr++;
+                    frag_c[m][n][3] += *c_ptr++;
                 }
                 else
                 {
                     half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
                     float2 interm = __half22float2(*c_ptr);
-                    frag_c[n][2] += interm.x;
-                    frag_c[n][3] += interm.y;
+                    frag_c[m][n][2] += interm.x;
+                    frag_c[m][n][3] += interm.y;
                 }
             }
         }
@@ -537,9 +551,11 @@ void exl3_gemm_kernel_inner
     {
         int n0 = warp_id * FRAGS_N_PER_WARP;
         #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        #pragma unroll
         for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
         {
-            int r0 = lane_id / 4;
+            int r0 = m * 16 + lane_id / 4;
             int r1 = r0 + 8;
             int c = (lane_id % 4) * 2;
             if (r0 < size_m)
@@ -547,13 +563,13 @@ void exl3_gemm_kernel_inner
                 if constexpr (c_fp32)
                 {
                     float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
-                    *c_ptr++ = frag_c[n][0];
-                    *c_ptr++ = frag_c[n][1];
+                    *c_ptr++ = frag_c[m][n][0];
+                    *c_ptr++ = frag_c[m][n][1];
                 }
                 else
                 {
                     half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
-                    half2 sum = __floats2half2_rn(frag_c[n][0], frag_c[n][1]);
+                    half2 sum = __floats2half2_rn(frag_c[m][n][0], frag_c[m][n][1]);
                     *c_ptr = sum;
                 }
             }
@@ -562,13 +578,13 @@ void exl3_gemm_kernel_inner
                 if constexpr (c_fp32)
                 {
                     float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
-                    *c_ptr++ = frag_c[n][2];
-                    *c_ptr++ = frag_c[n][3];
+                    *c_ptr++ = frag_c[m][n][2];
+                    *c_ptr++ = frag_c[m][n][3];
                 }
                 else
                 {
                     half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
-                    half2 sum = __floats2half2_rn(frag_c[n][2], frag_c[n][3]);
+                    half2 sum = __floats2half2_rn(frag_c[m][n][2], frag_c[m][n][3]);
                     *c_ptr = sum;
                 }
             }
@@ -581,12 +597,14 @@ void exl3_gemm_kernel_inner
         #if EXL3_GEMM_H_ACC
             // Fold the fp16 MMA accumulators into the fp32 accumulators once per k-slice
             #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            #pragma unroll
             for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
             {
-                float2 f0 = __half22float2(frag_c_h[n][0]);
-                float2 f1 = __half22float2(frag_c_h[n][1]);
-                frag_c[n][0] += f0.x; frag_c[n][1] += f0.y;
-                frag_c[n][2] += f1.x; frag_c[n][3] += f1.y;
+                float2 f0 = __half22float2(frag_c_h[m][n][0]);
+                float2 f1 = __half22float2(frag_c_h[m][n][1]);
+                frag_c[m][n][0] += f0.x; frag_c[m][n][1] += f0.y;
+                frag_c[m][n][2] += f1.x; frag_c[m][n][3] += f1.y;
             }
         #endif
 
@@ -619,17 +637,22 @@ void exl3_gemm_kernel_inner
         // Last block writes in row-major format
         if (!sub_k && last)
         {
-            if constexpr (shmem_out_had)
-                write_sum_tile_sh();
-            else
+            if constexpr (!shmem_out_had)
                 write_sum_gl();
         }
 
         if constexpr (shmem_out_had)
         {
-            if (last) __syncthreads();
-            if (!sub_k && last)
-                output_had_sh_gl();
+            // sh_c stages one 16-row block at a time and is reused by the next block, so each
+            // block's transform must complete before the next one overwrites the staging area
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                if (m && last) __syncthreads();
+                if (!sub_k && last) write_sum_tile_sh(m);
+                if (last) __syncthreads();
+                if (!sub_k && last) output_had_sh_gl(m);
+            }
         }
 
         barrier_release(lock, lock_d, last);
@@ -650,11 +673,15 @@ void exl3_gemm_kernel_inner
         #pragma unroll
         for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
         {
-            #if EXL3_GEMM_H_ACC
-                ptx_mma_m16n8k16(frag_a[buf], frag_b[buf][n], frag_c_h[n]);
-            #else
-                ptx_mma_m16n8k16(frag_a[buf], frag_b[buf][n], frag_c[n]);
-            #endif
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                #if EXL3_GEMM_H_ACC
+                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c_h[m][n]);
+                #else
+                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c[m][n]);
+                #endif
+            }
         }
     };
 

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_kernel.cuh
@@ -79,12 +79,6 @@ void exl3_gemm_kernel(EXL3_GEMM_ARGS)
      */
 }
 
-#define MAX_INDICES 128
-
-__device__ int64_t v_indices[128];
-__device__ half v_weights[128];
-__device__ int bszm_sync;
-
 template<EXL3_GEMM_T_ARGS>
 __global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * TILESIZE_K / 16)
 void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
@@ -96,45 +90,79 @@ void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
         int* barrier_counters_sense = locks + BARRIER_LOCKS_OFFSET;
     #endif
 
-    // Pack indices within min_index <= idx < max_index
+    // Local matrix for slot j, or -1 if the slot is inactive. With min_index >= 0 the tables are
+    // local to an expert shard: selections outside [min_index, max_index) are inactive and the
+    // rest are rebased. Slots keep their position either way, so slot j always refers to input
+    // row j, output row j and weight j
+    auto slot_matrix = [&] (int j) -> int
+    {
+        int idx = B_indices ? (int) B_indices[j] : j;
+        if (min_index >= 0 && (idx < min_index || idx >= max_index)) return -1;
+        return min_index >= 0 ? idx - min_index : idx;
+    };
+
+    // List the active slots so the loop below can skip the inactive ones. The list holds slot
+    // POSITIONS rather than renumbered indices, which is what lets a filtered launch keep the
+    // fixed per-token slot groups that the reduction needs. One warp per chunk counts, then
+    // writes at the chunk's prefix, so the grid does not wait on a serial scan
+    int* slot_total = locks + MGEMM_SLOTS_OFFSET;
+    int* chunk_count = slot_total + 1;
+    int* slot_list = chunk_count + MGEMM_CHUNKS;
+    int num_slots = bszm;
 
     if (min_index >= 0)
     {
-        if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0)
+        int chunk = blockIdx.z * gridDim.x + blockIdx.x;
+        int num_chunks = MIN((int) (gridDim.x * gridDim.z), MGEMM_CHUNKS);
+        int chunk_size = CEIL_DIVIDE(bszm, num_chunks);
+        int beg = MIN(chunk * chunk_size, bszm);
+        int end = MIN(beg + chunk_size, bszm);
+        int lane = threadIdx.x % 32;
+
+        if (chunk < num_chunks && threadIdx.x < 32)
         {
-            int j = 0;
-            for (int i = 0; i < bszm; ++i)
-            {
-                int idx = B_indices[i];
-                if (idx >= min_index && idx < max_index)
-                {
-                    v_indices[j] = idx - min_index;
-                    if (B_weights) v_weights[j] = B_weights[i];
-                    j++;
-                }
-            }
-            bszm_sync = j;
-            for (; j < bszm; ++j)
-            {
-                v_indices[j] = -1;
-            }
+            int count = 0;
+            for (int i = beg; i < end; i += 32)
+                count += __popc(__ballot_sync(0xffffffff, i + lane < end && slot_matrix(i + lane) >= 0));
+            if (lane == 0) chunk_count[chunk] = count;
         }
         __threadfence();
         grid.sync();
-        B_indices = v_indices;
-        if (B_weights) B_weights = v_weights;
-        bszm = bszm_sync;
+
+        if (chunk < num_chunks && threadIdx.x < 32)
+        {
+            int c = lane < num_chunks ? chunk_count[lane] : 0;
+            int total = c;
+            int base = lane < chunk ? c : 0;
+            for (int s = 16; s; s >>= 1)
+            {
+                total += __shfl_xor_sync(0xffffffff, total, s);
+                base += __shfl_xor_sync(0xffffffff, base, s);
+            }
+            for (int i = beg; i < end; i += 32)
+            {
+                bool active = i + lane < end && slot_matrix(i + lane) >= 0;
+                uint32_t mask = __ballot_sync(0xffffffff, active);
+                if (active) slot_list[base + __popc(mask & ((1u << lane) - 1))] = i + lane;
+                base += __popc(mask);
+            }
+            if (chunk == 0 && lane == 0) slot_total[0] = total;
+        }
+        __threadfence();
+        grid.sync();
+        num_slots = slot_total[0];
     }
 
-    for (int i = 0; i < bszm; i += gridDim.z)
+    for (int i = 0; i < num_slots; i += gridDim.z)
     {
-        int j = i + blockIdx.z;
+        int p = i + blockIdx.z;
+        int j = -1;
         int mat_index = -1;
         const uint16_t* B = nullptr;
-        if (j >= bszm) j = -1;
-        else
+        if (p < num_slots)
         {
-            mat_index = B_indices ? (int) B_indices[j] : j;
+            j = min_index >= 0 ? slot_list[p] : p;
+            mat_index = slot_matrix(j);
             if (mat_index >= 0)
             {
                 B = B_list[mat_index];
@@ -247,10 +275,10 @@ void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
     // Final reduction: each of the num_tokens groups of (bszm / num_tokens) contiguous slots is
     // summed into its own output row (row t for group t), instead of always collapsing into row
     // 0. num_tokens == 1 (the legacy single-token case) reduces to exactly the original
-    // single-row behavior. Groups MUST be processed in increasing t order per column: row t is
-    // only ever read by group floor(t / stride), which is <= t, so it has already been fully
-    // read (and, if that group's index equals t, is only then correctly overwritten) by the time
-    // group t's own write happens.
+    // single-row behavior. Inactive slots produced no output and are skipped. Groups MUST be
+    // processed in increasing t order per column: row t is only ever read by group
+    // floor(t / stride), which is <= t, so it has already been fully read (and, if that group's
+    // index equals t, is only then correctly overwritten) by the time group t's own write happens.
     if (B_weights && blockIdx.z == 0)
     {
         int total_warps = size_m * size_n / 32;
@@ -270,7 +298,7 @@ void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
                     float sum = 0.0f;
                     for (int j = 0; j < stride; ++j)
                     {
-                        sum += *C___;
+                        if (slot_matrix(t * stride + j) >= 0) sum += *C___;
                         C___ += size_m * size_n;
                     }
                     ((float*) C)[t * size_m * size_n + col] = sum;
@@ -281,7 +309,7 @@ void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
                     half sum = {};
                     for (int j = 0; j < stride; ++j)
                     {
-                        sum = __hadd(sum, *C___);
+                        if (slot_matrix(t * stride + j) >= 0) sum = __hadd(sum, *C___);
                         C___ += size_m * size_n;
                     }
                     ((half*) C)[t * size_m * size_n + col] = sum;

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_kernel.cuh
@@ -38,12 +38,12 @@ void exl3_gemm_kernel(EXL3_GEMM_ARGS)
     {
         exl3_gemm_kernel_inner
         <bits, c_fp32, cb, TILESIZE_M, TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES, true>
-        (A_, B, C_, MIN(size_m_, 16), size_k, size_n, locks, svh);
+        (A_, B, C_, MIN(size_m_, TILESIZE_M), size_k, size_n, locks, svh);
 
-        A_ += 16 * size_k;
-        if constexpr (c_fp32) C_ = (void*) (((float*) C_) + 16 * size_n);
-        else                  C_ = (void*) (((half*) C_) + 16 * size_n);
-        size_m_ -= 16;
+        A_ += TILESIZE_M * size_k;
+        if constexpr (c_fp32) C_ = (void*) (((float*) C_) + TILESIZE_M * size_n);
+        else                  C_ = (void*) (((half*) C_) + TILESIZE_M * size_n);
+        size_m_ -= TILESIZE_M;
 
         if (size_m_ > 0 || svh)
             grid.sync();
@@ -218,13 +218,13 @@ void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
 
                 exl3_gemm_kernel_inner
                 <bits, c_fp32, cb, TILESIZE_M, TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES, false>
-                (A_, B, C_, MIN(size_m_, 16), size_k, n_j, locks + lock_offs, nullptr);
+                (A_, B, C_, MIN(size_m_, TILESIZE_M), size_k, n_j, locks + lock_offs, nullptr);
             }
 
-            A_ += 16 * size_k;
-            if constexpr (c_fp32) C_ = (void*) (((float*) C_) + 16 * n_j);
-            else                  C_ = (void*) (((half*) C_) + 16 * n_j);
-            size_m_ -= 16;
+            A_ += TILESIZE_M * size_k;
+            if constexpr (c_fp32) C_ = (void*) (((float*) C_) + TILESIZE_M * n_j);
+            else                  C_ = (void*) (((half*) C_) + TILESIZE_M * n_j);
+            size_m_ -= TILESIZE_M;
 
             #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 890)
                 group_barrier(blockIdx.z, gridDim.x, barrier_counters_sense);

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -79,14 +79,19 @@ int exl3_gemm_num_kernel_shapes()
     return EXL3_GEMM_NUM_SHAPES;
 }
 
+int exl3_gemm_tilesize_m[] = {EXL3_GEMM_TILESIZE_M};
 int exl3_gemm_tilesize_k[] = {EXL3_GEMM_TILESIZE_K};
 int exl3_gemm_tilesize_n[] = {EXL3_GEMM_TILESIZE_N};
 int exl3_gemm_blockdim[] = {EXL3_GEMM_BLOCKDIM};
 
 bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, int K)
 {
+    int tilesize_m = exl3_gemm_tilesize_m[shape_idx];
     int tilesize_k = exl3_gemm_tilesize_k[shape_idx];
     int tilesize_n = exl3_gemm_tilesize_n[shape_idx];
+    // A multi-row-block shape only pays for itself once there is a second row block to fill;
+    // below that it doubles the MMA count for no decode saving
+    if (tilesize_m > 16 && size_m <= 16) return false;
     return (size_k % tilesize_k == 0) && (size_n % tilesize_n == 0);
 }
 

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
@@ -55,11 +55,25 @@ typedef void (*fp_exl3_mgemm_kernel) (EXL3_MGEMM_ARGS);
 #define EXL3_GEMM_SHAPE_3     16,     32,    256,     4,     3
 #define EXL3_GEMM_SHAPE_4     16,     16,    512,     4,     3
 
-#define EXL3_GEMM_TILESIZE_K  0, 16, 32, 32, 16
-#define EXL3_GEMM_TILESIZE_N  0, 128, 128, 256, 512
-#define EXL3_GEMM_BLOCKDIM  0, 256, 512, 512, 256
+// Multi-row-block shapes. One trellis decode feeds TILESIZE_M / 16 MMA row blocks, so the
+// weight stream is read and dequantized once per TILESIZE_M rows instead of once per 16
+#define EXL3_GEMM_SHAPE_5     32,     32,    128,     4,     3
+#define EXL3_GEMM_SHAPE_6     32,     16,    256,     4,     3
 
-#define EXL3_GEMM_NUM_SHAPES 4
+// Deeper row-block shapes. TILESIZE_K 16 keeps blockDim at 256, where the register cap is 255
+// rather than 128, which is what lets the A fragments and C accumulators for 3 and 4 row
+// blocks stay resident
+#define EXL3_GEMM_SHAPE_7     32,     16,    128,     4,     3
+#define EXL3_GEMM_SHAPE_8     48,     16,    128,     4,     3
+#define EXL3_GEMM_SHAPE_9     64,     16,    128,     4,     3
+#define EXL3_GEMM_SHAPE_10    32,     16,    512,     4,     3
+
+#define EXL3_GEMM_TILESIZE_M  0, 16, 16, 16, 16, 32, 32, 32, 48, 64, 32
+#define EXL3_GEMM_TILESIZE_K  0, 16, 32, 32, 16, 32, 16, 16, 16, 16, 16
+#define EXL3_GEMM_TILESIZE_N  0, 128, 128, 256, 512, 128, 256, 128, 128, 128, 512
+#define EXL3_GEMM_BLOCKDIM  0, 256, 512, 512, 256, 512, 256, 256, 256, 256, 256
+
+#define EXL3_GEMM_NUM_SHAPES 10
 
 // Shape 1 not currently used anywhere
 #define EXL3_GEMM_KERNEL_INSTANCES(_bits, _c_fp32, cb) \
@@ -67,14 +81,26 @@ typedef void (*fp_exl3_mgemm_kernel) (EXL3_MGEMM_ARGS);
     exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_1>, \
     exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_2>, \
     exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_3>, \
-    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_5>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_6>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_7>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_8>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_9>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_10>
 
 #define EXL3_MGEMM_KERNEL_INSTANCES(_bits, _c_fp32, cb) \
     nullptr, \
     exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_1>, \
     exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_2>, \
     exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_3>, \
-    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_5>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_6>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_7>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_8>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_9>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_10>
 
 #define EXL3_GEMM_BASE_THREADS 256
 

--- a/exllamav3/modules/block_sparse_mlp.py
+++ b/exllamav3/modules/block_sparse_mlp.py
@@ -1135,14 +1135,9 @@ class BlockSparseMLP(Module):
         # Eligibility for the multi-row CUDA-graph path (bsz 1..MAX_BSZN): computed up front so
         # it can override the f_threshold-based routing below (bsz>=f_threshold would otherwise
         # always fall through to the exl3_moe/dense path first, capping this tier's reach at
-        # f_threshold-1 instead of MAX_BSZN). bsz==1 is unrestricted (original bsz-1 path); bsz>1
-        # additionally requires no TP expert-range sharding (the kernel's compaction path doesn't
-        # preserve fixed per-token slot groups) -- shared experts are supported at any bsz via
-        # BC_GatedMLP's own multi-row graph (see mlp.py)
-        bszn_eligible = (
-            self.bc is not None and bsz <= MAX_BSZN and
-            (bsz == 1 or self.experts_cfg.min_expert == -1)
-        )
+        # f_threshold-1 instead of MAX_BSZN). TP expert-range sharding is supported at any bsz --
+        # shared experts are too, via BC_GatedMLP's own multi-row graph (see mlp.py)
+        bszn_eligible = self.bc is not None and bsz <= MAX_BSZN
 
         # Routing
         if self.router_pre_norm:
@@ -1351,9 +1346,7 @@ class BlockSparseMLP(Module):
         # tokens this small is rare and not worth the argsort/bincount host-sync cost that the
         # fused/exl3_moe path pays), captured as one CUDA graph per bsz and replayed with only a
         # few tensor pointers patched. Shared experts (if present) run through their own
-        # multi-row BC_GatedMLP graph, fused into the same capture. bsz > 1 additionally requires
-        # no TP expert-range sharding (the kernel's compaction path doesn't preserve fixed
-        # per-token slot groups); bsz == 1 is unrestricted
+        # multi-row BC_GatedMLP graph, fused into the same capture
         elif bszn_eligible:
             self.bc.run_bszN(y, selected_experts, routing_weights)
             if self.experts_cfg.out_trim is not None:
@@ -1362,7 +1355,7 @@ class BlockSparseMLP(Module):
                 final_hidden_states = self.experts_cfg.out_d[:bsz, ...].view(x.shape)
             bc_sh_exp = self.bc_sh_exp
 
-        # Per-token mgemm loop: fallback for TP-sharded / shared-experts models at bsz 2..f_threshold-1
+        # Per-token mgemm loop: fallback above the multi-row graph tier, bsz MAX_BSZN+1..f_threshold-1
         elif bsz > 1:
 
             final_hidden_states = torch.empty_like(y, dtype = torch.float)

--- a/tests/kernels/exl3_k_reduction_probe.cu
+++ b/tests/kernels/exl3_k_reduction_probe.cu
@@ -1,0 +1,100 @@
+// Test-only instantiations of the EXL3 GEMM at every TILEBLOCKS_K the kernel can be built at.
+//
+// The shipping shape table only reaches TILEBLOCKS_K <= 2, where the threadblock k-reduction runs
+// a single store/add pair, so no shipping shape exercises the staging regions the reduction
+// interleaves at higher k-tile counts. TILEBLOCKS_K == 1 runs no threadblock reduction at all and
+// is the reference the reduction cannot influence.
+
+#include <cuda_fp16.h>
+#include <cublas_v2.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "util.h"
+#include "util.cuh"
+#include "ptx.cuh"
+#include "quant/exl3_kernel_map.cuh"
+#include "quant/exl3_gemm_kernel.cuh"
+
+// (TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES). TILESIZE_M is fixed at 16 by the kernel.
+#define PROBE_SHAPES(X, bits) \
+    X(bits, 16, 128, 6, 5) \
+    X(bits, 32, 128, 4, 3) \
+    X(bits, 64, 128, 4, 3)
+
+#define PROBE_BITS(X) X(2) X(3) X(4) X(5) X(6) X(7) X(8)
+
+static int probe_gemm
+(
+    at::Tensor A,
+    at::Tensor B,
+    at::Tensor C,
+    at::Tensor suh,
+    at::Tensor A_had,
+    at::Tensor svh,
+    at::Tensor locks,
+    int64_t tilesize_k
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    int size_m = A.size(0);
+    int size_k = A.size(1);
+    int size_n = B.size(1) * 16;
+    int bits = B.size(2) / 16;
+
+    const half* A_ptr = (const half*) A.data_ptr();
+    const uint16_t* B_ptr = (const uint16_t*) B.data_ptr();
+    void* C_ptr = (void*) C.data_ptr();
+    const half* suh_ptr = (const half*) suh.data_ptr();
+    half* A_had_ptr = (half*) A_had.data_ptr();
+    const half* svh_ptr = (const half*) svh.data_ptr();
+    int* locks_ptr = (int*) locks.data_ptr();
+
+    void* kernelArgs[] =
+    {
+        (void*) &A_ptr, (void*) &B_ptr, (void*) &C_ptr,
+        (void*) &size_m, (void*) &size_k, (void*) &size_n,
+        (void*) &locks_ptr, (void*) &suh_ptr, (void*) &A_had_ptr, (void*) &svh_ptr
+    };
+
+    fp_exl3_gemm_kernel kernel = nullptr;
+    int tilesize_n = 0;
+
+    #define PROBE_CASE(_bits, _tk, _tn, _shs, _frs) \
+        if (bits == _bits && tilesize_k == _tk) \
+        { \
+            kernel = exl3_gemm_kernel<_bits, true, 0, 16, _tk, _tn, _shs, _frs>; \
+            tilesize_n = _tn; \
+        }
+    #define PROBE_BITS_CASE(_bits) PROBE_SHAPES(PROBE_CASE, _bits)
+    PROBE_BITS(PROBE_BITS_CASE)
+    #undef PROBE_BITS_CASE
+    #undef PROBE_CASE
+
+    TORCH_CHECK(kernel, "probe_gemm: no instantiation for bits/tilesize_k");
+
+    int device;
+    cudaGetDevice(&device);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, device);
+
+    int max_slices = MAX(size_k / (int) tilesize_k * size_n / tilesize_n, 1);
+    int num_sms = MAX(MIN(max_slices, prop.multiProcessorCount), 1);
+    int block_dim = EXL3_GEMM_BASE_THREADS * (int) tilesize_k / 16;
+
+    cudaFuncSetAttribute((void*) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
+    cudaLaunchCooperativeKernel((void*) kernel, num_sms, block_dim, kernelArgs, SMEM_MAX, stream);
+    C10_CUDA_CHECK(cudaPeekAtLastError());
+    return num_sms;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("probe_gemm", &probe_gemm, "EXL3 GEMM at a forced TILESIZE_K");
+}

--- a/tests/kernels/exl3_tilesize_k_guard.cu
+++ b/tests/kernels/exl3_tilesize_k_guard.cu
@@ -1,0 +1,26 @@
+// Test-only TU that instantiates the EXL3 GEMM inner kernel at the TILESIZE_K given by
+// -DPROBE_TILESIZE_K. Compiled on its own to check which values the kernel's own static_asserts
+// accept, so a shape whose A-fragment swizzle would run past the end of a row cannot be built.
+
+#include <cuda_fp16.h>
+#include <cstdint>
+
+#include "util.h"
+#include "util.cuh"
+#include "quant/hadamard_inner.cuh"
+#include "quant/exl3_kernel_map.cuh"
+#include "quant/exl3_gemm_inner.cuh"
+
+#ifndef PROBE_TILESIZE_K
+#define PROBE_TILESIZE_K 32
+#endif
+
+__global__ void probe_tilesize_k
+(
+    const half* A, const uint16_t* B, void* C,
+    int size_m, int size_k, int size_n, int* locks, const half* post_scale
+)
+{
+    exl3_gemm_kernel_inner<4, false, 0, 16, PROBE_TILESIZE_K, 128, 4, 3, true>
+        (A, B, C, size_m, size_k, size_n, locks, post_scale);
+}

--- a/tests/test_exl3_gemm_k_reduction.py
+++ b/tests/test_exl3_gemm_k_reduction.py
@@ -1,0 +1,171 @@
+# The EXL3 GEMM's threadblock k-reduction, at every TILEBLOCKS_K the kernel can be built at.
+#
+# The shipping shape table tops out at TILEBLOCKS_K == 2, which runs a single store/add pair, so
+# nothing in the table exercises the staging regions the reduction interleaves at higher k-tile
+# counts. These tests instantiate the kernel directly at TILESIZE_K 16 / 32 / 64 (TILEBLOCKS_K
+# 1 / 2 / 4) so a shape added to the table cannot arrive without coverage.
+#
+# TILEBLOCKS_K == 1 runs no threadblock reduction at all and is the reference. The failure mode
+# under test is non-deterministic, so every cell checks bitwise launch-to-launch stability as well
+# as error against the reference, and a perturbed-input control confirms the comparison
+# discriminates at all.
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXT_DIR = os.path.join(ROOT, "exllamav3", "exllamav3_ext")
+KERNEL_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "kernels")
+
+CUDA_HOME = os.environ.get("CUDA_HOME", "/usr/local/cuda")
+NVCC = os.path.join(CUDA_HOME, "bin", "nvcc")
+
+# TILESIZE_K -> TILEBLOCKS_K. 16 is the reference; 32 is what the shipping table reaches; 64 is
+# the first count that interleaves a second store into a live staging region.
+TILESIZE_K_REF = 16
+TILESIZE_K_UNDER_TEST = [32, 64]
+
+BITS = [2, 3, 4, 5, 6, 7, 8]
+# Straddles the size_m <= 8 store_small/add_small path and the full-width path
+SIZE_M = [1, 4, 8, 9, 20, 33]
+
+SIZE_K = 2048
+SIZE_N = 512
+REPS = 8
+
+# Quantization noise against the reference sits at ~1e-5 of output RMS; the reduction defect
+# presents at 0.4-4.8, so any threshold in between separates them.
+REL_TOL = 0.01
+# The perturbed-input control must clear this, or the cell is not comparing anything
+REL_CONTROL_MIN = 0.02
+
+
+def _nvcc_available():
+    return os.path.isfile(NVCC)
+
+
+def _guard_arch():
+    # The guard is a static_assert on template parameters, so any arch the kernel body itself
+    # compiles for will do. cp.async in the pipeline needs sm_80 or later.
+    if torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability()
+        if major >= 8:
+            return f"sm_{major * 10 + minor}"
+    return "sm_80"
+
+
+@pytest.fixture(scope = "module")
+def probe():
+    if not torch.cuda.is_available():
+        pytest.skip("no CUDA device")
+    if not _nvcc_available():
+        pytest.skip(f"no nvcc at {NVCC}")
+    from torch.utils.cpp_extension import load
+    return load(
+        name = "exl3_k_reduction_probe",
+        sources = [os.path.join(KERNEL_DIR, "exl3_k_reduction_probe.cu")],
+        extra_include_paths = [EXT_DIR],
+        extra_cflags = ["-O2"],
+        extra_cuda_cflags = [
+            "-O3", "--use_fast_math",
+            "-Xcudafe", "--diag_suppress=177",
+            "-Xcudafe", "--diag_suppress=20012",
+        ],
+        verbose = False,
+    )
+
+
+@pytest.fixture(scope = "module")
+def device():
+    return "cuda:0"
+
+
+def _operands(bits, size_m, device):
+    g = torch.Generator(device = "cpu").manual_seed(1234 + bits)
+    B = torch.randint(-32768, 32767, (SIZE_K // 16, SIZE_N // 16, 16 * bits),
+                      dtype = torch.int16, generator = g).to(device)
+    suh = (torch.randn(SIZE_K, generator = g) * 0.1 + 1.0).half().to(device)
+    svh = (torch.randn(SIZE_N, generator = g) * 0.1 + 1.0).half().to(device)
+    A = (torch.randn((size_m, SIZE_K), generator = g) * 0.05).half().to(device)
+    locks = torch.zeros(SIZE_N // 16 + 1024, dtype = torch.int32, device = device)
+    return A, B, suh, svh, locks
+
+
+def _run(probe, tilesize_k, A, B, suh, svh, locks, device):
+    C = torch.zeros((A.size(0), SIZE_N), dtype = torch.float32, device = device)
+    A_had = torch.empty_like(A)
+    probe.probe_gemm(A, B, C, suh, A_had, svh, locks, tilesize_k)
+    torch.cuda.synchronize()
+    return C
+
+
+@pytest.mark.parametrize("tilesize_k", TILESIZE_K_UNDER_TEST)
+@pytest.mark.parametrize("size_m", SIZE_M)
+@pytest.mark.parametrize("bits", BITS)
+@torch.inference_mode()
+def test_k_reduction_matches_single_k_tile(probe, device, bits, size_m, tilesize_k):
+    A, B, suh, svh, locks = _operands(bits, size_m, device)
+
+    ref = _run(probe, TILESIZE_K_REF, A, B, suh, svh, locks, device)
+    rms = ref.double().pow(2).mean().sqrt().item()
+    assert rms > 0.0
+
+    # Control: the reference kernel on perturbed input, so a cell that cannot tell the two apart
+    # fails loudly instead of passing on a comparison that measures nothing
+    A_perturbed = (A.float() * 1.02).half().contiguous()
+    control = _run(probe, TILESIZE_K_REF, A_perturbed, B, suh, svh, locks, device)
+    rel_control = (control - ref).abs().max().item() / rms
+    assert rel_control > REL_CONTROL_MIN, \
+        f"perturbed-input control only reached {rel_control:.6f}; the comparison does not discriminate"
+
+    outs = []
+    for i in range(REPS):
+        # Interleave the reference so threadblock scheduling and L2 state vary between reps
+        if i:
+            _run(probe, TILESIZE_K_REF, A, B, suh, svh, locks, device)
+        outs.append(_run(probe, tilesize_k, A, B, suh, svh, locks, device))
+
+    assert not any(torch.isnan(o).any().item() for o in outs), \
+        f"TILESIZE_K {tilesize_k} produced NaN at bits {bits}, size_m {size_m}"
+
+    for i, o in enumerate(outs[1:], 1):
+        assert torch.equal(outs[0], o), \
+            f"TILESIZE_K {tilesize_k} is not deterministic across launches on identical input " \
+            f"(rep {i} differs) at bits {bits}, size_m {size_m}"
+
+    rel = max((o - ref).abs().max().item() for o in outs) / rms
+    assert rel < REL_TOL, \
+        f"TILESIZE_K {tilesize_k} differs from the TILESIZE_K {TILESIZE_K_REF} reference by " \
+        f"{rel:.6f} of output RMS at bits {bits}, size_m {size_m}"
+
+
+# A_COLS = TILESIZE_K / 8 that is not a power of two makes the A-fragment XOR swizzle address
+# past the end of a row. The kernel must refuse to compile rather than silently alias rows.
+@pytest.mark.parametrize("tilesize_k, buildable", [
+    (16, True), (32, True), (64, True),
+    (48, False), (80, False), (112, False),
+])
+def test_tilesize_k_over_eight_must_be_power_of_two(tmp_path, tilesize_k, buildable):
+    if not _nvcc_available():
+        pytest.skip(f"no nvcc at {NVCC}")
+    result = subprocess.run(
+        [
+            NVCC, "-std=c++20", f"-arch={_guard_arch()}", "-c",
+            "-I", EXT_DIR, f"-DPROBE_TILESIZE_K={tilesize_k}",
+            os.path.join(KERNEL_DIR, "exl3_tilesize_k_guard.cu"),
+            "-o", str(tmp_path / "guard.o"),
+        ],
+        capture_output = True, text = True,
+    )
+    guard = "TILESIZE_K / 8 must be a power of two"
+    if buildable:
+        assert result.returncode == 0, \
+            f"TILESIZE_K {tilesize_k} should compile but did not:\n{result.stderr}"
+    else:
+        assert result.returncode != 0, f"TILESIZE_K {tilesize_k} compiled, but its swizzle aliases rows"
+        assert guard in result.stderr, \
+            f"TILESIZE_K {tilesize_k} was rejected, but not by the swizzle guard:\n{result.stderr}"

--- a/tests/test_mgemm_ep.py
+++ b/tests/test_mgemm_ep.py
@@ -1,0 +1,143 @@
+# exl3_mgemm with expert-range filtering: the batched (num_tokens > 1) reduction against the
+# per-token (num_tokens == 1) loop, which is the only mode that used to be allowed with
+# min_index >= 0. Both arms see the same trellis/scales, the same routing and the same input
+# rows, so any slot -> token mixup shows up as a gross mismatch. The shifted-range control
+# confirms the comparison actually discriminates.
+
+import torch
+from exllamav3.ext import exllamav3_ext as ext
+
+torch.manual_seed(0)
+device = "cuda:0"
+torch.cuda.set_device(device)
+
+NUM_EXPERTS = 32
+H = 2048
+I = 1024
+K = 4
+
+# (name, first local expert, last local expert)
+RANGES = [
+    ("all local",        0, 32),
+    ("half local",       0, 16),
+    ("none local",      32, 33),
+    ("offset range",     8, 24),
+]
+
+
+def make_experts(num, k, n):
+    trellis, suh, svh = [], [], []
+    for _ in range(num):
+        t = torch.randint(0, 65536, (k // 16, n // 16, 256 * K // 16), dtype = torch.int32, device = device)
+        trellis.append(t.to(torch.short))
+        suh.append(torch.sign(torch.randn(k, device = device)).half())
+        svh.append(torch.sign(torch.randn(n, device = device)).half())
+    return trellis, suh, svh
+
+
+def ptrs(tensors, first, last):
+    return torch.tensor([t.data_ptr() for t in tensors[first:last]], dtype = torch.long, device = device)
+
+
+class Proj:
+    def __init__(self, num, k, n):
+        self.trellis, self.suh, self.svh = make_experts(num, k, n)
+        self.k, self.n = k, n
+
+    def tables(self, first, last):
+        return ptrs(self.trellis, first, last), ptrs(self.suh, first, last), ptrs(self.svh, first, last)
+
+
+def mgemm(tables, A, C, A_had, indices, weights, first, last, num_tokens):
+    pt, ps, pv = tables
+    ext.exl3_mgemm(
+        A, pt, C, ps, A_had, pv, indices, weights, K, -1, 0, 0,
+        first, last, 0, num_tokens, None, None
+    )
+
+
+def moe(gate, up, down, first, last, x, sel, weights, num_tokens):
+    """gate/up/act/down over num_tokens * top_k slots, returning the [num_tokens, H] reduction."""
+    bszm = sel.numel()
+    yh = torch.zeros((bszm, 1, H), dtype = torch.half, device = device)
+    interm_g = torch.zeros((bszm, 1, I), dtype = torch.half, device = device)
+    interm_u = torch.zeros((bszm, 1, I), dtype = torch.half, device = device)
+    interm_a = torch.zeros((bszm, 1, I), dtype = torch.half, device = device)
+    out_d = torch.zeros((bszm, 1, H), dtype = torch.float, device = device)
+    idx = sel.reshape(1, -1)
+    w = weights.reshape(1, -1)
+    mgemm(gate.tables(first, last), x, interm_g, yh, idx, None, first, last, num_tokens)
+    mgemm(up.tables(first, last), x, interm_u, yh, idx, None, first, last, num_tokens)
+    ext.silu_mul(interm_g, interm_u, interm_a, 0.0)
+    mgemm(down.tables(first, last), interm_a, out_d, interm_g, idx, w, first, last, num_tokens)
+    return out_d[:num_tokens, 0, :].clone()
+
+
+def batched(gate, up, down, first, last, x, sel, weights):
+    """One call per projection over all slots, with each slot's own input row."""
+    num_tokens, top_k = sel.shape
+    rows = torch.arange(num_tokens, device = device).unsqueeze(1).expand(num_tokens, top_k).reshape(-1)
+    xg = x.index_select(0, rows).view(-1, 1, H).contiguous()
+    return moe(gate, up, down, first, last, xg, sel, weights, num_tokens)
+
+
+def per_token(gate, up, down, first, last, x, sel, weights):
+    """Reference: one num_tokens == 1 call per token, the broadcast input the kernel already had."""
+    num_tokens = sel.shape[0]
+    out = torch.zeros((num_tokens, H), dtype = torch.float, device = device)
+    for t in range(num_tokens):
+        xt = x[t].view(1, 1, H).contiguous()
+        out[t] = moe(gate, up, down, first, last, xt, sel[t:t+1], weights[t:t+1], 1)[0]
+    return out
+
+
+def routing(num_tokens, top_k, seed):
+    g = torch.Generator().manual_seed(seed)
+    sel = torch.stack([torch.randperm(NUM_EXPERTS, generator = g)[:top_k] for _ in range(num_tokens)])
+    w = torch.rand((num_tokens, top_k), generator = g)
+    w = w / w.sum(-1, keepdim = True)
+    return sel.long().to(device), w.half().to(device)
+
+
+def rel_err(a, b):
+    scale = b.abs().max().item()
+    err = (a - b).abs().max().item()
+    return err / scale if scale > 0 else err
+
+
+def main():
+    gate = Proj(NUM_EXPERTS + 1, H, I)
+    up = Proj(NUM_EXPERTS + 1, H, I)
+    down = Proj(NUM_EXPERTS + 1, I, H)
+
+    for name, first, last in RANGES:
+        for num_tokens in [1, 2, 4, 8, 32, 128, 256]:
+            for top_k in [1, 2, 6, 8]:
+                sel, w = routing(num_tokens, top_k, num_tokens * 100 + top_k)
+                x = (torch.randn((num_tokens, H), device = device) * 0.05).half()
+                a = batched(gate, up, down, first, last, x, sel, w)
+                b = per_token(gate, up, down, first, last, x, sel, w)
+                live = int(((sel >= first) & (sel < last)).sum().item())
+                assert torch.isfinite(a).all(), f"{name} bsz={num_tokens} k={top_k}: non-finite"
+                rel = rel_err(a, b)
+                assert rel < 5e-3, f"{name} bsz={num_tokens} k={top_k}: rel {rel:.2e}"
+                print(f"  PASS {name:13s} bsz={num_tokens:4d} top_k={top_k} "
+                      f"live={live:5d}/{num_tokens * top_k:5d}: rel {rel:.2e}")
+
+    # Discrimination check: the same call against a shard whose range is off by one expert
+    for first, last in [(0, 16), (8, 24)]:
+        for num_tokens in [8, 32]:
+            sel, w = routing(num_tokens, 6, num_tokens * 100 + 6)
+            x = (torch.randn((num_tokens, H), device = device) * 0.05).half()
+            ref = per_token(gate, up, down, first, last, x, sel, w)
+            good = rel_err(batched(gate, up, down, first, last, x, sel, w), ref)
+            bad = rel_err(batched(gate, up, down, first + 1, last + 1, x, sel, w), ref)
+            assert bad > 100 * good, f"control [{first},{last}) bsz={num_tokens}: {bad:.2e} vs {good:.2e}"
+            print(f"  PASS control  [{first:2d},{last:2d}) bsz={num_tokens:4d}: "
+                  f"matched {good:.2e}, shifted {bad:.2e}")
+
+    print("ALL PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qgemm_tilesize_m.py
+++ b/tests/test_qgemm_tilesize_m.py
@@ -1,0 +1,171 @@
+# The multi-row-block GEMM shapes (TILESIZE_M > 16) must be a pure scheduling change: a row
+# block's accumulation order over k is whatever the 16-row shape with the same TILESIZE_K and
+# TILESIZE_N already does, so where such a partner exists the outputs have to match BIT FOR
+# BIT, not within a tolerance. A tolerance-based check would pass straight through a
+# reduction-order change, which is the failure this guards.
+#
+# The reduction staging area is per row block for the same reason, and getting that wrong
+# showed up only at some bit widths and only above 24 rows, so both axes are swept.
+
+import pytest
+import torch
+
+from exllamav3.ext import exllamav3_ext as ext
+
+# (TILESIZE_M, TILESIZE_K, TILESIZE_N) per shape index, mirroring EXL3_GEMM_SHAPE_n
+SHAPES = {
+    1: (16, 16, 128),
+    2: (16, 32, 128),
+    3: (16, 32, 256),
+    4: (16, 16, 512),
+    5: (32, 32, 128),
+    6: (32, 16, 256),
+    7: (32, 16, 128),
+    8: (48, 16, 128),
+    9: (64, 16, 128),
+    10: (32, 16, 512),
+}
+
+# A multi-row-block shape and the 16-row shape it is a pure restriping of: same TILESIZE_K
+# (same sub-k reduction) and same TILESIZE_N (same warp-to-column assignment)
+IDENTICAL_PAIRS = [(5, 2), (7, 1), (8, 1), (9, 1), (10, 4)]
+
+# Shape 6 (32, 16, 256) has no 16-row partner: the table holds no (16, 16, 256), and the
+# natural M=32 twin of shape 3 -- (32, 32, 256) -- spills past the 128-register cap that
+# blockDim 512 imposes and cannot be built. It is compared against shape 3, which computes
+# the same output tile at a different TILESIZE_K, on a tolerance instead
+NO_IDENTICAL_PARTNER = {6: 3}
+
+MAX_M = max(m for m, _, _ in SHAPES.values())
+
+# Spans a first row block that is full and partial, the last row block full and partial for
+# every TILESIZE_M in the table, and strip boundaries above each of them
+ROWS = [17, 20, 24, 25, 26, 31, 32, 33, 48, 49, 64, 65, 80, 96, 112, 127, 128, 144, 160]
+SIZES = [(5120, 5120), (5120, 13824), (2048, 7168)]
+
+_NUM_SHAPES = ext.exl3_gemm_num_kernel_shapes()
+_needs_shapes = pytest.mark.skipif(
+    _NUM_SHAPES < max(SHAPES), reason="no multi-row-block shapes built"
+)
+_needs_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+
+
+def _operands(k, n, bits, seed, device):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    trellis = torch.randint(
+        -32768, 32767, (k // 16, n // 16, 16 * bits), dtype=torch.int16, generator=g
+    ).to(device)
+    suh = (torch.randn(k, generator=g) * 0.1 + 1.0).half().to(device)
+    svh = (torch.randn(n, generator=g) * 0.1 + 1.0).half().to(device)
+    a = (torch.randn((max(ROWS), k), generator=g) * 0.05).half().to(device)
+    return trellis, suh, svh, a
+
+
+def _gemm(a, trellis, suh, svh, shape_idx, c_dtype, n):
+    a = a.contiguous()
+    a_had = torch.empty_like(a)
+    c = torch.empty((a.shape[0], n), dtype=c_dtype, device=a.device)
+    ext.exl3_gemm(a, trellis, c, suh, a_had, svh, shape_idx, False, False, 0)
+    return c
+
+
+@_needs_cuda
+@_needs_shapes
+@pytest.mark.parametrize("new_shape,ref_shape", IDENTICAL_PAIRS)
+@pytest.mark.parametrize("bits", [1, 2, 3, 4, 5, 6, 7, 8])
+@pytest.mark.parametrize("size", SIZES)
+@torch.inference_mode()
+def test_multi_row_block_matches_its_16_row_partner_bitwise(
+    new_shape, ref_shape, bits, size, device="cuda:0"
+):
+    k, n = size
+    trellis, suh, svh, a_all = _operands(k, n, bits, 11 + bits, device)
+    for rows in ROWS:
+        a = a_all[:rows]
+        ref = _gemm(a, trellis, suh, svh, ref_shape, torch.float16, n)
+        got = _gemm(a, trellis, suh, svh, new_shape, torch.float16, n)
+        torch.cuda.synchronize()
+        assert torch.equal(ref, got), (
+            f"shape {new_shape} vs {ref_shape} bits={bits} {k}x{n} rows={rows}: "
+            "not bit-identical"
+        )
+        # A race in the staging area shows up as run-to-run drift, which a single
+        # comparison against a same-run reference can miss
+        again = _gemm(a, trellis, suh, svh, new_shape, torch.float16, n)
+        torch.cuda.synchronize()
+        assert torch.equal(got, again), (
+            f"shape {new_shape} bits={bits} {k}x{n} rows={rows}: not reproducible"
+        )
+
+
+@_needs_cuda
+@_needs_shapes
+@pytest.mark.parametrize("new_shape,ref_shape", sorted(NO_IDENTICAL_PARTNER.items()))
+@pytest.mark.parametrize("bits", [2, 4, 6, 8])
+@torch.inference_mode()
+def test_shape_without_a_partner_agrees_within_tolerance_and_repeats(
+    new_shape, ref_shape, bits, device="cuda:0"
+):
+    k, n = 5120, 5120
+    trellis, suh, svh, a_all = _operands(k, n, bits, 11 + bits, device)
+    for rows in ROWS:
+        a = a_all[:rows]
+        ref = _gemm(a, trellis, suh, svh, ref_shape, torch.float16, n).float()
+        got = _gemm(a, trellis, suh, svh, new_shape, torch.float16, n).float()
+        again = _gemm(a, trellis, suh, svh, new_shape, torch.float16, n).float()
+        torch.cuda.synchronize()
+        assert torch.equal(got, again), (
+            f"shape {new_shape} bits={bits} rows={rows}: not reproducible"
+        )
+        rms = ref.pow(2).mean().sqrt().item()
+        err = (got - ref).abs().max().item()
+        # The two shapes reduce over k in a different order, so they differ by the same
+        # fp16 accumulation slack any two TILESIZE_K values already differ by
+        assert err < 0.05 * rms, (
+            f"shape {new_shape} vs {ref_shape} bits={bits} rows={rows}: "
+            f"max abs error {err} on output RMS {rms}"
+        )
+
+
+@_needs_cuda
+@_needs_shapes
+@pytest.mark.parametrize("new_shape,ref_shape", IDENTICAL_PAIRS)
+@torch.inference_mode()
+def test_multi_row_block_matches_partner_bitwise_fp32_out(
+    new_shape, ref_shape, device="cuda:0"
+):
+    k, n, bits = 5120, 5120, 4
+    trellis, suh, svh, a_all = _operands(k, n, bits, 7, device)
+    for rows in [17, 32, 33, 64, 65, 144]:
+        a = a_all[:rows]
+        ref = _gemm(a, trellis, suh, svh, ref_shape, torch.float32, n)
+        got = _gemm(a, trellis, suh, svh, new_shape, torch.float32, n)
+        torch.cuda.synchronize()
+        assert torch.equal(ref, got), (
+            f"shape {new_shape} vs {ref_shape} rows={rows}: fp32 output not bit-identical"
+        )
+
+
+@_needs_shapes
+def test_multi_row_block_shapes_declined_at_or_below_16_rows():
+    # The <=16-row path is the hottest in the engine and must keep its existing shape set:
+    # a 32-row shape there doubles the MMA count for no decode saving
+    for shape_idx, (tilesize_m, _, _) in SHAPES.items():
+        if tilesize_m == 16:
+            continue
+        for rows in (1, 5, 8, 15, 16):
+            assert not ext.exl3_gemm_shape_compat(shape_idx, rows, 5120, 5120, 4), (
+                f"shape {shape_idx} offered at {rows} rows"
+            )
+        assert ext.exl3_gemm_shape_compat(shape_idx, 17, 5120, 5120, 4)
+
+
+@_needs_shapes
+def test_every_multi_row_block_shape_is_covered_by_a_comparison():
+    # A shape added to the table without a bit-identity partner or an explicit entry in
+    # NO_IDENTICAL_PARTNER would ship with no numerics check at all
+    compared = {s for s, _ in IDENTICAL_PAIRS} | set(NO_IDENTICAL_PARTNER)
+    for shape_idx, (tilesize_m, _, _) in SHAPES.items():
+        if tilesize_m > 16:
+            assert shape_idx in compared, f"shape {shape_idx} has no numerics comparison"
+    assert len(SHAPES) == _NUM_SHAPES, "SHAPES is out of step with the built shape table"


### PR DESCRIPTION
Hi Turbo — I've been using exl3 since it launched. This is my first contribution
(Claude-assisted) for your consideration.

Two related things in `exl3_mgemm`'s expert-range-filtering path: a
memory-safety bug that bites at any real batch size, and the restriction that
made that path single-token in the first place. Targeted at `dev` per the
convention in recent PRs. Happy to rework any of it.

---

## 1. Out-of-bounds write in the filtered path (the load-bearing fix)

The filtered path stored its compacted index list in a fixed

```cpp
__device__ int64_t v_indices[128];
```

The 128-slot limit is documented but never enforced. Any launch with
`min_index >= 0` and more than 128 slots writes past the end — with `top_k` 6
that is **any batch above 21 tokens**. At the batch sizes an inference server
actually runs (384 slots at batch 64, 1536 at batch 256) it is writing 3-12x
past the array.

The list now lives in a bounded region of the existing per-device lock buffer,
with a host-side `TORCH_CHECK` so exceeding it is an error rather than
corruption.

This is worth taking on its own merit even if you don't want the rest.

## 2. The restriction that forced single-token filtering

```cpp
TORCH_CHECK(num_tokens == 1 || min_index < 0,
    "exl3_mgemm: multi-token reduction (num_tokens > 1) is not compatible with "
    "expert-range filtering (min_index >= 0); TP-sharded experts must use num_tokens == 1");
```

Once experts are sharded across ranks, `BlockSparseMLP`'s batched path is
disabled and the expert GEMM falls back to a per-token loop — three cooperative
launches per token instead of three for the batch.

### Why it existed

A slot's *position* is the only record of which token it belongs to: slot `i`
belongs to token `i / (bszm / num_tokens)`. The old compaction renumbered slots,
destroying that. At `num_tokens == 1` every slot shares one token, so it didn't
matter — hence the guard rather than a fix.

### How it's fixed

The list stores the **positions** of active slots instead of renumbered indices:

```cpp
if (active) slot_list[base + __popc(mask & ((1u << lane) - 1))] = i + lane;
```

Inactive slots are still skipped, but each surviving slot keeps its own input
row, output row and routing weight. Rebasing by `min_index` moves into a small
`slot_matrix()` helper shared by both sites. `moe_bias_add_kernel` mirrored the
old packing with an O(k) scan per thread; slots no longer move, so that scan is
gone. `BlockSparseMLP` no longer excludes sharded experts from the multi-row
graph path.

## Correctness

Reference is exllamav3's own per-token loop — the mode that already worked with
filtering — so this compares the new path against the behaviour it replaces.

* **112 / 112 configurations pass**: `num_tokens` in {1,2,4,8,32,128,256} x
  `top_k` in {1,2,6,8} x four shard ranges (all local, half local, none local,
  and an offset range `[8,24)`). Worst relative error **1.20e-3**, worst RMS
  2.6e-4. fp16 eps is 9.8e-4 and the two arms take different kernel shapes from
  the autotuner, so this is accumulation-order noise. Largest case 256 tokens x
  top_k 8 = 2048 slots, well past the old 128 limit.
* **Degenerate cases**: zero surviving slots (exactly 0.0 both arms), all
  surviving.
* **Negative control** — same call against a shard range shifted by one expert:
  relative error rises from ~7e-4 to 0.93-1.53, a 1.4-1.7e3x separation.
* **`num_tokens == 1` is bit-identical**: built from this branch and its merge
  base, ran 18 single-token cases through both — 18/18 bitwise equal
  (`torch.equal`). The existing production path is untouched.

`tests/test_mgemm_ep.py` runs the parity sweep and the negative control. It
generates its own random trellis data, so it needs no model on disk.

## Performance

Batched vs the per-token loop it replaces. RTX 4090, clocks locked 2100 MHz,
medians of 25 after 5 warmups, half the experts local, `top_k` 6 over 32:

| batch | batched | per-token loop | speedup |
|---|---|---|---|
| 8 | 0.222 ms | 0.554 ms | 2.49x |
| 32 | 0.510 ms | 2.093 ms | 4.10x |
| 64 | 0.933 ms | 4.127 ms | 4.42x |
| 128 | 1.776 ms | 8.120 ms | 4.57x |
| 256 | 3.600 ms | 16.156 ms | 4.49x |

Both arms do the same GEMM work; most of the gap is `3 x batch` cooperative
launches against 3.

**Caveat I'd rather state than have you find:** these were measured before I
understood that the autotune cache key clamps `bszm` at 24
(`MIN(bszm_in, 24)`), so the two arms hash to the same entry and the first shape
to warm dictates the config for both. I believe the direction is right — the
launch-count argument is structural — but I would not defend the exact
multipliers until they are re-measured with a per-arm cold cache. Happy to redo
them if useful.

## Scope, honestly

I originally wrote this to make expert-parallel MoE serving batch properly. I've
since found that `exl3_moe` — the expert-major fused kernel, including its
`MOE_ACT_RELU2_NOGATE` path — is the better fit for that workload, since it
dequantises each expert once rather than re-reading it per slot. So I am no
longer claiming this is the right way to serve sharded MoE.

What I think still stands regardless: the out-of-bounds write in section 1 is a
real bug in a path anyone can reach, and the multi-token restriction is a real
limitation of a public API. If you'd prefer only the OOB fix, I'm happy to strip
this down to that commit alone.

## Risks and limitations

* **No API change.** `exl3_mgemm`'s signature is unchanged.
* **Validated on sm_89 (RTX 4090) only.** Hopper/Blackwell take the
  `group_barrier` path rather than `grid.sync`; the compaction sits before that
  branch but has not been exercised there.
* The active-slot list is per-device state in the lock buffer, inheriting the
  existing one-cooperative-mgemm-in-flight-per-device assumption. The buffer
  grows ~64 KB per device.
* ~16% of a filtered launch is still spent carrying inactive slots. Removing
  that needs a different launch configuration, not just a different list.

For reference, dropping the compaction and filtering as a per-slot predicate —
a much smaller diff — measures 1.8x *worse* (6.355 ms vs 3.600 ms at batch 256),
because the main loop's iteration count dominates. What needed to change was
only *what the list stores*.