### PR TITLE
PoC: per-layer split or fused-uniform QKV topology

### DIFF
--- a/exllamav3/conversion/compile.py
+++ b/exllamav3/conversion/compile.py
@@ -7,6 +7,7 @@ from ..loader.safetensors_alt import save_file
 from ..util.memory import free_mem
 from ..modules import Module, Linear
 from .quant_config import update_config, create_quantization_config_json
+from .qkv_topology import canonical_json, validate_payload_index
 
 def tsize(t):
     return t.nelement() * t.element_size()
@@ -26,6 +27,12 @@ def compile_model(args, model, config, tokenizer, mtp_model = None, vision_model
         work_dir = args["work_dir"]
         qtensors_dir = os.path.join(work_dir, "qtensors")
         qtensors_stc = SafetensorsCollection(qtensors_dir, tensor_name_fixes = config.get_tensor_name_fixes())
+    qkv_topology = args.get("exl3_qkv_topology")
+    qkv_safetensors_metadata = (
+        {"exl3_qkv_topology": canonical_json(qkv_topology)}
+        if qkv_topology is not None else
+        None
+    )
 
     # Prepare output directory
     if not os.path.exists(out_dir):
@@ -127,9 +134,15 @@ def compile_model(args, model, config, tokenizer, mtp_model = None, vision_model
             file_dict.update(tensors)
         for name in file_dict.keys():
             map_dict[name] = filename
-        save_file(file_dict, os.path.join(out_dir, filename))
+        save_file(
+            file_dict,
+            os.path.join(out_dir, filename),
+            metadata = qkv_safetensors_metadata,
+        )
         del file_dict
         free_mem()
+    if qkv_topology is not None:
+        validate_payload_index(map_dict, qkv_topology)
 
     # Copy non-tensor files
     print(f" -- Copying non-tensor files from {in_dir}")
@@ -169,6 +182,8 @@ def compile_model(args, model, config, tokenizer, mtp_model = None, vision_model
             },
             "weight_map": map_dict
         }
+        if qkv_topology is not None:
+            safetensors_index["metadata"]["exl3_qkv_topology"] = qkv_topology
         with open(os.path.join(out_dir, "model.safetensors.index.json"), "w") as f:
             f.write(json.dumps(safetensors_index, indent = 4))
 
@@ -215,6 +230,8 @@ def compile_model(args, model, config, tokenizer, mtp_model = None, vision_model
             qcfg.update({
                 "original_quantization_config": orig_qcfg
             })
+    if qkv_topology is not None:
+        qcfg["exl3_qkv_topology"] = qkv_topology
 
     if vision_model and args.get("vision_bits", 16) != 16:
         qcfg["vision_bits"] = args["vision_bits"]

--- a/exllamav3/conversion/convert_model.py
+++ b/exllamav3/conversion/convert_model.py
@@ -17,12 +17,10 @@ from .compile import compile_model, dsize
 from .allocation import create_q_strategy, print_strategy
 from ..loader.safetensors_alt import save_file, safe_open
 from .qkv_topology import (
-    QKVTopologyError,
     apply_fused_strategy,
-    attention_descriptor,
     install_fused_qkv,
     load_topology_plan,
-    resolve_topology,
+    resolve_target_topology,
 )
 import os, shutil
 import json
@@ -1007,37 +1005,29 @@ def main(args, job_state):
         for linear in model
         if isinstance(linear, Linear) and linear.qmap is not None and linear.qbits_key == "bits"
     }
-    qkv_models = [m for m in (model, mtp_model, vision_model) if m is not None]
-    qkv_attentions = [
-        attn
-        for qkv_model in qkv_models
-        for attn in qkv_model
-        if isinstance(attn, Attention)
-    ]
     scale_policy = {True: "always", False: "never", None: "auto"}[args["apply_out_scales"]]
-    qkv_descriptors = [
-        attention_descriptor(attn, strategy, args["codebook"], scale_policy)
-        for attn in qkv_attentions
-    ]
-    unsupported = [attn.key for attn, descriptor in zip(qkv_attentions, qkv_descriptors) if descriptor is None]
-    if unsupported:
-        raise QKVTopologyError(
-            f"Topology metadata cannot describe full-attention layers with nonstandard QKV: {unsupported}"
-        )
-    qkv_topology = resolve_topology(qkv_descriptors, args.get("qkv_topology_plan"))
-    args["exl3_qkv_topology"] = qkv_topology
-    qkv_rows = {row["layer"]: row for row in qkv_topology["layers"]}
-    for attn in qkv_attentions:
-        row = qkv_rows[attn.key]
-        if row["variant"] == "fused_uniform":
-            component_keys = [getattr(attn, name).key for name in row["components"]]
-            if all(key in main_weight_numel for key in component_keys):
-                q = attn.q_proj
-                fused_out = (sum(row["output_splits"]) + 127) // 128 * 128
-                for key in component_keys:
-                    main_weight_numel.pop(key)
-                main_weight_numel[attn.key + ".qkv_proj"] = q.in_features * fused_out
-        apply_fused_strategy(attn, row, strategy)
+    qkv_topology, qkv_attentions = resolve_target_topology(
+        model,
+        strategy,
+        args["codebook"],
+        scale_policy,
+        args.get("qkv_topology_plan"),
+    )
+    qkv_rows = {}
+    if qkv_topology is not None:
+        args["exl3_qkv_topology"] = qkv_topology
+        qkv_rows = {row["layer"]: row for row in qkv_topology["layers"]}
+        for attn in qkv_attentions:
+            row = qkv_rows[attn.key]
+            if row["variant"] == "fused_uniform":
+                component_keys = [getattr(attn, name).key for name in row["components"]]
+                if all(key in main_weight_numel for key in component_keys):
+                    q = attn.q_proj
+                    fused_out = (sum(row["output_splits"]) + 127) // 128 * 128
+                    for key in component_keys:
+                        main_weight_numel.pop(key)
+                    main_weight_numel[attn.key + ".qkv_proj"] = q.in_features * fused_out
+            apply_fused_strategy(attn, row, strategy)
     main_numel = sum(main_weight_numel.values())
     final_bpw = (
         sum(main_weight_numel[key] * strategy[key] for key in main_weight_numel) / main_numel

--- a/exllamav3/conversion/convert_model.py
+++ b/exllamav3/conversion/convert_model.py
@@ -3,7 +3,7 @@ import torch
 import time
 import sys
 from .. import Config, Model, Tokenizer
-from ..modules import Linear
+from ..modules import Attention, Linear
 from ..modules.linear import convert_exl3_group
 from ..modules.quant.exl3_lib.quantize import auto_split
 from ..modules.quant import LinearFP16, LinearEXL3
@@ -16,6 +16,14 @@ from .calibration_data import get_default_calibration
 from .compile import compile_model, dsize
 from .allocation import create_q_strategy, print_strategy
 from ..loader.safetensors_alt import save_file, safe_open
+from .qkv_topology import (
+    QKVTopologyError,
+    apply_fused_strategy,
+    attention_descriptor,
+    install_fused_qkv,
+    load_topology_plan,
+    resolve_topology,
+)
 import os, shutil
 import json
 import threading
@@ -47,12 +55,18 @@ parser.add_argument("-v", "--verbose", action = "store_true", help = "Verbose mo
 parser.add_argument("-d", "--devices", type = str, default = "0", help = "List of devices to use for quantization, e.g. --devices 0,1,2")
 parser.add_argument("-dr", "--device_ratios", type = str, default = "", help = "Split ratio for devices, e.g. --device_ratio 2,2,4")
 parser.add_argument("-img", "--image_dump", action = "store_true", help = "Save model tensors as images (saved to working directory)")
-parser.add_argument("-cb", "--codebook", type = str, default = "mul1", help = "Codebook: mul1 (default), mcg or 3inst")
+parser.add_argument("-cb", "--codebook", type = str, default = None, help = "Codebook: mul1 (default), mcg or 3inst")
 parser.add_argument("-pm", "--parallel_mode", action = "store_true", help = "Deprecated (no-op): parallel mode is now the default; layers with fewer tensors than devices fall back to tile splitting")
 parser.add_argument("--max_module", type = int, help = "End quantization after this many modules, includes embedding and norm layers (for debug purposes)", default = None)
+parser.add_argument(
+    "--qkv_topology_plan",
+    type = str,
+    default = None,
+    help = "JSON exl3_qkv_topology/1 layer plan; unspecified full-attention layers remain split",
+)
 
 group = parser.add_mutually_exclusive_group()
-group.add_argument("--out_scales", type = str, default = "always", help = "Enable out channel scales (always/never/auto, default: always)")
+group.add_argument("--out_scales", type = str, default = None, help = "Enable out channel scales (always/never/auto, default: always)")
 
 parser.add_argument("--override_anyway", action = "store_true", help = "Allow resuming even when overriding settings that will break the existing job.")
 
@@ -134,7 +148,7 @@ def prepare(args) -> (dict, dict, bool, str):
         return None, None, False, "Specify either --in_dir to start a new job or --resume to resume an interrupted job"
     if not args.out_dir and not args.resume:
         return None, None, False, "Must specify --out_dir or --resume"
-    if args.codebook not in ["mcg", "mul1", "3inst"]:
+    if args.codebook is not None and args.codebook not in ["mcg", "mul1", "3inst"]:
         return None, None, False, "Codebook must be 'mcg', 'mul1' or '3inst'"
     if args.bits is not None and (args.bits > 8 or args.bits < 1):
         return None, None, False, "--bits must be between 1 and 8"
@@ -147,6 +161,13 @@ def prepare(args) -> (dict, dict, bool, str):
         in_args["work_dir"] = args.work_dir
 
     prepare_env(in_args)
+    requested_qkv_topology = load_topology_plan(args.qkv_topology_plan) if args.qkv_topology_plan else None
+    if args.resume:
+        stored_qkv_topology = in_args.get("qkv_topology_plan")
+        if requested_qkv_topology is not None and requested_qkv_topology != stored_qkv_topology:
+            raise ValueError(" ## Error: Cannot change --qkv_topology_plan while resuming a job")
+    else:
+        in_args["qkv_topology_plan"] = requested_qkv_topology
 
     def override(arg, can_override, default):
         if (arg not in args or vars(args)[arg] is None) and arg not in in_args:
@@ -191,7 +212,10 @@ def prepare(args) -> (dict, dict, bool, str):
     # Momentary args
     in_args["image_dump"] = args.image_dump
     in_args["verbose"] = args.verbose
-    in_args["apply_out_scales"] = {"always": True, "never": False, "auto": None}[args.out_scales]
+    if args.out_scales is not None:
+        in_args["apply_out_scales"] = {"always": True, "never": False, "auto": None}[args.out_scales]
+    elif "apply_out_scales" not in in_args:
+        in_args["apply_out_scales"] = True
     in_args["max_module"] = args.max_module
 
     if args.resume:
@@ -978,6 +1002,47 @@ def main(args, job_state):
         model, mtp_model, config, args["bits"], args["head_bits"], args["mtp_bits"], hq,
         vision_model = vision_model, vision_bpw = args.get("vision_bits", 16),
     )
+    main_weight_numel = {
+        linear.key: linear.weights_numel()
+        for linear in model
+        if isinstance(linear, Linear) and linear.qmap is not None and linear.qbits_key == "bits"
+    }
+    qkv_models = [m for m in (model, mtp_model, vision_model) if m is not None]
+    qkv_attentions = [
+        attn
+        for qkv_model in qkv_models
+        for attn in qkv_model
+        if isinstance(attn, Attention)
+    ]
+    scale_policy = {True: "always", False: "never", None: "auto"}[args["apply_out_scales"]]
+    qkv_descriptors = [
+        attention_descriptor(attn, strategy, args["codebook"], scale_policy)
+        for attn in qkv_attentions
+    ]
+    unsupported = [attn.key for attn, descriptor in zip(qkv_attentions, qkv_descriptors) if descriptor is None]
+    if unsupported:
+        raise QKVTopologyError(
+            f"Topology metadata cannot describe full-attention layers with nonstandard QKV: {unsupported}"
+        )
+    qkv_topology = resolve_topology(qkv_descriptors, args.get("qkv_topology_plan"))
+    args["exl3_qkv_topology"] = qkv_topology
+    qkv_rows = {row["layer"]: row for row in qkv_topology["layers"]}
+    for attn in qkv_attentions:
+        row = qkv_rows[attn.key]
+        if row["variant"] == "fused_uniform":
+            component_keys = [getattr(attn, name).key for name in row["components"]]
+            if all(key in main_weight_numel for key in component_keys):
+                q = attn.q_proj
+                fused_out = (sum(row["output_splits"]) + 127) // 128 * 128
+                for key in component_keys:
+                    main_weight_numel.pop(key)
+                main_weight_numel[attn.key + ".qkv_proj"] = q.in_features * fused_out
+        apply_fused_strategy(attn, row, strategy)
+    main_numel = sum(main_weight_numel.values())
+    final_bpw = (
+        sum(main_weight_numel[key] * strategy[key] for key in main_weight_numel) / main_numel
+        if main_numel else 0
+    )
     args["final_bits"] = round(final_bpw, 2)
     print(" -- Quantization strategy, summary:")
     print(print_strategy(strategy))
@@ -1122,6 +1187,13 @@ def main(args, job_state):
                     for k, v in capture_H.items():
                         v["H_swap_device"] = v["H"].device
                         v["H"] = v["H"].cpu()
+
+            # The Hessian was captured through the original q/k/v modules. Only now replace
+            # selected blocks with one BF16-derived logical qkv_proj carrying that same qmap.
+            for attn in module:
+                row = qkv_rows.get(attn.key) if isinstance(attn, Attention) else None
+                if row is not None and row["variant"] == "fused_uniform" and attn.qkv_proj is None:
+                    install_fused_qkv(attn)
 
             # Get submodules to quantize
             linears = [m for m in module if isinstance(m, Linear) and m.qmap and m.device is not None]
@@ -1292,6 +1364,11 @@ def main(args, job_state):
                 if m.used_alt_key:
                     print(f"     - Cloned {m.key} from {m.alt_key}")
             module.config.stc.close()
+            for attn in module:
+                row = qkv_rows.get(attn.key) if isinstance(attn, Attention) else None
+                if row is not None and row["variant"] == "fused_uniform" and attn.qkv_proj is None:
+                    install_fused_qkv(attn)
+
 
             linears = [m for m in module if isinstance(m, Linear) and m.qmap and m.device is not None]
             for linear in linears:

--- a/exllamav3/conversion/qkv_topology.py
+++ b/exllamav3/conversion/qkv_topology.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Iterable
+
+import torch
+if TYPE_CHECKING:
+    from ..modules import Attention, Linear
+
+
+
+SCHEMA = "exl3_qkv_topology/1"
+COMPONENTS = ("q_proj", "k_proj", "v_proj")
+VARIANTS = ("split", "fused_uniform")
+SCALE_VALUES = ("always", "never", "auto")
+
+
+class QKVTopologyError(ValueError):
+    pass
+
+
+def canonical_json(value: dict) -> str:
+    return json.dumps(value, sort_keys = True, separators = (",", ":"))
+
+
+def load_topology_plan(path: str) -> dict:
+    with open(path, "r", encoding = "utf8") as f:
+        plan = json.load(f)
+    if not isinstance(plan, dict):
+        raise QKVTopologyError("QKV topology plan must be a JSON object")
+    if plan.get("schema") != SCHEMA:
+        raise QKVTopologyError(f"QKV topology plan schema must be {SCHEMA!r}")
+    layers = plan.get("layers")
+    if not isinstance(layers, list):
+        raise QKVTopologyError("QKV topology plan layers must be a list")
+    return plan
+
+
+def _validate_K(K, where: str) -> int:
+    if isinstance(K, bool) or not isinstance(K, int) or not 1 <= K <= 8:
+        raise QKVTopologyError(f"{where} K must be one integer value between 1 and 8")
+    return K
+
+
+def _validate_scale(scale, where: str) -> str:
+    if scale not in SCALE_VALUES:
+        raise QKVTopologyError(f"{where} scale must be one of {SCALE_VALUES}")
+    return scale
+
+
+def _plan_rows(plan: dict | None) -> dict[str, dict]:
+    if plan is None:
+        return {}
+    if plan.get("schema") != SCHEMA or not isinstance(plan.get("layers"), list):
+        raise QKVTopologyError(f"QKV topology plan must use schema {SCHEMA!r} and a layers list")
+    result = {}
+    for row in plan["layers"]:
+        if not isinstance(row, dict):
+            raise QKVTopologyError("Each QKV topology layer entry must be an object")
+        allowed = {"layer", "variant", "K", "codebook", "scale"}
+        extra = set(row) - allowed
+        if extra:
+            raise QKVTopologyError(f"Unknown QKV topology fields for layer entry: {sorted(extra)}")
+        layer = row.get("layer")
+        if not isinstance(layer, str) or not layer:
+            raise QKVTopologyError("Each QKV topology layer entry requires a nonempty layer string")
+        if layer in result:
+            raise QKVTopologyError(f"Duplicate QKV topology declaration for {layer}")
+        variant = row.get("variant")
+        if variant not in VARIANTS:
+            raise QKVTopologyError(f"Unknown QKV topology variant for {layer}: {variant!r}")
+        if variant == "split":
+            forbidden = set(row) & {"K", "codebook", "scale"}
+            if forbidden:
+                raise QKVTopologyError(
+                    f"Split layer {layer} inherits independent projection settings; "
+                    f"do not provide {sorted(forbidden)}"
+                )
+        else:
+            _validate_K(row.get("K"), layer)
+            if row.get("codebook") not in ("mul1", "mcg", "3inst"):
+                raise QKVTopologyError(f"Fused layer {layer} requires one supported codebook")
+            _validate_scale(row.get("scale"), layer)
+        result[layer] = row
+    return result
+
+
+def attention_descriptor(attn: Attention, strategy: dict, codebook: str, scale: str) -> dict | None:
+    from ..modules import Linear
+    if attn.interleaved_gate or attn.use_k_as_v:
+        return None
+    projections = []
+    for name in COMPONENTS:
+        linear = getattr(attn, name, None)
+        if not isinstance(linear, Linear):
+            return None
+        if linear.key != attn.key + "." + name:
+            return None
+        if linear.key not in strategy:
+            raise QKVTopologyError(f"No quantization strategy for {linear.key}")
+        projections.append({
+            "name": name,
+            "K": strategy[linear.key],
+            "codebook": codebook,
+            "scale": scale,
+            "out_features": linear.out_features_unpadded,
+        })
+    qmaps = {getattr(attn, name).qmap for name in COMPONENTS}
+    if len(qmaps) != 1 or None in qmaps:
+        raise QKVTopologyError(f"Attention layer {attn.key} does not have one shared QKV calibration identity")
+    return {
+        "layer": attn.key,
+        "qmap": next(iter(qmaps)),
+        "projections": projections,
+    }
+
+
+def resolve_topology(
+    descriptors: Iterable[dict],
+    plan: dict | None,
+) -> dict:
+    requested = _plan_rows(plan)
+    by_layer = {}
+    for descriptor in descriptors:
+        layer = descriptor["layer"]
+        if layer in by_layer:
+            raise QKVTopologyError(f"Duplicate attention descriptor for {layer}")
+        projections = descriptor.get("projections")
+        if not isinstance(projections, list) or [p.get("name") for p in projections] != list(COMPONENTS):
+            raise QKVTopologyError(f"Attention descriptor {layer} must declare q, k, v in frozen order")
+        splits = [p.get("out_features") for p in projections]
+        if any(isinstance(s, bool) or not isinstance(s, int) or s <= 0 for s in splits):
+            raise QKVTopologyError(f"Attention descriptor {layer} has invalid output splits")
+        by_layer[layer] = descriptor
+
+    unknown = set(requested) - set(by_layer)
+    if unknown:
+        raise QKVTopologyError(f"QKV topology plan names unknown or unsupported attention layers: {sorted(unknown)}")
+
+    rows = []
+    for layer in sorted(by_layer):
+        descriptor = by_layer[layer]
+        projection_rows = descriptor["projections"]
+        request = requested.get(layer, {"variant": "split"})
+        variant = request["variant"]
+        common = {
+            "layer": layer,
+            "variant": variant,
+            "components": list(COMPONENTS),
+            "output_splits": [p["out_features"] for p in projection_rows],
+        }
+        if variant == "split":
+            common["projections"] = [
+                {k: p[k] for k in ("name", "K", "codebook", "scale")}
+                for p in projection_rows
+            ]
+        else:
+            codebooks = {p["codebook"] for p in projection_rows}
+            scales = {p["scale"] for p in projection_rows}
+            if codebooks != {request["codebook"]} or scales != {request["scale"]}:
+                raise QKVTopologyError(
+                    f"Fused layer {layer} must use the converter's one codebook and scale policy"
+                )
+            common["projection"] = {
+                "name": "qkv_proj",
+                "K": request["K"],
+                "codebook": request["codebook"],
+                "scale": request["scale"],
+            }
+        rows.append(common)
+    return {"schema": SCHEMA, "layers": rows}
+
+
+def concatenate_qkv_bf16(weights: Iterable[torch.Tensor]) -> torch.Tensor:
+    weights = tuple(weights)
+    if len(weights) != 3:
+        raise QKVTopologyError("QKV concatenation requires exactly q, k, v weights")
+    if any(w.dtype != torch.bfloat16 for w in weights):
+        raise QKVTopologyError("Fused-uniform QKV must be derived directly from BF16 weights")
+    if any(w.ndim != 2 for w in weights):
+        raise QKVTopologyError("QKV weights must be rank-2 tensors")
+    if len({w.shape[0] for w in weights}) != 1:
+        raise QKVTopologyError("QKV weights must have one common input width")
+    return torch.cat(weights, dim = 1).contiguous()
+
+
+def split_qkv(weight: torch.Tensor, output_splits: Iterable[int]) -> tuple[torch.Tensor, ...]:
+    splits = tuple(output_splits)
+    if len(splits) != 3 or any(isinstance(s, bool) or not isinstance(s, int) or s <= 0 for s in splits):
+        raise QKVTopologyError("QKV output_splits must contain three positive integers")
+    if weight.ndim != 2 or sum(splits) != weight.shape[1]:
+        raise QKVTopologyError("QKV output_splits do not reconstruct the fused output width")
+    return torch.split(weight, splits, dim = 1)
+
+
+def _load_source_bf16(linear: Linear) -> tuple[torch.Tensor, torch.Tensor | None]:
+    stc = linear.config.stc
+    if linear.alt_key or linear.fkey or linear.is_sliced:
+        raise QKVTopologyError(f"Fused-uniform PoC requires a direct, unsliced source tensor for {linear.key}")
+    weight_key = linear.key + ".weight"
+    if not stc.has_tensor(weight_key):
+        raise QKVTopologyError(f"Missing direct source tensor {weight_key}")
+    weight = stc.get_tensor(
+        weight_key,
+        linear.device,
+        allow_bf16 = True,
+        transpose = linear.transposed_load,
+        no_defer = True,
+    )
+    expected = (linear.in_features_unpadded, linear.out_features_unpadded)
+    if weight.dtype != torch.bfloat16 or tuple(weight.shape) != expected:
+        raise QKVTopologyError(
+            f"{weight_key} must be BF16 with logical shape {expected}, got {weight.dtype} {tuple(weight.shape)}"
+        )
+    bias_key = linear.key + ".bias"
+    bias = stc.get_tensor(bias_key, linear.device, optional = True, allow_bf16 = True, no_defer = True)
+    if bias is not None and (bias.dtype != torch.bfloat16 or tuple(bias.shape) != (linear.out_features_unpadded,)):
+        raise QKVTopologyError(f"{bias_key} must be BF16 with logical output width")
+    return weight, bias
+
+
+def install_fused_qkv(attn: Attention) -> Linear:
+    from ..modules import Linear
+    from ..modules.quant import LinearFP16
+    components = [getattr(attn, name, None) for name in COMPONENTS]
+    if not all(isinstance(linear, Linear) for linear in components):
+        raise QKVTopologyError(f"Attention layer {attn.key} is not a split full-attention QKV block")
+    if attn.use_k_as_v or attn.interleaved_gate:
+        raise QKVTopologyError(f"Attention layer {attn.key} cannot preserve ordinary q,k,v output order")
+    if any(not isinstance(linear.inner, LinearFP16) for linear in components):
+        raise QKVTopologyError(f"Attention layer {attn.key} must be loaded from source before QKV fusion")
+    if len({linear.qmap for linear in components}) != 1 or components[0].qmap is None:
+        raise QKVTopologyError(f"Attention layer {attn.key} does not share one QKV calibration identity")
+    if len({linear.in_features_unpadded for linear in components}) != 1:
+        raise QKVTopologyError(f"Attention layer {attn.key} QKV input widths differ")
+
+    source = [_load_source_bf16(linear) for linear in components]
+    weight = concatenate_qkv_bf16(item[0] for item in source)
+    biases = [item[1] for item in source]
+    if any(b is None for b in biases) and not all(b is None for b in biases):
+        raise QKVTopologyError(f"Attention layer {attn.key} has only a partial QKV bias set")
+    bias = torch.cat(biases).contiguous() if biases[0] is not None else None
+
+    q = components[0]
+    qkv = Linear(
+        q.config,
+        attn.key + ".qkv_proj",
+        q.in_features_unpadded,
+        sum(linear.out_features_unpadded for linear in components),
+        qmap = q.qmap,
+        qbits_key = q.qbits_key,
+        trim_padded_out = True,
+    )
+    weight = qkv.pad_out(weight)
+    bias = qkv.pad_out(bias)
+    qkv.device = attn.device
+    qkv.inner = LinearFP16(
+        qkv.in_features,
+        qkv.out_features,
+        weight,
+        bias,
+        qkv.full_in_features,
+        qkv.full_out_features,
+        qkv.first_in_feature,
+        qkv.first_out_feature,
+        qkv.out_dtype,
+        key = qkv.key,
+    )
+    qkv.quant_type = "fp16"
+
+    component_ids = {id(linear) for linear in components}
+    first = min(i for i, module in enumerate(attn.modules) if id(module) in component_ids)
+    attn.modules = [module for module in attn.modules if id(module) not in component_ids]
+    attn.modules.insert(first, qkv)
+    for linear in components:
+        linear.unload()
+    attn.q_proj = None
+    attn.k_proj = None
+    attn.v_proj = None
+    attn.qkv_proj = qkv
+    return qkv
+
+
+def apply_fused_strategy(attn: Attention, row: dict, strategy: dict) -> None:
+    if row["variant"] != "fused_uniform":
+        return
+    component_keys = [getattr(attn, name).key for name in COMPONENTS]
+    for key in component_keys:
+        strategy.pop(key, None)
+    strategy[attn.key + ".qkv_proj"] = row["projection"]["K"]
+
+
+def topology_layer_map(topology: dict | None) -> dict[str, dict]:
+    if topology is None:
+        return {}
+    if not isinstance(topology, dict) or topology.get("schema") != SCHEMA or not isinstance(topology.get("layers"), list):
+        raise QKVTopologyError(f"Topology metadata must use schema {SCHEMA!r} and a layers list")
+    result = {}
+    previous = None
+    common_keys = {"layer", "variant", "components", "output_splits"}
+    projection_keys = {"name", "K", "codebook", "scale"}
+    for row in topology["layers"]:
+        if not isinstance(row, dict):
+            raise QKVTopologyError("Topology layer declarations must be objects")
+        layer = row.get("layer")
+        if not isinstance(layer, str) or not layer or layer in result:
+            raise QKVTopologyError("Topology layers must have unique nonempty layer names")
+        if previous is not None and layer <= previous:
+            raise QKVTopologyError("Topology layers must be in deterministic lexical order")
+        previous = layer
+        if row.get("components") != list(COMPONENTS):
+            raise QKVTopologyError(f"Topology component order changed for {layer}")
+        splits = row.get("output_splits")
+        if not isinstance(splits, list) or len(splits) != 3 or any(
+            isinstance(s, bool) or not isinstance(s, int) or s <= 0 for s in splits
+        ):
+            raise QKVTopologyError(f"Topology output_splits are invalid for {layer}")
+        if row.get("variant") == "split":
+            if set(row) != common_keys | {"projections"}:
+                raise QKVTopologyError(f"Split topology fields are invalid for {layer}")
+            declarations = row["projections"]
+            if not isinstance(declarations, list) or [p.get("name") for p in declarations] != list(COMPONENTS):
+                raise QKVTopologyError(f"Split topology for {layer} must declare q, k, v")
+        elif row.get("variant") == "fused_uniform":
+            if set(row) != common_keys | {"projection"}:
+                raise QKVTopologyError(f"Fused topology fields are invalid for {layer}")
+            declarations = [row["projection"]]
+            if not isinstance(declarations[0], dict) or declarations[0].get("name") != "qkv_proj":
+                raise QKVTopologyError(f"Fused topology for {layer} must declare qkv_proj")
+        else:
+            raise QKVTopologyError(f"Unknown topology variant for {layer}: {row.get('variant')!r}")
+        for declaration in declarations:
+            if not isinstance(declaration, dict) or set(declaration) != projection_keys:
+                raise QKVTopologyError(f"Projection fields are invalid for {layer}")
+            _validate_K(declaration["K"], layer)
+            if declaration["codebook"] not in ("mul1", "mcg", "3inst"):
+                raise QKVTopologyError(f"Projection codebook is invalid for {layer}")
+            _validate_scale(declaration["scale"], layer)
+        result[layer] = row
+    return result
+
+
+def validate_payload_index(tensor_keys: Iterable[str], topology: dict) -> None:
+    layer_map = topology_layer_map(topology)
+    keys = set(tensor_keys)
+    for layer, row in layer_map.items():
+        variant = row.get("variant")
+        if variant == "split":
+            declarations = row.get("projections")
+            if not isinstance(declarations, list) or [p.get("name") for p in declarations] != list(COMPONENTS):
+                raise QKVTopologyError(f"Compiled split topology for {layer} must declare q, k, v")
+            logical = [(layer + "." + declaration["name"], declaration) for declaration in declarations]
+            forbidden = layer + ".qkv_proj."
+        elif variant == "fused_uniform":
+            declaration = row.get("projection")
+            if not isinstance(declaration, dict) or declaration.get("name") != "qkv_proj":
+                raise QKVTopologyError(f"Compiled fused topology for {layer} must declare qkv_proj")
+            logical = [(layer + ".qkv_proj", declaration)]
+            forbidden = tuple(layer + "." + name + "." for name in COMPONENTS)
+        else:
+            raise QKVTopologyError(f"Compiled topology for {layer} has unknown variant {variant!r}")
+        for prefix, declaration in logical:
+            if prefix + ".trellis" not in keys:
+                raise QKVTopologyError(f"Compiled payload is missing {prefix}.trellis")
+            marker = {"mul1": ".mul1", "mcg": ".mcg", "3inst": None}.get(declaration.get("codebook"))
+            if declaration.get("codebook") not in ("mul1", "mcg", "3inst"):
+                raise QKVTopologyError(f"Compiled payload declares an unknown codebook for {prefix}")
+            if marker is not None and prefix + marker not in keys:
+                raise QKVTopologyError(f"Compiled payload is missing codebook marker {prefix + marker}")
+            other_markers = {prefix + ".mul1", prefix + ".mcg"}
+            expected_marker = {prefix + marker} if marker is not None else set()
+            if keys & (other_markers - expected_marker):
+                raise QKVTopologyError(f"Compiled payload has a conflicting codebook marker for {prefix}")
+        forbidden_prefixes = (forbidden,) if isinstance(forbidden, str) else forbidden
+        duplicate = sorted(key for key in keys if key.startswith(forbidden_prefixes))
+        if duplicate:
+            raise QKVTopologyError(f"Compiled payload contains duplicate QKV topology tensors: {duplicate[:3]}")

--- a/exllamav3/conversion/qkv_topology.py
+++ b/exllamav3/conversion/qkv_topology.py
@@ -13,6 +13,7 @@ SCHEMA = "exl3_qkv_topology/1"
 COMPONENTS = ("q_proj", "k_proj", "v_proj")
 VARIANTS = ("split", "fused_uniform")
 SCALE_VALUES = ("always", "never", "auto")
+CODEBOOK_VALUES = ("mcg", "mul1")
 
 
 class QKVTopologyError(ValueError):
@@ -37,8 +38,8 @@ def load_topology_plan(path: str) -> dict:
 
 
 def _validate_K(K, where: str) -> int:
-    if isinstance(K, bool) or not isinstance(K, int) or not 1 <= K <= 8:
-        raise QKVTopologyError(f"{where} K must be one integer value between 1 and 8")
+    if isinstance(K, bool) or not isinstance(K, int) or not 3 <= K <= 8:
+        raise QKVTopologyError(f"{where} K must be one integer value between 3 and 8")
     return K
 
 
@@ -78,7 +79,7 @@ def _plan_rows(plan: dict | None) -> dict[str, dict]:
                 )
         else:
             _validate_K(row.get("K"), layer)
-            if row.get("codebook") not in ("mul1", "mcg", "3inst"):
+            if row.get("codebook") not in CODEBOOK_VALUES:
                 raise QKVTopologyError(f"Fused layer {layer} requires one supported codebook")
             _validate_scale(row.get("scale"), layer)
         result[layer] = row
@@ -87,7 +88,7 @@ def _plan_rows(plan: dict | None) -> dict[str, dict]:
 
 def attention_descriptor(attn: Attention, strategy: dict, codebook: str, scale: str) -> dict | None:
     from ..modules import Linear
-    if attn.interleaved_gate or attn.use_k_as_v:
+    if attn.use_k_as_v:
         return None
     projections = []
     for name in COMPONENTS:
@@ -150,6 +151,11 @@ def resolve_topology(
             "output_splits": [p["out_features"] for p in projection_rows],
         }
         if variant == "split":
+            for projection in projection_rows:
+                _validate_K(projection["K"], layer)
+                if projection["codebook"] not in CODEBOOK_VALUES:
+                    raise QKVTopologyError(f"Projection codebook is invalid for {layer}")
+                _validate_scale(projection["scale"], layer)
             common["projections"] = [
                 {k: p[k] for k in ("name", "K", "codebook", "scale")}
                 for p in projection_rows
@@ -169,6 +175,27 @@ def resolve_topology(
             }
         rows.append(common)
     return {"schema": SCHEMA, "layers": rows}
+
+
+def resolve_target_topology(
+    target_model: Iterable,
+    strategy: dict,
+    codebook: str,
+    scale: str,
+    plan: dict | None,
+) -> tuple[dict | None, tuple[Attention, ...]]:
+    if plan is None:
+        return None, ()
+
+    from ..modules import Attention
+    attentions = tuple(module for module in target_model if isinstance(module, Attention))
+    descriptors = tuple(attention_descriptor(attn, strategy, codebook, scale) for attn in attentions)
+    unsupported = [attn.key for attn, descriptor in zip(attentions, descriptors) if descriptor is None]
+    if unsupported:
+        raise QKVTopologyError(
+            f"Topology metadata cannot describe full-attention layers with nonstandard QKV: {unsupported}"
+        )
+    return resolve_topology(descriptors, plan), attentions
 
 
 def concatenate_qkv_bf16(weights: Iterable[torch.Tensor]) -> torch.Tensor:
@@ -225,8 +252,8 @@ def install_fused_qkv(attn: Attention) -> Linear:
     components = [getattr(attn, name, None) for name in COMPONENTS]
     if not all(isinstance(linear, Linear) for linear in components):
         raise QKVTopologyError(f"Attention layer {attn.key} is not a split full-attention QKV block")
-    if attn.use_k_as_v or attn.interleaved_gate:
-        raise QKVTopologyError(f"Attention layer {attn.key} cannot preserve ordinary q,k,v output order")
+    if attn.use_k_as_v:
+        raise QKVTopologyError(f"Attention layer {attn.key} cannot preserve independent q,k,v outputs")
     if any(not isinstance(linear.inner, LinearFP16) for linear in components):
         raise QKVTopologyError(f"Attention layer {attn.key} must be loaded from source before QKV fusion")
     if len({linear.qmap for linear in components}) != 1 or components[0].qmap is None:
@@ -333,7 +360,7 @@ def topology_layer_map(topology: dict | None) -> dict[str, dict]:
             if not isinstance(declaration, dict) or set(declaration) != projection_keys:
                 raise QKVTopologyError(f"Projection fields are invalid for {layer}")
             _validate_K(declaration["K"], layer)
-            if declaration["codebook"] not in ("mul1", "mcg", "3inst"):
+            if declaration["codebook"] not in CODEBOOK_VALUES:
                 raise QKVTopologyError(f"Projection codebook is invalid for {layer}")
             _validate_scale(declaration["scale"], layer)
         result[layer] = row
@@ -362,8 +389,8 @@ def validate_payload_index(tensor_keys: Iterable[str], topology: dict) -> None:
         for prefix, declaration in logical:
             if prefix + ".trellis" not in keys:
                 raise QKVTopologyError(f"Compiled payload is missing {prefix}.trellis")
-            marker = {"mul1": ".mul1", "mcg": ".mcg", "3inst": None}.get(declaration.get("codebook"))
-            if declaration.get("codebook") not in ("mul1", "mcg", "3inst"):
+            marker = {"mul1": ".mul1", "mcg": ".mcg"}.get(declaration.get("codebook"))
+            if declaration.get("codebook") not in CODEBOOK_VALUES:
                 raise QKVTopologyError(f"Compiled payload declares an unknown codebook for {prefix}")
             if marker is not None and prefix + marker not in keys:
                 raise QKVTopologyError(f"Compiled payload is missing codebook marker {prefix + marker}")

--- a/exllamav3/conversion/quant_config.py
+++ b/exllamav3/conversion/quant_config.py
@@ -1,6 +1,7 @@
 from ..model import Config, Model
 import os, json
 import torch
+from .qkv_topology import COMPONENTS, SCHEMA, QKVTopologyError
 
 def update_config(
     config_dict: dict
@@ -53,6 +54,72 @@ def create_quantization_config_json(
         config_dict = json.load(f)
         assert "quantization_config" in config_dict, f"{model_dir} does not appear to be a quantized model"
         quantization_config = config_dict["quantization_config"]
+    topology = quantization_config.get("exl3_qkv_topology")
+    if topology is not None:
+        if topology.get("schema") != SCHEMA or not isinstance(topology.get("layers"), list):
+            raise QKVTopologyError(f"quantization_config.exl3_qkv_topology must use {SCHEMA!r}")
+
+        def storage_entry(logical_key):
+            stored_tensors = config.stc.list_tensors(logical_key, only_serializable = True)
+            trellis_key = logical_key + ".trellis"
+            if trellis_key not in stored_tensors:
+                raise QKVTopologyError(f"Missing indexed logical payload {trellis_key}")
+            shape = stored_tensors[trellis_key]["shape"]
+            entry = {
+                "stored_tensors": stored_tensors,
+                "quant_format": "exl3",
+                "bits_per_weight": shape[-1] // 16,
+            }
+            mul1 = config.stc.get_tensor(logical_key + ".mul1", optional = True, no_defer = True)
+            mcg = config.stc.get_tensor(logical_key + ".mcg", optional = True, no_defer = True)
+            if mul1 is not None and mcg is not None:
+                raise QKVTopologyError(f"Logical payload {logical_key} has multiple codebook markers")
+            entry["codebook"] = "mul1" if mul1 is not None else "mcg" if mcg is not None else "3inst"
+            if mul1 is not None:
+                entry["mul1_multiplier"] = mul1.view(torch.uint32).item()
+            if mcg is not None:
+                entry["mcg_multiplier"] = mcg.view(torch.uint32).item()
+            return entry
+
+        seen_layers = set()
+        for row in topology["layers"]:
+            layer = row.get("layer")
+            if not isinstance(layer, str) or layer in seen_layers:
+                raise QKVTopologyError("Topology layers must have unique nonempty layer names")
+            seen_layers.add(layer)
+            if row.get("components") != list(COMPONENTS):
+                raise QKVTopologyError(f"Topology component order changed for {layer}")
+            if row.get("variant") == "split":
+                declarations = row.get("projections")
+                if not isinstance(declarations, list) or [p.get("name") for p in declarations] != list(COMPONENTS):
+                    raise QKVTopologyError(f"Split topology for {layer} must declare q, k, v projections")
+                storage_dict.pop(layer + ".qkv_proj", None)
+            elif row.get("variant") == "fused_uniform":
+                declaration = row.get("projection")
+                if not isinstance(declaration, dict) or declaration.get("name") != "qkv_proj":
+                    raise QKVTopologyError(f"Fused topology for {layer} must declare qkv_proj")
+                declarations = [declaration]
+                for name in COMPONENTS:
+                    storage_dict.pop(layer + "." + name, None)
+            else:
+                raise QKVTopologyError(f"Unknown topology variant for {layer}: {row.get('variant')!r}")
+
+            for declaration in declarations:
+                logical_key = layer + "." + declaration["name"]
+                entry = storage_entry(logical_key)
+                if entry["bits_per_weight"] != declaration.get("K"):
+                    raise QKVTopologyError(
+                        f"Indexed K for {logical_key} is {entry['bits_per_weight']}, "
+                        f"metadata declares {declaration.get('K')}"
+                    )
+                if entry["codebook"] != declaration.get("codebook"):
+                    raise QKVTopologyError(
+                        f"Indexed codebook for {logical_key} is {entry['codebook']}, "
+                        f"metadata declares {declaration.get('codebook')}"
+                    )
+                entry["scale"] = declaration.get("scale")
+                storage_dict[logical_key] = entry
+
 
     # Update config with storage data
     quantization_config["tensor_storage"] = storage_dict

--- a/exllamav3/model/config.py
+++ b/exllamav3/model/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from ..util.rope import RopeSettings, RopeStyle
 from ..loader import SafetensorsCollection
 from ..util.file import read_dict, no_value, no_default
+from ..conversion.qkv_topology import topology_layer_map
 import uuid
 
 @dataclass
@@ -106,6 +107,9 @@ class Config(ABC):
         self.config_filename = os.path.join(directory, "config.json")
         with open(self.config_filename, encoding = "utf8") as f:
             self.config_dict = json.load(f)
+        quantization_config = self.config_dict.get("quantization_config", {})
+        self.qkv_topology_enabled = quantization_config.get("exl3_qkv_topology") is not None
+        self.qkv_topology = topology_layer_map(quantization_config.get("exl3_qkv_topology"))
 
         assert len(self.config_dict["architectures"]) == 1, \
             f"Multiple architectures defined in {self.config_filename}"

--- a/exllamav3/modules/attn.py
+++ b/exllamav3/modules/attn.py
@@ -611,10 +611,21 @@ class Attention(Module):
         if self.qkv_proj is not None:
             qkv = self.qkv_proj.forward(x, params)
             q_width = self.num_q_heads * self.head_dim
+            qg_width = q_width * (2 if self.interleaved_gate else 1)
             kv_width = self.num_kv_heads * self.head_dim
-            q, k, v = torch.split(qkv, (q_width, kv_width, kv_width), dim = -1)
-            g = self.g_proj.forward(x, params) if self.g_proj is not None else None
-            q = q.view(bsz, q_len, self.num_q_heads, self.head_dim)
+            q, k, v = torch.split(qkv, (qg_width, kv_width, kv_width), dim = -1)
+            if self.interleaved_gate:
+                if self.head_dim % 8 == 0 and q.dtype == torch.half:
+                    qg = q
+                    q = torch.empty((bsz, q_len, self.num_q_heads, self.head_dim), dtype = torch.half, device = qg.device)
+                    g = torch.empty((bsz, q_len, q_width), dtype = torch.half, device = qg.device)
+                    ext.deinterleave_qg(qg, q, g, self.head_dim)
+                else:
+                    q, g = torch.chunk(q.view(bsz, q_len, -1, self.head_dim * 2), 2, dim = -1)
+                    g = g.reshape(bsz, q_len, -1)
+            else:
+                g = self.g_proj.forward(x, params) if self.g_proj is not None else None
+                q = q.view(bsz, q_len, self.num_q_heads, self.head_dim)
             k = k.view(bsz, q_len, self.num_kv_heads, self.head_dim)
             v = v.view(bsz, q_len, self.num_kv_heads, self.head_dim)
             if self.v_norm is not None:

--- a/exllamav3/modules/attn.py
+++ b/exllamav3/modules/attn.py
@@ -216,9 +216,19 @@ class Attention(Module):
         if post_rope_norm:
             assert q_norm is None and k_norm is None, \
                 "Post-RoPE norm only supported without weights"
+        self.qkv_proj = None
 
         if self.num_kv_heads == 0:
             return
+        topology_map = getattr(config, "qkv_topology", {})
+        topology_enabled = getattr(config, "qkv_topology_enabled", bool(topology_map))
+        if topology_enabled and key not in topology_map:
+            quantized_qkv = any(
+                config.stc.has_tensor(key + "." + name + ".trellis")
+                for name in ("q_proj", "k_proj", "v_proj", "qkv_proj")
+            )
+            if quantized_qkv:
+                raise ValueError(f"{key}: missing full-attention declaration in exl3_qkv_topology/1 metadata")
 
         # Create q, k, v projections
         if key_fused_qkv:
@@ -294,6 +304,42 @@ class Attention(Module):
                 self.register_submodule(self.k_proj)
                 if self.v_proj:
                     self.register_submodule(self.v_proj)
+
+        topology_row = topology_map.get(key)
+        if topology_row is not None:
+            expected_splits = [
+                self.q_proj.out_features_unpadded,
+                self.k_proj.out_features_unpadded,
+                self.v_proj.out_features_unpadded,
+            ]
+            if topology_row["output_splits"] != expected_splits:
+                raise ValueError(
+                    f"{key}: QKV topology output_splits {topology_row['output_splits']} "
+                    f"do not match architecture widths {expected_splits}"
+                )
+            if topology_row["variant"] == "fused_uniform":
+                if interleaved_gate or use_k_as_v or not all(
+                    isinstance(linear, Linear) for linear in (self.q_proj, self.k_proj, self.v_proj)
+                ):
+                    raise ValueError(f"{key}: fused_uniform topology requires independent q, k, v Linear projections")
+                split_ids = {id(self.q_proj), id(self.k_proj), id(self.v_proj)}
+                first = min(i for i, module in enumerate(self.modules) if id(module) in split_ids)
+                self.modules = [module for module in self.modules if id(module) not in split_ids]
+                self.qkv_proj = Linear(
+                    config,
+                    key + ".qkv_proj",
+                    hidden_size,
+                    sum(expected_splits),
+                    qmap = self.q_proj.qmap,
+                    select_hq_bits = select_hq_bits,
+                    qgroup = key + ".qkv",
+                    trim_padded_out = True,
+                    qbits_key = qbits_key,
+                )
+                self.modules.insert(first, self.qkv_proj)
+                self.q_proj = None
+                self.k_proj = None
+                self.v_proj = None
 
         # Create o proj
         if key_o:
@@ -400,6 +446,10 @@ class Attention(Module):
 
     @override
     def optimizer_targets(self):
+        if self.qkv_proj is not None:
+            qkv = self.qkv_proj.optimizer_targets()
+            o = self.o_proj.optimizer_targets()
+            return [[qkv, [], o]]
         q = self.q_proj.optimizer_targets()
         k = self.k_proj.optimizer_targets()
         v = self.v_proj.optimizer_targets()
@@ -429,6 +479,7 @@ class Attention(Module):
 
         # Test if K and V proj can be fused
         if (
+            self.qkv_proj is None and
             not self.config.infer_params.no_reconstruct and
             not self.use_k_as_v and
             device != torch.device("cpu") and
@@ -452,6 +503,7 @@ class Attention(Module):
 
         # Test if Q and G proj can be fused
         if (
+            self.qkv_proj is None and
             not self.config.infer_params.no_reconstruct and
             self.g_proj is not None and
             device != torch.device("cpu") and
@@ -556,6 +608,19 @@ class Attention(Module):
 
     def project_qkv(self, x: torch.Tensor, params: dict) -> tuple:
         bsz, q_len, dim = x.shape
+        if self.qkv_proj is not None:
+            qkv = self.qkv_proj.forward(x, params)
+            q_width = self.num_q_heads * self.head_dim
+            kv_width = self.num_kv_heads * self.head_dim
+            q, k, v = torch.split(qkv, (q_width, kv_width, kv_width), dim = -1)
+            g = self.g_proj.forward(x, params) if self.g_proj is not None else None
+            q = q.view(bsz, q_len, self.num_q_heads, self.head_dim)
+            k = k.view(bsz, q_len, self.num_kv_heads, self.head_dim)
+            v = v.view(bsz, q_len, self.num_kv_heads, self.head_dim)
+            if self.v_norm is not None:
+                v = self.v_norm.forward(v, params, out_dtype = torch.half)
+            return q, k, v, g
+
 
         if self.multi_qg is None or bsz * q_len > 32:
             q = self.q_proj.forward(x, params)
@@ -918,6 +983,8 @@ class Attention(Module):
 
 
     def make_tp_allocation(self, options: dict) -> list[TPAllocation]:
+        if self.qkv_proj is not None:
+            raise ValueError(f"{self.key}: tensor parallelism is not supported for fused_uniform QKV topology")
         storage = 0
         storage += self.q_proj.storage_size()
         storage += self.k_proj.storage_size()
@@ -964,6 +1031,8 @@ class Attention(Module):
 
 
     def tp_export(self, plan, producer):
+        if self.qkv_proj is not None:
+            raise ValueError(f"{self.key}: tensor parallelism is not supported for fused_uniform QKV topology")
         assert self.device is not None, "Cannot export module for TP before loading."
 
         def _export(child):

--- a/exllamav3/modules/attn.py
+++ b/exllamav3/modules/attn.py
@@ -616,7 +616,7 @@ class Attention(Module):
             q, k, v = torch.split(qkv, (qg_width, kv_width, kv_width), dim = -1)
             if self.interleaved_gate:
                 if self.head_dim % 8 == 0 and q.dtype == torch.half:
-                    qg = q
+                    qg = q.contiguous()
                     q = torch.empty((bsz, q_len, self.num_q_heads, self.head_dim), dtype = torch.half, device = qg.device)
                     g = torch.empty((bsz, q_len, q_width), dtype = torch.half, device = qg.device)
                     ext.deinterleave_qg(qg, q, g, self.head_dim)

--- a/tests/test_qkv_topology.py
+++ b/tests/test_qkv_topology.py
@@ -6,9 +6,12 @@ from exllamav3.modules.attn import Attention
 from exllamav3.conversion.qkv_topology import (
     QKVTopologyError,
     SCHEMA,
+    attention_descriptor,
     concatenate_qkv_bf16,
+    resolve_target_topology,
     resolve_topology,
     split_qkv,
+    topology_layer_map,
     validate_payload_index,
 )
 
@@ -48,6 +51,110 @@ def mixed_plan():
             },
         ],
     }
+
+
+def qwen35_attention(layer):
+    return Attention(
+        NullConfig(),
+        layer,
+        0,
+        hidden_size = 5120,
+        head_dim = 256,
+        num_q_heads = 24,
+        num_kv_heads = 4,
+        rope_settings = None,
+        key_q = "q_proj",
+        key_k = "k_proj",
+        key_v = "v_proj",
+        key_o = "o_proj",
+        qmap = "block.attn",
+        interleaved_gate = True,
+    )
+
+
+def qkv_strategy(attn, K = 6):
+    return {
+        attn.q_proj.key: K,
+        attn.k_proj.key: K,
+        attn.v_proj.key: K,
+    }
+
+
+def fused_plan(layer, K = 6, codebook = "mul1"):
+    return {
+        "schema": SCHEMA,
+        "layers": [{
+            "layer": layer,
+            "variant": "fused_uniform",
+            "K": K,
+            "codebook": codebook,
+            "scale": "always",
+        }],
+    }
+
+
+def test_qwen35_interleaved_gate_uses_actual_doubled_q_projection_width():
+    attn = qwen35_attention("model.layers.3.self_attn")
+
+    descriptor_ = attention_descriptor(attn, qkv_strategy(attn), "mul1", "always")
+    topology = resolve_topology([descriptor_], fused_plan(attn.key))
+
+    assert {attn.q_proj.qmap, attn.k_proj.qmap, attn.v_proj.qmap} == {"block.attn.input"}
+    assert descriptor_["qmap"] == "block.attn.input"
+    assert [p["out_features"] for p in descriptor_["projections"]] == [12288, 1024, 1024]
+    assert topology["layers"][0]["output_splits"] == [12288, 1024, 1024]
+
+
+def test_topology_setup_is_opt_in_and_does_not_scan_existing_models_without_a_plan():
+    class ExistingModel:
+        def __iter__(self):
+            raise AssertionError("no-plan conversion must not inspect attention topology")
+
+    topology, attentions = resolve_target_topology(
+        ExistingModel(),
+        {},
+        "3inst",
+        "always",
+        None,
+    )
+
+    assert topology is None
+    assert attentions == ()
+
+
+@pytest.mark.parametrize(
+    ("K", "codebook", "message"),
+    [(2, "mul1", "between 3 and 8"), (6, "3inst", "codebook is invalid")],
+)
+def test_opted_in_split_metadata_rejects_incompatible_projection_domain(K, codebook, message):
+    attn = qwen35_attention("model.layers.3.self_attn")
+    plan = {"schema": SCHEMA, "layers": []}
+
+    with pytest.raises(QKVTopologyError, match = message):
+        resolve_target_topology(
+            [attn],
+            qkv_strategy(attn, K),
+            codebook,
+            "always",
+            plan,
+        )
+
+
+def test_target_topology_excludes_mtp_and_vision_side_models():
+    target = qwen35_attention("model.layers.3.self_attn")
+    mtp = qwen35_attention("mtp_model.layers.0.self_attn")
+    vision = qwen35_attention("visual.blocks.0.self_attn")
+
+    topology, attentions = resolve_target_topology(
+        [target],
+        qkv_strategy(target) | qkv_strategy(mtp) | qkv_strategy(vision),
+        "mul1",
+        "always",
+        fused_plan(target.key),
+    )
+
+    assert attentions == (target,)
+    assert [row["layer"] for row in topology["layers"]] == [target.key]
 
 
 def test_mixed_layer_map_is_sorted_complete_and_defaults_to_split():
@@ -153,6 +260,36 @@ def test_fused_uniform_requires_one_common_K_codebook_and_scale():
             [descriptor("model.layers.0.self_attn"), descriptor("model.layers.1.self_attn")],
             mismatched_codebook,
         )
+
+
+@pytest.mark.parametrize("K", [1, 2, 9, True])
+def test_plan_rejects_K_outside_compiled_qkv_domain(K):
+    plan = fused_plan("model.layers.0.self_attn", K = K)
+
+    with pytest.raises(QKVTopologyError, match = "between 3 and 8"):
+        resolve_topology([descriptor("model.layers.0.self_attn")], plan)
+
+
+@pytest.mark.parametrize("codebook", ["3inst", "unknown"])
+def test_plan_and_metadata_reject_codebooks_outside_compiled_qkv_domain(codebook):
+    layer = "model.layers.0.self_attn"
+    with pytest.raises(QKVTopologyError, match = "supported codebook"):
+        resolve_topology([descriptor(layer)], fused_plan(layer, codebook = codebook))
+
+    topology = resolve_topology([descriptor(layer)], fused_plan(layer))
+    topology["layers"][0]["projection"]["codebook"] = codebook
+    with pytest.raises(QKVTopologyError, match = "codebook is invalid"):
+        topology_layer_map(topology)
+
+
+@pytest.mark.parametrize("K", [1, 2, 9, True])
+def test_metadata_rejects_K_outside_compiled_qkv_domain(K):
+    layer = "model.layers.0.self_attn"
+    topology = resolve_topology([descriptor(layer)], fused_plan(layer))
+    topology["layers"][0]["projection"]["K"] = K
+
+    with pytest.raises(QKVTopologyError, match = "between 3 and 8"):
+        topology_layer_map(topology)
 
 
 def test_index_reconstruction_rejects_missing_or_duplicate_payloads():

--- a/tests/test_qkv_topology.py
+++ b/tests/test_qkv_topology.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+import exllamav3.modules.attn as attn_module
 
 from exllamav3.model.config import NullConfig
 from exllamav3.modules.attn import Attention
@@ -129,6 +130,38 @@ def test_fused_qkv_forward_deinterleaves_qwen_query_gate_payload():
     )
     assert torch.equal(q, expected_q)
     assert torch.equal(g, expected_g.reshape(1, 2, 6144))
+
+
+def test_fused_qkv_fast_deinterleave_receives_contiguous_qg(monkeypatch):
+    attn = qwen35_attention("model.layers.3.self_attn")
+    x = torch.zeros((1, 2, 5120), dtype = torch.float16)
+    fused = torch.arange(2 * 14336, dtype = torch.float16).view(1, 2, 14336)
+
+    class FusedProjection:
+        @staticmethod
+        def forward(_x, _params):
+            return fused
+
+    def deinterleave(qg, q, g, head_dim):
+        assert qg.is_contiguous()
+        expected_q, expected_g = torch.chunk(
+            qg.view(1, 2, 24, head_dim * 2), 2, dim = -1
+        )
+        q.copy_(expected_q)
+        g.copy_(expected_g.reshape(1, 2, -1))
+
+    monkeypatch.setattr(attn_module.ext, "deinterleave_qg", deinterleave)
+    attn.qkv_proj = FusedProjection()
+    attn.g_proj = None
+    attn.v_norm = None
+
+    q, k, v, g = attn.project_qkv(x, {})
+
+    assert q.shape == (1, 2, 24, 256)
+    assert g.shape == (1, 2, 6144)
+    assert k.shape == v.shape == (1, 2, 4, 256)
+
+
 
 
 

--- a/tests/test_qkv_topology.py
+++ b/tests/test_qkv_topology.py
@@ -105,6 +105,34 @@ def test_qwen35_interleaved_gate_uses_actual_doubled_q_projection_width():
     assert topology["layers"][0]["output_splits"] == [12288, 1024, 1024]
 
 
+def test_fused_qkv_forward_deinterleaves_qwen_query_gate_payload():
+    attn = qwen35_attention("model.layers.3.self_attn")
+    x = torch.zeros((1, 2, 5120), dtype = torch.float32)
+    fused = torch.arange(2 * 14336, dtype = torch.float32).view(1, 2, 14336)
+
+    class FusedProjection:
+        @staticmethod
+        def forward(_x, _params):
+            return fused
+
+    attn.qkv_proj = FusedProjection()
+    attn.g_proj = None
+    attn.v_norm = None
+
+    q, k, v, g = attn.project_qkv(x, {})
+
+    assert q.shape == (1, 2, 24, 256)
+    assert g.shape == (1, 2, 6144)
+    assert k.shape == v.shape == (1, 2, 4, 256)
+    expected_q, expected_g = torch.chunk(
+        fused[..., :12288].view(1, 2, 24, 512), 2, dim = -1
+    )
+    assert torch.equal(q, expected_q)
+    assert torch.equal(g, expected_g.reshape(1, 2, 6144))
+
+
+
+
 def test_topology_setup_is_opt_in_and_does_not_scan_existing_models_without_a_plan():
     class ExistingModel:
         def __iter__(self):

--- a/tests/test_qkv_topology.py
+++ b/tests/test_qkv_topology.py
@@ -1,0 +1,196 @@
+import pytest
+import torch
+
+from exllamav3.model.config import NullConfig
+from exllamav3.modules.attn import Attention
+from exllamav3.conversion.qkv_topology import (
+    QKVTopologyError,
+    SCHEMA,
+    concatenate_qkv_bf16,
+    resolve_topology,
+    split_qkv,
+    validate_payload_index,
+)
+
+
+def descriptor(layer, q_K = 6, k_K = 5, v_K = 4):
+    return {
+        "layer": layer,
+        "qmap": layer + ".input",
+        "projections": [
+            {
+                "name": name,
+                "K": K,
+                "codebook": "mul1",
+                "scale": "always",
+                "out_features": width,
+            }
+            for name, K, width in zip(
+                ("q_proj", "k_proj", "v_proj"),
+                (q_K, k_K, v_K),
+                (12288, 1024, 1024),
+            )
+        ],
+    }
+
+
+def mixed_plan():
+    return {
+        "schema": SCHEMA,
+        "layers": [
+            {"layer": "model.layers.0.self_attn", "variant": "split"},
+            {
+                "layer": "model.layers.1.self_attn",
+                "variant": "fused_uniform",
+                "K": 6,
+                "codebook": "mul1",
+                "scale": "always",
+            },
+        ],
+    }
+
+
+def test_mixed_layer_map_is_sorted_complete_and_defaults_to_split():
+    topology = resolve_topology(
+        [
+            descriptor("model.layers.2.self_attn"),
+            descriptor("model.layers.0.self_attn"),
+            descriptor("model.layers.1.self_attn"),
+        ],
+        mixed_plan(),
+    )
+
+    assert topology["schema"] == SCHEMA
+    assert [row["layer"] for row in topology["layers"]] == [
+        "model.layers.0.self_attn",
+        "model.layers.1.self_attn",
+        "model.layers.2.self_attn",
+    ]
+    assert [row["variant"] for row in topology["layers"]] == [
+        "split",
+        "fused_uniform",
+        "split",
+    ]
+    assert topology["layers"][0]["projections"] == [
+        {"name": "q_proj", "K": 6, "codebook": "mul1", "scale": "always"},
+        {"name": "k_proj", "K": 5, "codebook": "mul1", "scale": "always"},
+        {"name": "v_proj", "K": 4, "codebook": "mul1", "scale": "always"},
+    ]
+    assert topology["layers"][1]["projection"] == {
+        "name": "qkv_proj",
+        "K": 6,
+        "codebook": "mul1",
+        "scale": "always",
+    }
+    assert topology["layers"][1]["output_splits"] == [12288, 1024, 1024]
+
+def test_attention_construction_rebuilds_mixed_logical_payloads_from_metadata():
+    topology = resolve_topology(
+        [descriptor("model.layers.0.self_attn"), descriptor("model.layers.1.self_attn")],
+        mixed_plan(),
+    )
+    config = NullConfig()
+    config.qkv_topology = {row["layer"]: row for row in topology["layers"]}
+
+    def make_attention(layer, layer_idx):
+        return Attention(
+            config,
+            layer,
+            layer_idx,
+            hidden_size = 5120,
+            head_dim = 128,
+            num_q_heads = 96,
+            num_kv_heads = 8,
+            rope_settings = None,
+            key_q = "q_proj",
+            key_k = "k_proj",
+            key_v = "v_proj",
+            key_o = "o_proj",
+            qmap = layer,
+        )
+
+    split = make_attention("model.layers.0.self_attn", 0)
+    fused = make_attention("model.layers.1.self_attn", 1)
+
+    assert split.qkv_proj is None
+    assert [split.q_proj.key, split.k_proj.key, split.v_proj.key] == [
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.0.self_attn.k_proj",
+        "model.layers.0.self_attn.v_proj",
+    ]
+    assert fused.q_proj is fused.k_proj is fused.v_proj is None
+    assert fused.qkv_proj.key == "model.layers.1.self_attn.qkv_proj"
+    assert fused.qkv_proj.out_features_unpadded == 12288 + 1024 + 1024
+
+    with pytest.raises(ValueError, match = "tensor parallelism is not supported"):
+        fused.make_tp_allocation({})
+
+
+def test_bf16_concatenation_and_split_reconstruct_exact_bits():
+    q = torch.arange(2 * 12, dtype = torch.float32).reshape(2, 12).to(torch.bfloat16)
+    k = (100 + torch.arange(2 * 3, dtype = torch.float32)).reshape(2, 3).to(torch.bfloat16)
+    v = (200 + torch.arange(2 * 3, dtype = torch.float32)).reshape(2, 3).to(torch.bfloat16)
+
+    fused = concatenate_qkv_bf16((q, k, v))
+    reconstructed = split_qkv(fused, (12, 3, 3))
+
+    assert fused.dtype == torch.bfloat16
+    assert fused.is_contiguous()
+    for actual, expected in zip(reconstructed, (q, k, v)):
+        assert torch.equal(actual.view(torch.uint16), expected.view(torch.uint16))
+
+
+def test_fused_uniform_requires_one_common_K_codebook_and_scale():
+    invalid_K = mixed_plan()
+    invalid_K["layers"][1]["K"] = {"q_proj": 6, "k_proj": 5, "v_proj": 5}
+    with pytest.raises(QKVTopologyError, match = "one integer value"):
+        resolve_topology([descriptor("model.layers.0.self_attn"), descriptor("model.layers.1.self_attn")], invalid_K)
+
+    mismatched_codebook = mixed_plan()
+    mismatched_codebook["layers"][1]["codebook"] = "mcg"
+    with pytest.raises(QKVTopologyError, match = "converter's one codebook"):
+        resolve_topology(
+            [descriptor("model.layers.0.self_attn"), descriptor("model.layers.1.self_attn")],
+            mismatched_codebook,
+        )
+
+
+def test_index_reconstruction_rejects_missing_or_duplicate_payloads():
+    topology = resolve_topology(
+        [descriptor("model.layers.0.self_attn"), descriptor("model.layers.1.self_attn")],
+        mixed_plan(),
+    )
+    keys = {
+        "model.layers.0.self_attn.q_proj.trellis",
+        "model.layers.0.self_attn.q_proj.mul1",
+        "model.layers.0.self_attn.k_proj.trellis",
+        "model.layers.0.self_attn.k_proj.mul1",
+        "model.layers.0.self_attn.v_proj.trellis",
+        "model.layers.0.self_attn.v_proj.mul1",
+        "model.layers.1.self_attn.qkv_proj.trellis",
+        "model.layers.1.self_attn.qkv_proj.mul1",
+    }
+    validate_payload_index(keys, topology)
+
+    with pytest.raises(QKVTopologyError, match = "duplicate"):
+        validate_payload_index(keys | {"model.layers.1.self_attn.q_proj.trellis"}, topology)
+    with pytest.raises(QKVTopologyError, match = "missing"):
+        validate_payload_index(keys - {"model.layers.0.self_attn.k_proj.trellis"}, topology)
+
+
+def test_plan_rejects_unknown_layers_and_duplicate_declarations():
+    plan = mixed_plan()
+    plan["layers"].append({"layer": "model.layers.99.self_attn", "variant": "split"})
+    with pytest.raises(QKVTopologyError, match = "unknown or unsupported"):
+        resolve_topology(
+            [descriptor("model.layers.0.self_attn"), descriptor("model.layers.1.self_attn")],
+            plan,
+        )
+
+    plan = mixed_plan()
+    plan["layers"].append({"layer": "model.layers.1.self_attn", "variant": "split"})
+    with pytest.raises(QKVTopologyError, match = "Duplicate"):
+        resolve_topology(
+            [descriptor("model.layers.0.self_attn"), descriptor("model.layers.1.self_attn")],
+            plan,
+        )


### PR DESCRIPTION
## Purpose

Proof of concept for #297: allow one checkpoint to choose QKV topology **per full-attention block**.

- `split`: existing q/k/v EXL3 objects, independent K/codebook/scale choices, preserving mixed precision and the serving consumer's three-launch route.
- `fused_uniform`: concatenate the BF16 q/k/v source weights in frozen q,k,v order, quantize that matrix jointly at one common K/codebook/scale, and serialize one qkv payload for a one-launch consumer.

This is the practical hybrid requested by the downstream allocator: retain split widths where q/v sensitivity matters; use uniform fusion only where a new fused direct marginal shows no decision-relevant fidelity loss. A heterogeneous-width one-launch tuple remains future kernel/format work.

## Implementation

Adds versioned `exl3_qkv_topology/1` metadata and a deterministic converter plan:

- complete split-default rows with per-layer fused overrides;
- direct BF16 q/k/v loading and exact q,k,v-order concatenation;
- one joint quantization call retaining the input calibration qmap;
- mixed split/fused Attention construction and runtime routing;
- config, safetensors/index and tensor-storage logical reconstruction metadata;
- fail-closed common-K/codebook/scale, unknown/duplicate declaration, missing/duplicate payload and component checks;
- fused TP explicitly rejected by the PoC rather than silently mis-sharded.

No load-time re-encoding and no duplicate split+fused payload for one block. Split remains the default.

## Verification

The companion source verifier pins the patch/base/patched identities and mixed-schema invariants. Focused tests were executed in the immutable CUDA 13.2/r34 environment after compiling the pinned source extension:

```text
6 passed, 1 warning in 1.89s
```

Coverage includes mixed maps/runtime construction, BF16 concatenation/split bit identity, common-K/codebook/scale enforcement, unknown/duplicate declarations, and missing/duplicate payloads.

A consumer PoC is open at local-inference-lab/vllm#454. The ~88 us split versus ~36 us fused figure remains **modeled**; this PR enables the real block/end-logit/graph/TG experiment and makes no performance claim.

AI assistance was used to implement and review the PoC; the patch identity, extension build and focused tests were independently executed as described.