### PR TITLE
Validate reconstruct kernel indices before dispatch

### DIFF
--- a/exllamav3/exllamav3_ext/quant/reconstruct.cu
+++ b/exllamav3/exllamav3_ext/quant/reconstruct.cu
@@ -108,6 +108,11 @@ void reconstruct_slice
     const at::cuda::OptionalCUDAGuard device_guard(unpacked.device());
     cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
+    // The kernel-instance tables hold 24 entries: K in 1..8 x {plain, mcg, mul1}.
+    // K is derived from the checkpoint (trellis.shape[-1] // 16), so an untrusted
+    // model file can drive cbi outside the table and launch whatever pointer lies
+    // there. Bound both the input and the computed index.
+    TORCH_CHECK(K >= 1 && K <= 8, "K must be in 1..8, got ", K);
     TORCH_CHECK_SHAPES(unpacked, 0, packed, 0, 16);
     TORCH_CHECK_SIZE(packed, 2, 256 * K / 16);
     TORCH_CHECK_DTYPE(unpacked, kHalf);
@@ -132,6 +137,8 @@ void reconstruct_slice
     int cbi = K - 1;
     if (mcg) cbi += 8;
     else if (mul1) cbi += 16;
+    TORCH_CHECK(cbi >= 0 && cbi < (int) reconstruct_kernel_instances.size(),
+                "kernel index out of range: ", cbi);
 
     reconstruct_kernel_instances[cbi]<<<gridDim, blockDim, 0, stream>>>
     (
@@ -336,6 +343,11 @@ void reconstruct_had_slice
     const at::cuda::OptionalCUDAGuard device_guard(unpacked.device());
     cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
+    // The kernel-instance tables hold 24 entries: K in 1..8 x {plain, mcg, mul1}.
+    // K is derived from the checkpoint (trellis.shape[-1] // 16), so an untrusted
+    // model file can drive cbi outside the table and launch whatever pointer lies
+    // there. Bound both the input and the computed index.
+    TORCH_CHECK(K >= 1 && K <= 8, "K must be in 1..8, got ", K);
     TORCH_CHECK_SHAPES(unpacked, 0, packed, 0, 16);
     TORCH_CHECK_SIZE(packed, 2, 256 * K / 16);
     TORCH_CHECK_DTYPE(unpacked, kHalf);
@@ -359,6 +371,8 @@ void reconstruct_had_slice
     int cbi = K - 1;
     if (mcg) cbi += 8;
     else if (mul1) cbi += 16;
+    TORCH_CHECK(cbi >= 0 && cbi < (int) reconstruct_had_kernel_instances.size(),
+                "kernel index out of range: ", cbi);
 
     reconstruct_had_kernel_instances[cbi]<<<gridDim, RH_THREADS, 0, stream>>>
     (


### PR DESCRIPTION
## Summary

`reconstruct_slice` and `reconstruct_had_slice` select CUDA kernels by indexing fixed 24-entry function-pointer tables. The index is derived from `K`, which ultimately comes from the EXL3 checkpoint's trellis shape, but neither dispatch site currently checks that `K` is within the supported range.

This change validates `K` as `1..8` before any size arithmetic, then validates the computed index before dispatch. Invalid `K` values reaching either reconstruct entry point now produce a `RuntimeError` instead of indexing outside the reconstruct kernel table.

This addresses the issue coordinated as CERT/CC VU#369611 and discussed in #250.

## Validation

The affected `reconstruct.cu` blob on current `master` (`0c49587a7c235e6303a6bbedc8b665272ad3a2ea`) is byte-identical to the source used for the A100 validation. This uses the same validated guards, with the `K` check moved ahead of the existing `256 * K / 16` size expression so malformed values cannot reach that arithmetic first.

On the patched A100 build:

- valid `K=1`, `K=4`, and `K=8` boundary/control cases returned normally;
- invalid `K=0` and `K=9` cases were rejected with `RuntimeError: K must be in 1..8` in both reconstruct dispatch paths;
- the corresponding unpatched cases reached a non-zero exit or CUDA illegal-memory-access result; and
- `turboderp/Llama-3.2-1B-Instruct-exl3` at 2.0 bpw loaded and generated normally.

The compatibility check covers that tested checkpoint and configuration; it is not intended as a survey of every EXL3 model.

## Scope

The patch changes only the two load/reconstruct dispatch sites. It does not alter valid kernel selection or model output.

AI assistance was used while preparing the patch and validation. I reviewed the change and am responsible for it.
