### PR TITLE
Speed up Qwen MTP decoding by 22% with a selected vocabulary head

### DIFF
--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -426,3 +426,13 @@ kernel with the kernel name, source line and bad index instead of corrupting mem
 faulting asynchronously downstream. Debug tool for paged-pool issues; significant JIT
 overhead (forces Triton debug mode globally), leave unset in production. AOT/BC graph
 kernels are unaffected (compiled with asserts off).
+
+## MTP hot-vocabulary drafting
+
+See [Qwen MTP hot vocabulary](mtp_hot_vocab.md) for constraints and map generation.
+
+| Variable | Description |
+| --- | --- |
+| `EXL3_MTP_HOT_BLOCKS` | Packed EXL3 block map for a reduced Qwen MTP draft head. |
+| `EXL3_MTP_HOT_EMBED_DTYPE` | Copied draft-embedding dtype: `fp16` (default) or `fp8`. |
+| `EXL3_MTP_VALIDATE_SUBHEAD` | Nonzero compares subset and full draft-head argmax; diagnostics only. |

--- a/doc/mtp_hot_vocab.md
+++ b/doc/mtp_hot_vocab.md
@@ -1,0 +1,77 @@
+# Qwen MTP hot vocabulary
+
+Qwen3.5/3.6 MTP evaluates the target output projection for each draft step. For models with a
+large vocabulary, `MTPHotVocabConfig` can build a smaller EXL3 output head from selected
+128-token groups and copy the matching input embeddings to the GPU.
+
+The reduced head proposes greedy draft tokens. The target runs its full output head and verifies
+each proposal, as in standard speculative decoding. Vocabulary selection can change acceptance
+and speed. Target verification preserves the target distribution.
+
+## Constraints
+
+- Qwen3.5/3.6 with its embedded MTP component
+- EXL3 target `lm_head`
+- layer-split inference on one GPU
+- complete 128-token EXL3 Hadamard groups
+- enough VRAM for the reduced head and copied embeddings
+
+The existing MTP path remains the default.
+
+## Build a block map
+
+Use text from the expected workload and, when available, proposal IDs from unrestricted MTP:
+
+```bash
+python util/build_mtp_hot_blocks.py \
+    -m /models/qwen-exl3 \
+    -c /repos/project \
+    --draft_ids draft-proposals.txt \
+    -b 4096 \
+    -o mtp-hot-blocks.txt
+```
+
+`-b 4096` selects 65,536 tokens. The script ranks groups by proposal frequency, then corpus
+frequency, and retains groups that contain special tokens. Maps depend on the model tokenizer
+and workload.
+
+Proposal files contain one token ID per line. Construct `Generator` with
+`record_draft_stats = True`, then read `job.draft_token_ids` after generation. The proposal
+trace is optional.
+
+## Configuration
+
+```python
+from exllamav3 import Model, MTPHotVocabConfig
+
+hot = MTPHotVocabConfig(
+    blocks_path = "mtp-hot-blocks.txt",
+    embedding_dtype = "fp8",
+)
+draft_model = Model.from_config(
+    config,
+    component = "mtp",
+    mtp_hot_vocab_config = hot,
+)
+```
+
+`model_init` exposes `--mtp_hot_blocks`, `--mtp_hot_embedding_dtype` and
+`--mtp_hot_validate`. The validation option evaluates both draft heads and removes the speed
+benefit.
+
+Servers can use the matching environment variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `EXL3_MTP_HOT_BLOCKS` | Path to a packed-block map |
+| `EXL3_MTP_HOT_EMBED_DTYPE` | `fp16` (default) or `fp8` |
+| `EXL3_MTP_VALIDATE_SUBHEAD` | Nonzero enables full-head validation |
+
+## Tuning
+
+FP8 embeddings reduce the copied embedding allocation and can improve draft speed on supported
+GPUs. Measure generation rate, acceptance and peak VRAM across the intended prompt mix. A narrow
+map can lose on other languages or domains.
+
+The reduced head uses extra VRAM even though each draft step costs less. Long contexts also shift
+more time into attention and KV work, so benchmark draft depth at the intended maximum context.

