### PR TITLE
Loader: Account for already-reserved memory in autosplit reserve

### DIFF
--- a/exllamav3/util/memory.py
+++ b/exllamav3/util/memory.py
@@ -30,8 +30,13 @@ def set_memory_fraction_reserve(
 ):
     touch_device(device)
     free, total = torch.cuda.mem_get_info(device)
-    fraction = (free - reserve) / total
-    fraction = max(0.01, fraction)
+    # mem_get_info reports memory free *after* whatever this process has already reserved, but
+    # set_per_process_memory_fraction limits the process's *cumulative* reserved bytes. Add the
+    # current reservation back, or memory held by an earlier load in the same process (a draft
+    # model, a vision tower) is subtracted from the budget twice.
+    current = torch.cuda.memory_reserved(device)
+    fraction = (current + free - reserve) / total
+    fraction = min(1.0, max(0.01, fraction))
     torch.cuda.set_per_process_memory_fraction(fraction, device = device)
 
 


### PR DESCRIPTION
TL:DR
Exl3 is reserving (double-counting) VRAM reserve on model load when multiple models are loaded (i.e. main model + vision + mtp). Currently, I am doing a 4.6 bpw 3.8 27B and can get about 125k context (at q8/q8). Going to 130, it complains OOM. Making this fix lets me go higher (~160k) and fill full context without crashes.
More nuanced (explanation below):
----------
`set_memory_fraction_reserve()` derives the per-process cap from `torch.cuda.mem_get_info()`, which reports memory free after whatever this process has already reserved. `torch.cuda.set_per_process_memory_fraction()` then applies that as a limit on the process's cumulative reserved bytes, so memory allocated by an earlier load in the same process is subtracted from the budget twice.

This affects any caller loading more than one `Model` per process — the pattern in `examples/generator.py` (draft + main) and `examples/multimodal.py` (vision + main), and how TabbyAPI loads a vision tower, an MTP draft and the main model. `_load_autosplit()` installs the cap once per load, so by the third component the ceiling has collapsed by the size of the first two.

Measured on a 24 GB RTX 4090 loading a 27B EXL3 model with a vision tower and MTP drafting at 130k context:

| stage  | already_reserved | cap installed | cap with this change |
| ------ | ---------------: | ------------: | -------------------: |
| vision |            0 MiB |     22940 MiB |            22940 MiB |
| draft  |         1184 MiB |     21646 MiB |            22830 MiB |
| main   |         1568 MiB |     21262 MiB |            22830 MiB |

The main model then fails with `Insufficient VRAM in split for model and cache` while 1678 MiB is still free on the device. Adding the already-reserved bytes back holds the cap steady at 22830 MiB across all three stages and the load succeeds.

Single-component loads are unaffected beyond the few MiB `touch_device()` reserves.

Relates to #50 — this is one cause of that report (the multi-component case); the single-component numbers there are not explained by this change.