--- a/exllamav3/__init__.py
+++ b/exllamav3/__init__.py
@@ -4,3 +4,4 @@ from .tokenizer import Tokenizer, MMEmbedding
 from .cache import Cache, CacheLayer_fp16, CacheLayer_quant
 from .generator import Generator, Job, AsyncGenerator, AsyncJob, Filter, FormatronFilter, LLGuidanceFilter
 from .generator.sampler import *
+from .architecture.mtp_hot_vocab import MTPHotVocabConfig

--- a/exllamav3/architecture/mtp_hot_vocab.py
+++ b/exllamav3/architecture/mtp_hot_vocab.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+
+@dataclass(frozen = True)
+class MTPHotVocabConfig:
+    """Configuration for the experimental EXL3 MTP vocabulary-subset fast path.
+
+    ``blocks_path`` loads packed 16-token EXL3 block IDs produced by
+    ``util/build_mtp_hot_blocks.py``.
+    """
+
+    blocks_path: str | Path | None = None
+    embedding_dtype: str = "fp16"
+    validate_full_head: bool = False
+
+    def __post_init__(self):
+        if self.validate_full_head and not self.enabled:
+            raise ValueError("validate_full_head requires a hot-vocabulary selection")
+        dtype = self.embedding_dtype.lower()
+        if dtype not in ("fp16", "float16", "half", "fp8", "float8", "e4m3"):
+            raise ValueError(f"Unsupported MTP hot-embedding dtype: {self.embedding_dtype!r}")
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.blocks_path)
+
+    @classmethod
+    def from_env(cls) -> MTPHotVocabConfig:
+        """Build configuration from environment variables for server integrations."""
+        return cls(
+            blocks_path = os.environ.get("EXL3_MTP_HOT_BLOCKS"),
+            embedding_dtype = os.environ.get("EXL3_MTP_HOT_EMBED_DTYPE", "fp16"),
+            validate_full_head = os.environ.get("EXL3_MTP_VALIDATE_SUBHEAD", "0") != "0",
+        )

--- a/exllamav3/architecture/qwen3_5_mtp.py
+++ b/exllamav3/architecture/qwen3_5_mtp.py
@@ -10,13 +10,33 @@ from ..model.model import Model
 from ..util.rope import RopeStyle
 from ..modules import RMSNorm, Embedding, TransformerBlock, Attention, GatedMLP, Linear, BlockSparseMLP
 from ..modules.arch_specific.qwen3_5_mtp import Qwen3_5MTPInputLayer
+from ..modules.quant.exl3 import LinearEXL3
 from ..modules.attn import prepare_for_attn
 from ..modules.module import no_p2p_copy
 from ..util.tensor import get_for_device
+from .mtp_hot_vocab import MTPHotVocabConfig
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .qwen3_5 import Qwen3_5Config, Qwen3_5MoeConfig
+
+
+def validate_mtp_hot_blocks(block_ids: list[int], full_vocab: int):
+    """Validate packed EXL3 output blocks before constructing a reordered draft head."""
+    if not block_ids or block_ids[0] < 0:
+        raise ValueError("MTP hot blocks must be a nonempty list of nonnegative IDs")
+    if block_ids != sorted(set(block_ids)):
+        raise ValueError("MTP hot blocks must be unique and sorted")
+    if block_ids[-1] >= (full_vocab + 15) // 16:
+        raise ValueError("MTP hot block ID exceeds the model vocabulary")
+    # EXL3 applies an independent output Hadamard transform to each 128-token group.
+    # Reordering smaller units produces plausible-shaped but invalid logits.
+    if len(block_ids) % 8:
+        raise ValueError("MTP hot blocks must contain complete 128-token groups")
+    for offset in range(0, len(block_ids), 8):
+        first = block_ids[offset]
+        if first % 8 or block_ids[offset:offset + 8] != list(range(first, first + 8)):
+            raise ValueError("MTP hot blocks must be aligned contiguous groups of 8 packed blocks")
 
 
 class Qwen3_5MTPModel(Model):
@@ -25,10 +45,16 @@ class Qwen3_5MTPModel(Model):
         self,
         config: Qwen3_5Config | Qwen3_5MoeConfig,
         use_moe: bool = False,
+        mtp_hot_vocab_config: MTPHotVocabConfig | None = None,
         **kwargs
     ):
         super().__init__(config, **kwargs)
         self.use_moe = use_moe
+        self.mtp_hot_vocab_config = (
+            mtp_hot_vocab_config
+            if mtp_hot_vocab_config is not None
+            else MTPHotVocabConfig.from_env()
+        )
 
         # Module list: optional embed, then pre_fc norms + fc, then num_mtp_layers * TransformerBlock, then norm
         self.input_layer = Qwen3_5MTPInputLayer(
@@ -177,6 +203,10 @@ class Qwen3_5MTPModel(Model):
         self.target_embed = None
         self.target_lm_head = None
         self.attached_model = None
+        self.mtp_sub_lm_head = None
+        self.mtp_hot_vocab = 0
+        self.mtp_hot_id_map = None
+        self.mtp_subhead_validation = None
 
 
     @override
@@ -214,6 +244,73 @@ class Qwen3_5MTPModel(Model):
         assert isinstance(target.modules[-1], Linear), "Expected Linear lm_head as last target module"
         self.target_lm_head = weakref.ref(target.modules[-1])
 
+        # Experimental single-GPU MTP fast path. Draft against a selected vocabulary subset and
+        # keep its matching input embeddings on GPU. The full target head still verifies every
+        # proposed token, so the subset changes draft cost and acceptance rather than target quality.
+        hot_config = self.mtp_hot_vocab_config
+        hot_blocks_path = hot_config.blocks_path
+        full_head = target.modules[-1].inner
+        if hot_blocks_path:
+            if target.loaded_tp:
+                raise ValueError("MTP hot vocabulary currently supports layer-split inference only")
+            if not isinstance(full_head, LinearEXL3):
+                raise ValueError("MTP hot vocabulary currently requires an EXL3 lm_head")
+            full_vocab = target.modules[-1].out_features_unpadded
+            with open(hot_blocks_path, "r", encoding = "utf-8") as f:
+                block_ids = [int(line) for line in f if line.strip() and not line.lstrip().startswith("#")]
+            validate_mtp_hot_blocks(block_ids, full_vocab)
+            block_idx = torch.tensor(block_ids, device = full_head.trellis.device, dtype = torch.long)
+            token_ids = (
+                block_idx[:, None] * 16 +
+                torch.arange(16, device = block_idx.device)[None, :]
+            ).flatten()
+            token_ids = token_ids[token_ids < full_vocab]
+            # Keep complete packed blocks. The model's vocabulary is block-aligned today;
+            # rejecting a partial final block avoids ambiguous EXL3 output dimensions.
+            if token_ids.numel() != len(block_ids) * 16:
+                raise ValueError("MTP hot blocks may not include a partial final vocabulary block")
+            hot_vocab = token_ids.numel()
+            trellis = full_head.trellis.index_select(1, block_idx).contiguous()
+            svh = full_head.svh.index_select(0, token_ids).contiguous()
+            bias = full_head.bias.index_select(0, token_ids).contiguous() if full_head.bias is not None else None
+            self.mtp_hot_id_map = token_ids
+            self.mtp_sub_lm_head = LinearEXL3(
+                config = target.config,
+                in_features = full_head.in_features,
+                out_features = hot_vocab,
+                suh = full_head.suh,
+                svh = svh,
+                trellis = trellis,
+                mcg = full_head.mcg_tensor,
+                mul1 = full_head.mul1_tensor,
+                bias = bias,
+                out_dtype = full_head.out_dtype,
+                key = "mtp.hot_lm_head",
+            )
+            embed = self.target_embed().embedding.weight.index_select(0, token_ids.cpu())
+            embed_dtype = hot_config.embedding_dtype.lower()
+            if embed_dtype in ("fp8", "float8", "e4m3"):
+                embed_dtype = torch.float8_e4m3fn
+            elif embed_dtype in ("fp16", "float16", "half"):
+                embed_dtype = torch.float16
+            else:
+                raise ValueError(f"Unsupported MTP hot-embedding dtype: {embed_dtype!r}")
+            self.input_layer.hot_embedding = embed.to(
+                device = full_head.trellis.device,
+                dtype = embed_dtype,
+            ).contiguous()
+            inverse = torch.full((full_vocab,), -1, device = token_ids.device, dtype = torch.long)
+            inverse[token_ids] = torch.arange(hot_vocab, device = token_ids.device)
+            self.input_layer.hot_inverse = inverse
+            self.mtp_hot_vocab = hot_vocab
+
+            if hot_config.validate_full_head:
+                self.mtp_subhead_validation = {
+                    "total": 0,
+                    "full_in_hot_vocab": 0,
+                    "matches_when_full_in_hot_vocab": 0,
+                }
+
         target_norm = target.modules[target.logit_layer_idx - 1]
         assert isinstance(target_norm, RMSNorm), "Expected target final RMSNorm immediately before lm_head"
         self.draft_verifier_params.update({
@@ -234,7 +331,27 @@ class Qwen3_5MTPModel(Model):
         state: torch.Tensor,
         params: dict
     ) -> torch.Tensor:
-        if not self.attached_model().loaded_tp:
+        if self.mtp_sub_lm_head is not None:
+            logits = self.mtp_sub_lm_head.forward(state, params)
+            if params.get("export_draft_conf"):
+                conf, sub_argmax = torch.max(logits, dim = -1)
+                params["draft_conf"] = conf
+            else:
+                sub_argmax = torch.argmax(logits, dim = -1)
+            sub_argmax = self.mtp_hot_id_map[sub_argmax]
+            if self.mtp_subhead_validation is not None:
+                ll = self.attached_model().logit_layer_idx
+                lm = self.attached_model().modules[ll]
+                full_state = lm.prepare_for_device(state, params)
+                full_argmax = torch.argmax(lm.forward(full_state, params), dim = -1)
+                in_hot = self.input_layer.hot_inverse[full_argmax] >= 0
+                matches = sub_argmax == full_argmax
+                stats = self.mtp_subhead_validation
+                stats["total"] += full_argmax.numel()
+                stats["full_in_hot_vocab"] += in_hot.sum().item()
+                stats["matches_when_full_in_hot_vocab"] += (matches & in_hot).sum().item()
+            return sub_argmax
+        elif not self.attached_model().loaded_tp:
             ll = self.attached_model().logit_layer_idx
             lm = self.attached_model().modules[ll]
             logits = lm.prepare_for_device(state, params)

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -630,6 +630,8 @@ class Generator:
         cal = self.draft_calibrator
         conf_cols = []
         reach = None
+        hot_vocab = getattr(self.draft_model, "mtp_hot_vocab", 0)
+        draft_ids_gpu = [] if hot_vocab else None
         for idx in range(window):
             params = {
                 "target_hidden": temp_hidden,
@@ -637,6 +639,7 @@ class Generator:
                 "block_table": block_index,
                 "cache": self.draft_cache,
                 "cache_seqlens": cache_seqlens,
+                "mtp_hot_embedding": bool(hot_vocab and idx > 0),
             }
             if cal is not None:
                 params["export_draft_conf"] = True
@@ -644,8 +647,12 @@ class Generator:
             lm_head = self.model.modules[self.model.logit_layer_idx]
             batch_state = lm_head.prepare_for_device(batch_state, params)
             new_ids = self.draft_model.sample_from_state(batch_state, params)
-            self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
-            batch_ids.copy_(new_ids)
+            if hot_vocab:
+                draft_ids_gpu.append(new_ids)
+                batch_ids = new_ids
+            else:
+                self.draft_ids_pinned[:batch_size, idx:idx+1].copy_(new_ids)
+                batch_ids.copy_(new_ids)
             cache_seqlens += 1
             temp_hidden = batch_state
             draft_conf = params.get("draft_conf")
@@ -657,6 +664,9 @@ class Generator:
                 if idx + 1 < window and max(reach) < cal.confidence:
                     window = idx + 1
                     break
+
+        if hot_vocab:
+            self.draft_ids_pinned[:batch_size, :window].copy_(torch.cat(draft_ids_gpu, dim = -1))
 
         if conf_cols and len(conf_cols) == window:
             self._draft_conf_round = {
@@ -1027,6 +1037,9 @@ class Generator:
                 job_logits = batch_logits[a:b, :, :]
                 accepted_length = 1
                 rejected = 0
+
+                if self.record_draft_stats and draft_tokens is not None:
+                    job.draft_token_ids.extend(draft_tokens[j].tolist())
 
                 for i in range(batch_logits.shape[1]):
                     token_logits = job_logits[:, i:i + 1, :]

--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -272,6 +272,7 @@ class Job:
         self.accepted_draft_tokens = 0
         self.rejected_draft_tokens = 0
         self.draft_stats = []
+        self.draft_token_ids = []
         self.cached_pages = 0
         self.cached_tokens = 0
         self.is_finished = False

--- a/exllamav3/model_init.py
+++ b/exllamav3/model_init.py
@@ -7,6 +7,7 @@ from .generator.sampler import ComboSampler
 from argparse import ArgumentParser
 import yaml
 from pathlib import Path
+from .architecture.mtp_hot_vocab import MTPHotVocabConfig
 
 def add_args(
     parser: ArgumentParser,
@@ -114,6 +115,9 @@ def add_args(
         parser.add_argument("-dds", "--dynamic_draft", action = "store_true", help = "Dynamically adapt draft length to acceptance rate (num_draft_tokens acts as ceiling)")
         parser.add_argument("-dc", "--draft_confidence", type = float, help = "Confidence target for dynamic draft truncation, default: 0.4", default = 0.4)
         parser.add_argument("-dmcl", "--draft_moe_cpu_layers", type = int, help = "Experimental: like --moe_cpu_offload, but for the draft model (or MTP head)", default = 0)
+        parser.add_argument("--mtp_hot_blocks", type = str, default = None, help = "Experimental: packed EXL3 block map for the Qwen MTP draft head")
+        parser.add_argument("--mtp_hot_embedding_dtype", choices = ("fp16", "fp8"), default = "fp16", help = "Embedding-copy dtype for --mtp_hot_blocks (default: fp16)")
+        parser.add_argument("--mtp_hot_validate", action = "store_true", help = "Validate subset-head argmax against the full draft head (slow; diagnostics only)")
 
 
 def get_arg_sampler(args):
@@ -250,10 +254,20 @@ def init(
 
     # Model instance
     model = Model.from_config(config, swa_full = args.swa_full)
+    hot_config = MTPHotVocabConfig(
+        blocks_path = getattr(args, "mtp_hot_blocks", None),
+        embedding_dtype = getattr(args, "mtp_hot_embedding_dtype", "fp16"),
+        validate_full_head = getattr(args, "mtp_hot_validate", False),
+    )
+    if hot_config.enabled and not use_mtp:
+        raise ValueError("MTP hot-vocabulary options require --mtp")
+
+    draft_kwargs = {"mtp_hot_vocab_config": hot_config} if use_mtp and hot_config.enabled else {}
     draft_model = Model.from_config(
         draft_config,
         swa_full = args.swa_full,
         component = "mtp" if use_mtp else "text",
+        **draft_kwargs,
     ) if draft_model_dir else None
 
     # Cache

--- a/exllamav3/modules/arch_specific/qwen3_5_mtp.py
+++ b/exllamav3/modules/arch_specific/qwen3_5_mtp.py
@@ -72,6 +72,8 @@ class Qwen3_5MTPInputLayer(Module):
 
         # Populated by attach_to()
         self.attached_model = None
+        self.hot_embedding = None
+        self.hot_inverse = None
 
         self.caps.update({"x_cpu": True})
 
@@ -99,7 +101,11 @@ class Qwen3_5MTPInputLayer(Module):
         y = self.pre_fc_norm_hidden.forward(y, params)
 
         # Token embedding
-        if not self.attached_model().loaded_tp:
+        if params.get("mtp_hot_embedding") and self.hot_embedding is not None:
+            if self.hot_inverse is not None:
+                x = self.hot_inverse[x]
+            x = F.embedding(x, self.hot_embedding).half()
+        elif not self.attached_model().loaded_tp:
             x = self.attached_model().modules[0].forward(x, params, out_dtype = torch.half)
         else:
             x = self.attached_model().tp_producer.send(x)

--- a/tests/test_mtp_hot_vocab.py
+++ b/tests/test_mtp_hot_vocab.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import pytest
+
+from exllamav3.architecture.mtp_hot_vocab import MTPHotVocabConfig
+from exllamav3.architecture.qwen3_5_mtp import validate_mtp_hot_blocks
+
+
+def test_configuration():
+    assert not MTPHotVocabConfig().enabled
+    assert MTPHotVocabConfig(blocks_path = "blocks.txt", embedding_dtype = "fp8").enabled
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"blocks_path": "blocks.txt", "embedding_dtype": "int8"},
+    {"validate_full_head": True},
+])
+def test_configuration_rejects_invalid_options(kwargs):
+    with pytest.raises(ValueError):
+        MTPHotVocabConfig(**kwargs)
+
+
+def test_environment_configuration():
+    env = {
+        "EXL3_MTP_HOT_BLOCKS": "blocks.txt",
+        "EXL3_MTP_HOT_EMBED_DTYPE": "fp8",
+        "EXL3_MTP_VALIDATE_SUBHEAD": "1",
+    }
+    with patch.dict("os.environ", env, clear = True):
+        config = MTPHotVocabConfig.from_env()
+    assert config.blocks_path == "blocks.txt"
+    assert config.embedding_dtype == "fp8"
+    assert config.validate_full_head
+
+
+def test_accepts_noncontiguous_hadamard_groups():
+    validate_mtp_hot_blocks(
+        list(range(8, 16)) + list(range(24, 32)),
+        full_vocab = 4096,
+    )
+
+
+@pytest.mark.parametrize("blocks", [
+    list(range(7)),
+    list(range(1, 9)),
+    list(range(8)) + list(range(7, 15)),
+])
+def test_rejects_partial_or_misaligned_groups(blocks):
+    with pytest.raises(ValueError):
+        validate_mtp_hot_blocks(blocks, full_vocab = 4096)
+
+
+def test_rejects_out_of_range_group():
+    with pytest.raises(ValueError):
+        validate_mtp_hot_blocks(list(range(32, 40)), full_vocab = 512)

--- a/util/build_mtp_hot_blocks.py
+++ b/util/build_mtp_hot_blocks.py
@@ -1,0 +1,112 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import argparse
+from collections import Counter
+from pathlib import Path
+
+from exllamav3 import Config, Tokenizer
+
+
+BLOCK_SIZE = 16
+GROUP_SIZE = 128
+BLOCKS_PER_GROUP = GROUP_SIZE // BLOCK_SIZE
+EXTENSIONS = {
+    ".c", ".cc", ".cpp", ".cu", ".cuh", ".h", ".hpp",
+    ".go", ".java", ".js", ".json", ".jsx", ".md", ".py",
+    ".rs", ".sh", ".toml", ".ts", ".tsx", ".txt", ".yaml", ".yml",
+}
+
+
+def main(args, parser):
+
+    if args.blocks <= 0 or args.blocks % BLOCKS_PER_GROUP:
+        parser.error(f"--blocks must be a positive multiple of {BLOCKS_PER_GROUP}")
+
+    config = Config.from_directory(args.model)
+    tokenizer = Tokenizer.from_config(config)
+    counts = Counter()
+    files = 0
+    tokens = 0
+
+    for root_name in args.corpus:
+        root = Path(root_name)
+        paths = [root] if root.is_file() else sorted(root.rglob("*"))
+        for path in paths:
+            if not path.is_file() or path.suffix.lower() not in EXTENSIONS:
+                continue
+            text = path.read_text(encoding = "utf-8", errors = "ignore")[:args.max_chars_per_file]
+            if not text:
+                continue
+            ids = tokenizer.encode(text, add_bos = False)[0].tolist()
+            counts.update(token_id // GROUP_SIZE for token_id in ids)
+            files += 1
+            tokens += len(ids)
+
+    required_ids = set(config.eos_token_id_list)
+    required_ids.update(x for x in (config.bos_token_id, config.pad_token_id) if x is not None)
+    draft_counts = Counter()
+    for filename in args.draft_ids:
+        with open(filename, "r", encoding = "utf-8") as f:
+            ids = [int(line) for line in f if line.strip() and not line.lstrip().startswith("#")]
+        if any(token_id < 0 or token_id >= config.vocab_size for token_id in ids):
+            parser.error(f"Draft ID outside the model vocabulary in {filename}")
+        draft_counts.update(token_id // GROUP_SIZE for token_id in ids)
+
+    num_groups = args.blocks // BLOCKS_PER_GROUP
+    required_groups = {token_id // GROUP_SIZE for token_id in required_ids}
+    if num_groups < len(required_groups):
+        parser.error(f"--blocks must provide room for all {len(required_groups)} special-token groups")
+
+    selected_groups = set(required_groups)
+    for frequencies in (draft_counts, counts):
+        for group, _ in frequencies.most_common():
+            if len(selected_groups) >= num_groups:
+                break
+            selected_groups.add(group)
+    if len(selected_groups) < num_groups:
+        for group in range((config.vocab_size + GROUP_SIZE - 1) // GROUP_SIZE):
+            if len(selected_groups) >= num_groups:
+                break
+            selected_groups.add(group)
+
+    selected_groups = sorted(selected_groups)
+    selected = [
+        group * BLOCKS_PER_GROUP + offset
+        for group in selected_groups
+        for offset in range(BLOCKS_PER_GROUP)
+    ]
+    covered = sum(count for group, count in counts.items() if group in selected_groups)
+    output = Path(args.output)
+    output.write_text(
+        "# EXL3 MTP hot vocabulary: packed 16-token block IDs\n"
+        f"# corpus_files={files} corpus_tokens={tokens} blocks={len(selected)} "
+        f"corpus_coverage={covered / max(tokens, 1):.8f}\n" +
+        "\n".join(map(str, selected)) + "\n",
+        encoding = "utf-8",
+    )
+    print({
+        "files": files,
+        "tokens": tokens,
+        "blocks": len(selected),
+        "tokens_in_head": len(selected) * BLOCK_SIZE,
+        "corpus_coverage": covered / max(tokens, 1),
+        "output": str(output),
+    })
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        allow_abbrev = False,
+        description = "Build an aligned EXL3 vocabulary-subset map for Qwen MTP drafting.",
+    )
+    parser.add_argument("-m", "--model", required = True, help = "EXL3 model directory")
+    parser.add_argument("-c", "--corpus", action = "append", required = True, help = "Representative file or directory (repeatable)")
+    parser.add_argument("-b", "--blocks", type = int, default = 4096, help = "Packed 16-token blocks (default: 4096 = 65,536 tokens)")
+    parser.add_argument("-o", "--output", required = True, help = "Output block-map path")
+    parser.add_argument("--max_chars_per_file", type = int, default = 1_000_000)
+    parser.add_argument(
+        "--draft_ids", action = "append", default = [],
+        help = "Observed unrestricted MTP proposal IDs; their groups are selected first",
+    )
+    _args = parser.parse_args()
+    main(_args, parser)


### PR DESCRIPTION
## Result

**A selected 64K draft head increased mean Qwen3.8-27B MTP decode throughput by 21.9%, from 36.58 to 44.58 t/s, on an RTX 4060 Ti 16 GB.** The target still verifies every proposal with its full 248K-token head. The fast path adds about 0.55 GiB of allocation and still fits a configured 131,072-token Q4/Q4 cache.

| Configuration | Code (t/s) | Reasoning (t/s) | Prose (t/s) | Structured (t/s) | Mean (t/s) |
| --- | ---: | ---: | ---: | ---: | ---: |
| Full 248K head, MTP-4 | 30.354 | 41.154 | 31.637 | 43.191 | 36.584 |
| Selected 64K head, FP8 embeddings, MTP-4 | 38.077 | 51.815 | 38.030 | 50.392 | **44.579** |

The selected-head MTP-4 profile also beat the full-head MTP-3 control by 16.8% (44.579 vs. 38.159 t/s).

Benchmark setup: Qwen3.8-27B EXL3 3.00 bpw, Q4 target and MTP KV, batch size 1, argmax, thinking enabled, and four fixed 251-token code/reasoning/prose/structured generations. The branch uses `dev` commit `abf4911` and a CUDA 12.8 extension built for SM 8.9.

## Implementation

Qwen MTP runs the target output projection for each greedy draft step. Qwen3.8 has 248,320 vocabulary rows, so that projection consumes a large share of draft time.

This opt-in EXL3 path:

- builds a smaller draft-only output head from selected vocabulary groups and keeps the matching input embeddings on the GPU;
- chains intermediate MTP token IDs on the GPU, with one CPU readback after each draft block;
- uses the full target head for verification and composes with the confidence-calibrated dynamic-draft pipeline on `dev`.

Unconfigured models keep the existing MTP path.

EXL3 applies its output Hadamard transform in aligned 128-token groups. The implementation accepts complete groups of eight packed blocks; arbitrary block selection or reordering would produce invalid logits. `util/build_mtp_hot_blocks.py` ranks groups from unrestricted MTP proposal traces, then corpus frequency, and retains special-token groups.

## Correctness and tradeoffs

The selected head proposes draft tokens. The target's original full-vocabulary head verifies each proposal. Target weights, target quantization, and speculative-decoding correctness remain unchanged. A poor domain map can lower acceptance and erase the speed gain.

Full-head diagnostics on the rebased `dev` branch found the full-head winner inside the selected vocabulary for 68 of 72 proposals. The selected and full heads matched on all 68 of those proposals. An earlier larger pass matched 582 of 582 proposals under the same condition.

At a configured 131,072-token Q4/Q4 cache:

| Configuration | Allocated | Reserved |
| --- | ---: | ---: |
| Full head, MTP-4 | 12.819 GiB | 13.789 GiB |
| Selected 64K + FP8 embeddings, MTP-4 | 13.369 GiB | 14.102 GiB |

Long contexts shift more time into attention and KV work. MTP-3 beat MTP-4 at high occupancy on this GPU, so operators should benchmark draft depth and context instead of treating the measured 64K/MTP-4 profile as a universal preset.

## Configuration

`MTPHotVocabConfig` configures the MTP component. Standard model initialization exposes:

- `--mtp_hot_blocks`
- `--mtp_hot_embedding_dtype {fp16,fp8}`
- `--mtp_hot_validate`

Environment-variable equivalents support servers that cannot forward component configuration yet. See `doc/mtp_hot_vocab.md`.

Current scope: Qwen3.5/3.6 embedded MTP, an EXL3 target `lm_head`, and single-GPU layer split.

## Validation

- `pytest -q tests/test_mtp_hot_vocab.py`: 9 tests passed
- source `compileall` and `git diff --check`
- real-model selected/full-head numerical checks
- balanced MTP-3/MTP-4 controls and an 85,952-token real-source smoke test
