### PR TITLE
Precomputed MoE expert-placement profiles for CPU offload

### DIFF
--- a/doc/moe_expert_profiles.md
+++ b/doc/moe_expert_profiles.md
@@ -1,0 +1,189 @@
+# MoE expert placement profiles
+
+CPU MoE offload (`-mcs` / `-mcl`) splits each block-sparse layer's experts between VRAM and
+system RAM. Routing is heavily skewed, so *which* experts stay resident decides how much
+traffic crosses the memory bus — on a DDR5-bound setup that is the difference between the CPU
+being invisible and the CPU being the bottleneck.
+
+Upstream discovers that ordering at runtime. A **profile** measures it ahead of time, so
+placement is right at token zero.
+
+## Why placement matters
+
+Measured on GLM-5.3-Flash (42 MoE layers × 288 experts), sorting each layer's experts by
+measured decode traffic:
+
+| experts kept in VRAM | `-mcs` | traffic served from VRAM | CPU share | vs uniform placement |
+| --- | --- | --- | --- | --- |
+| 75% | 72 | 98.4% | 1.6% | 15.2x less CPU work |
+| 50% | 144 | 90.7% | 9.3% | 5.4x |
+| 37.5% | 180 | 83.7% | 16.3% | 3.8x |
+| 25% | 216 | 73.5% | 26.5% | 2.8x |
+
+The curve is strongly non-linear: half the experts can be evicted while ~91% of the routing
+still lands in VRAM.
+
+## Measured effect
+
+Placement only buys throughput where the CPU side is actually the bottleneck. On GLM-5.3-Flash,
+`eval/perf.py`, decode tok/s averaged over context 0..4k, native profile, two repeats:
+
+GLM-5.3-Flash 4.05bpw, `-mcs 180`, native profile, decode tok/s:
+
+| context | dynamic | `seed` + profile | |
+| --- | --- | --- | --- |
+| 0 | 18.80 | 21.88 | +16.4% |
+| 256 | 18.52 | 20.79 | +12.3% |
+| 512 | 18.82 | 21.00 | +11.6% |
+| 1,024 | 18.52 | 19.82 | +7.0% |
+| 2,048 | 15.37 | 17.51 | +13.9% |
+| 4,096 | 17.19 | 16.76 | -2.5% |
+| 8,192 | 18.29 | 20.02 | +9.5% |
+| 16,384 | 17.00 | 18.72 | +10.1% |
+| 32,768 | 17.05 | 17.95 | +5.3% |
+| 65,536 | 15.26 | 14.73 | -3.5% |
+| 131,072 | 18.09 | 18.91 | +4.5% |
+| 261,888 | 17.40 | 17.69 | +1.7% |
+
+| band | dynamic | `seed` | | |
+| --- | --- | --- | --- | --- |
+| short, 0-2k | 18.01 | 20.20 | **+12.2%** | wins 5/5 |
+| mid, 4k-32k | 17.38 | 18.36 | +5.6% | wins 3/4 |
+| long, 64k-256k | 16.92 | 17.11 | +1.1% | wins 2/3 |
+| overall | 17.44 | 18.73 | +7.4% | wins 10/12 |
+
+**The gain decays with context, and that is structural.** Placement only affects the MoE share
+of a decode step. That work is constant per token while attention grows with context, so by
+64k the experts are a small part of the critical path and reordering them buys little. Build
+profiles for chat, agentic loops and code completion; skip them for long-document work.
+
+The same run on 2.05bpw `-mcs 150` gives +3.5% (5/7 points, not significant): that config has
+DDR5 bandwidth to spare, so there is nothing to reclaim. The 4.05bpw config decodes at ~95% of
+its bandwidth ceiling, which is why it responds. Measure your own configuration.
+
+Correctness is unaffected: perplexity over the same rows is 3.489850 with no offload, 3.490881
+with offload and dynamic placement, 3.492384 seeded and 3.490442 static -- all within eval
+noise.
+
+## Building a profile
+
+```
+python util/moe_profile_build.py -m /models/GLM-5.3-Flash-exl3-4.05bpw \
+    -corpus /data/wikitext-2-raw/wiki.train.raw -o wiki.npz \
+    -nprompts 48 -plen 1024 -gen 128 -resident 108
+```
+
+`-corpus` takes a bundled calibration corpus (`wiki`, `c4`, `code`, `multilingual`,
+`technical`, `tiny`), a text file, or a JSON list of prompts. The bundled `.utf8` files are not
+installed as package data, so on an installed exllamav3 pass a path or set `EXL3_CAL_DATA_DIR`.
+A model that does not fit resident needs `-mcs`; routing is unaffected by where experts live:
+only routing decisions are needed and a fully resident load is faster.
+
+Decode is the allocation signal — that is the regime offload runs in. Profile quality is driven
+first by **how many independent windows** are sampled (`-nprompts`) and only then by how many
+tokens each contributes (`-plen`, `-gen`). Diversity beats length: one long generation follows a
+single trajectory and its ranking encodes that trajectory rather than the corpus. A profile fitted
+that way scored 94.8% against its own counts and delivered 42-45% live — worse than random
+placement plus upstream's own sweeps.
+
+Two guards make that failure visible instead of silent:
+
+* **Sample size.** Below 20 hits/expert the tool warns and falls back to the prefill bank, because
+  a ranking built from one or two hits per expert is noise that *looks* like extreme concentration
+  (unsampled experts sort to the tail, so the "hot" head trivially covers everything).
+* **Generalization.** Windows are split into disjoint fit/test sets; capture is reported on the
+  held-out half beside `uniform` (random placement) and `oracle` (the best any static profile can
+  do). Held-out within 3 points of uniform, or in-sample more than 25 points above held-out, each
+  print an explicit warning. With fewer than 4 windows no split is possible and the tool says so
+  rather than reporting an in-sample number.
+
+## Flags
+
+| flag | meaning |
+| --- | --- |
+| `-mcp` / `--moe_cpu_profile` | profile spec: names or paths, comma-separated, optional `:weight` |
+| `-mcpm` / `--moe_cpu_profile_mode` | `seed` (default) or `static` |
+| `-mcpd` / `--moe_cpu_profile_dir` | extra search directory |
+| `-mcpq` / `--moe_cpu_profile_any_quant` | accept a profile from another checkpoint of the same model |
+
+## Using a profile
+
+```
+python -m exllamav3.server -m /models/... -mcs 180 \
+    --moe_cpu_profile code --moe_cpu_profile_mode seed
+```
+
+Profiles are looked up as `<name>.{npz,safetensors,exl3moe,json}`, in order:
+
+1. `<model_dir>/moe_profiles/` — ships inside the model repo
+2. `$EXL3_MOE_PROFILE_DIR` (os.pathsep-separated)
+3. `~/.cache/exllamav3/moe_profiles/`
+
+### Combining profiles
+
+```
+--moe_cpu_profile code:3,wiki:1
+```
+
+Sources are merged on **per-layer normalized** frequency, so a corpus with more tokens does not
+simply win; the optional `:weight` sets relative contribution.
+
+### seed vs static
+
+| mode | placement | dynamic swapping | use when |
+| --- | --- | --- | --- |
+| `-mcpm seed` (default) | starts from the profile | stays on, keeps adapting | the workload may drift from the profile |
+| `-mcpm static` | frozen at the profile order | off | you want predictable latency and no mid-generation placement changes |
+
+`static` is the more stable of the two: a placement change is a small numeric step for every
+migrated expert (the same weights compute slightly differently on the two devices), so `seed`
+can shift output subtly at a sweep boundary while `static` never does.
+
+## Profile identity: per model, per quantization
+
+Routing depends on the model **and** on how it was quantized — different bitrates give
+different hidden states and therefore different expert choices. A profile therefore belongs to
+one `(model, checkpoint)` pair, and both are checked at load:
+
+* **Model identity** — architecture, layer count, expert count, `moe_intermediate_size`,
+  `hidden_size`. A mismatch is always fatal; placement from another architecture is meaningless.
+* **Checkpoint identity** — `checkpoint_sha` plus `quant_method`/`bits`/`head_bits`/`codebook`.
+  A mismatch is fatal unless `--moe_cpu_profile_any_quant` is passed, which downgrades
+  it to a loud warning.
+
+`checkpoint_sha` hashes each shard's safetensors **header** (tensor names, dtypes, shapes,
+offsets) plus its file size — never the weight data. On a 165 GB, 20-shard checkpoint that is
+19.7 MB of reads and about 0.03 s, and it still changes when a checkpoint is requantized at the
+same nominal bitrate, which comparing `bits` alone would miss.
+
+A profile without a fingerprint (for example a third-party usage census) loads with a warning
+rather than an error.
+
+## Swap policy
+
+With `seed`, dynamic placement continues to run. Its cadence is tunable:
+
+| flag | env | default | meaning |
+| --- | --- | --- | --- |
+| `-mcw` / `--moe_cpu_swap {on,off}` | `EXL3_MOE_CPU_SWAP` | on | dynamic placement at all |
+| `-mcwi` / `--moe_cpu_swap_interval` | `EXL3_MOE_CPU_SWAP_INTERVAL` | 128 | decode steps between sweeps |
+| `-mcwm` / `--moe_cpu_swap_max` | `EXL3_MOE_CPU_SWAP_MAX` | 64 | expert swaps per sweep, across **all** layers |
+| `-mcwh` / `--moe_cpu_swap_hysteresis` | `EXL3_MOE_CPU_SWAP_HYST` | 2.0 | hit-ratio a CPU expert must beat to be promoted |
+
+Sweeps are deferred to the generator's queue-drained hook so they never fire mid-generation,
+with an inline fallback when badly overdue (raw `model.forward` drivers have no such hook).
+Note the default budget is 64 swaps *in total* per sweep: on a 42-layer model that is ~1.5
+swaps per layer, so converging a cold placement takes thousands of decode steps — which is the
+reason to seed from a profile rather than wait.
+
+## Third-party profiles
+
+Profiles are data, not code, and the format is deliberately the same as the usage
+census (`counts_decode` / `counts_prefill`, `int64 [prompts, layers, experts]`), so censuses
+captured by external tooling load directly. Publish them next to the weights in
+`moe_profiles/`, or in a separate repo pointed at by `EXL3_MOE_PROFILE_DIR`.
+
+Positional censuses carry no layer names, so rows are matched to MoE layers in registration
+order. Where possible ship the `<name>.meta.json` sidecar our builder writes: it carries
+`layer_keys` and the fingerprint, and keyed matching removes any chance of an off-by-one when
+an architecture interleaves dense and sparse MLPs.

--- a/exllamav3/model/moe_profile.py
+++ b/exllamav3/model/moe_profile.py
@@ -1,0 +1,401 @@
+"""Precomputed MoE expert-placement profiles.
+
+CPU MoE offload (-mcs/-mcl) splits each layer's experts between GPU and system RAM. Routing is
+heavily skewed, so WHICH experts sit on the GPU decides how much traffic crosses the memory
+bus. Upstream discovers that ordering at runtime, which is slow to converge: sweeps move at
+most EXL3_MOE_CPU_SWAP_MAX (64) experts across ALL layers every EXL3_MOE_CPU_SWAP_INTERVAL
+(128) decode steps, so a large model needs thousands of tokens to settle.
+
+A profile is a table of per-expert selection counts measured OFFLINE and shipped as a file, so
+placement starts correct at token zero. Nothing is probed or computed at load beyond one
+argsort per layer.
+
+Accepted sources (auto-detected by content, not extension):
+
+  *.npz   usage census: counts_decode / counts_prefill, int64 [n_prompts, n_layers,
+          n_experts], summed over prompts. Decode is the allocation signal.
+  *.safetensors / *.exl3moe   counts int64 [n_layers, n_experts] (+ optional precomputed perm)
+  *.json  {"<layer_key>": [c0..cN]} -- the format upstream's EXL3_MOE_CPU_SPLIT_STATS uses
+
+Sources combine with weights, e.g. "wiki:1,code:3". Counts are normalized per layer
+before weighting, so a corpus with more tokens does not simply win.
+"""
+
+import os, json, hashlib
+
+MODEL_KEYS = ("architecture", "layers", "experts", "moe_intermediate_size", "hidden_size")
+QUANT_KEYS = ("checkpoint_sha", "quant_method", "bits", "head_bits", "codebook")
+
+
+def checkpoint_hash(directory, max_shards=None):
+    """Content hash of a quantized checkpoint, cheap enough to run at every load.
+
+    Hashes the safetensors HEADERS of every shard -- tensor names, dtypes, shapes and byte
+    offsets -- plus each shard's size. That is a few MB of reads instead of the ~150 GB the
+    weights occupy, and it still changes whenever the checkpoint changes: a requantization
+    alters trellis shapes and offsets even at the same nominal bitrate, which a bits/codebook
+    comparison alone would miss.
+
+    Returns a 16-hex-char digest, or None if the directory holds no safetensors.
+    """
+    import glob, struct
+    files = sorted(glob.glob(os.path.join(directory, "*.safetensors")))
+    if not files:
+        return None
+    if max_shards:
+        files = files[:max_shards]
+    h = hashlib.sha256()
+    for f in files:
+        try:
+            sz = os.path.getsize(f)
+            with open(f, "rb") as fh:
+                n = struct.unpack("<Q", fh.read(8))[0]
+                if n > 64 * 1024 * 1024:      # refuse an implausible header
+                    return None
+                hdr = fh.read(n)
+            h.update(os.path.basename(f).encode())
+            h.update(struct.pack("<Q", sz))
+            h.update(hdr)
+        except Exception:
+            return None
+    return h.hexdigest()[:16]
+
+
+def model_fingerprint(config, num_experts=None):
+    """Identity of the exact artifact a profile was measured on.
+
+    Routing depends on the model AND on how it was quantized -- different bitrates give
+    different hidden states and therefore different expert choices -- so a profile is valid
+    for one (model, quantization) pair. Split into MODEL_KEYS (never ignorable) and
+    QUANT_KEYS (ignorable with an explicit override).
+    """
+    cd = getattr(config, "config_dict", None) or {}
+    t = cd.get("text_config") if isinstance(cd.get("text_config"), dict) else cd
+    q = cd.get("quantization_config") or {}
+    arch = (cd.get("architectures") or [None])
+    fp = {
+        "architecture": arch[0] if arch else None,
+        "layers": t.get("num_hidden_layers"),
+        "experts": num_experts if num_experts is not None else
+                   (t.get("n_routed_experts") or t.get("num_experts")),
+        "moe_intermediate_size": t.get("moe_intermediate_size"),
+        "hidden_size": t.get("hidden_size"),
+        "quant_method": q.get("quant_method"),
+        "bits": q.get("bits"),
+        "head_bits": q.get("head_bits"),
+        "codebook": q.get("codebook"),
+    }
+    d = getattr(config, "directory", None)
+    if d and os.path.isdir(d):
+        fp["checkpoint_sha"] = checkpoint_hash(d)
+    return {k: v for k, v in fp.items() if v is not None}
+
+
+def check_fingerprint(profile_fp, model_fp, path, allow_quant_mismatch=False):
+    """Enforce the per-model / per-quantization policy. Returns a list of warnings."""
+    warn = []
+    if not profile_fp:
+        warn.append(f" !! {os.path.basename(path)}: no fingerprint; cannot verify it was built "
+                    f"for this model/quantization. Rebuild with util/moe_profile_build.py to "
+                    f"embed one.")
+        return warn
+    bad_model = [(k, profile_fp.get(k), model_fp.get(k)) for k in MODEL_KEYS
+                 if k in profile_fp and k in model_fp and profile_fp[k] != model_fp[k]]
+    if bad_model:
+        det = "; ".join(f"{k}: profile={a!r} model={b!r}" for k, a, b in bad_model)
+        raise ValueError(
+            f"{path}: this profile was built for a different MODEL ({det}). "
+            f"Expert placement from another architecture is meaningless; rebuild the profile.")
+    bad_quant = [(k, profile_fp.get(k), model_fp.get(k)) for k in QUANT_KEYS
+                 if k in profile_fp and k in model_fp and profile_fp[k] != model_fp[k]]
+    if bad_quant:
+        det = "; ".join(f"{k}: profile={a!r} model={b!r}" for k, a, b in bad_quant)
+        if not allow_quant_mismatch:
+            head = "a different CHECKPOINT" if any(k == "checkpoint_sha" for k, _, _ in bad_quant) \
+                   else "a different QUANTIZATION"
+            raise ValueError(
+                f"{path}: this profile was built on {head} ({det}).\n"
+                f"Routing depends on the quantization, so placement measured at one bitrate "
+                f"may be wrong at another.\nRebuild the profile for this quant, or pass "
+                f"--moe_cpu_profile_any_quant to use it anyway.")
+        warn.append(f" !! {os.path.basename(path)}: QUANTIZATION MISMATCH ({det}) -- used "
+                    f"anyway because --moe_cpu_profile_any_quant is set. Placement "
+                    f"may be worse than dynamic; measure before trusting it.")
+    return warn
+
+
+# Packed first: when a name resolves to several files, prefer the one that is cheapest to
+# load. .exl3moe carries the ranking precomputed (mmap-free pread, no argsort); .npz is the
+# census, which is complete but must be decompressed, summed over prompts and sorted. Ship
+# both and serving picks the fast one while -score can still audit the census by path.
+_EXTS = (".exl3moe", ".safetensors", ".npz", ".json")
+
+
+def _np():
+    import numpy as np
+    return np
+
+
+def search_dirs(model_dir=None):
+    """Profiles are model-specific. Shipped-with-model wins, then env, then user cache."""
+    d = []
+    if model_dir:
+        d.append(os.path.join(model_dir, "moe_profiles"))
+    env = os.environ.get("EXL3_MOE_PROFILE_DIR")
+    if env:
+        d += [p for p in env.split(os.pathsep) if p]
+    d.append(os.path.join(os.path.expanduser("~"), ".cache", "exllamav3", "moe_profiles"))
+    return d
+
+
+def resolve_path(spec, model_dir=None):
+    """A path, or a bare name looked up in the search dirs (any accepted extension)."""
+    if os.path.isfile(spec):
+        return spec
+    for d in search_dirs(model_dir):
+        if not os.path.isdir(d):
+            continue
+        for ext in _EXTS:
+            p = os.path.join(d, spec + ext)
+            if os.path.isfile(p):
+                return p
+    raise FileNotFoundError(
+        f"MoE profile '{spec}' not found. Looked in: " +
+        ", ".join(search_dirs(model_dir)) +
+        f" (extensions: {', '.join(_EXTS)}). Build one with util/moe_profile_build.py, "
+        f"or point --moe_cpu_profile at a file.")
+
+
+_ST_DTYPES = {"I64": "<i8", "I32": "<i4", "I16": "<i2", "U8": "|u1",
+              "F64": "<f8", "F32": "<f4", "F16": "<f2"}
+
+
+def _read_safetensors_pread(path, names = None):
+    """Minimal safetensors reader: header + only the tensors named, via pread.
+
+    -> (dict name -> ndarray, metadata dict). Avoids mmap (see the call site) and avoids a
+    hard dependency on the safetensors package for the read path.
+
+    `names` matters: a packed profile also carries the per-prompt census, which only -score
+    reads. Every tensor has its own byte range, so preading just "ranking" skips the census
+    entirely -- 0.02 ms regardless of how large the census is. Reading the whole file
+    instead costs 0.09 ms and grows with it.
+    """
+    np = _np()
+    import struct
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        n = struct.unpack("<Q", os.pread(fd, 8, 0))[0]
+        hdr = json.loads(os.pread(fd, n, 8).decode("utf-8"))
+        md = hdr.get("__metadata__", {}) or {}
+        base = 8 + n
+        out = {}
+        for name, info in hdr.items():
+            if name == "__metadata__":
+                continue
+            if names is not None and name not in names:
+                continue
+            dt = _ST_DTYPES.get(info["dtype"])
+            if dt is None:
+                raise ValueError(f"{path}: unsupported dtype {info['dtype']} for {name}")
+            s0, s1 = info["data_offsets"]
+            buf = os.pread(fd, s1 - s0, base + s0)
+            if len(buf) != s1 - s0:
+                raise ValueError(f"{path}: short read for {name}")
+            out[name] = np.frombuffer(buf, dtype=np.dtype(dt)).reshape(info["shape"])
+        return out, md
+    finally:
+        os.close(fd)
+
+
+def load_counts(path):
+    """-> (counts [n_layers, n_experts] float64, layer_keys or None, meta dict)"""
+    np = _np()
+    low = path.lower()
+
+    if low.endswith(".npz"):
+        z = np.load(path, allow_pickle=False)
+        # decode is the allocation signal, since CPU offload runs in decode.
+        def _flat(name):
+            if name not in z:
+                return None
+            v = np.asarray(z[name])
+            if v.ndim == 3:      # [n_prompts, n_layers, n_experts] -> sum over prompts
+                v = v.sum(axis=0)
+            if v.ndim != 2:
+                raise ValueError(f"{path}: expected 2D or 3D '{name}', got shape {v.shape}")
+            return v.astype(np.float64)
+
+        dec, pre = _flat("counts_decode"), _flat("counts_prefill")
+        plain = _flat("counts")
+        a, k = (dec, "counts_decode") if dec is not None else \
+               (plain, "counts") if plain is not None else (pre, "counts_prefill")
+        if a is None:
+            raise ValueError(f"{path}: no counts_decode/counts/counts_prefill array")
+
+        # Ranking E experts from a few hits each is noise that masquerades as extreme skew:
+        # unsampled experts sort to the tail and the "hot" head trivially covers everything.
+        cells = max(a.shape[0] * a.shape[1], 1)
+        per = a.sum() / cells
+        if per < 20.0:
+            alt = pre if k != "counts_prefill" else None
+            if alt is not None and alt.sum() / cells >= 20.0:
+                print(f" !! {os.path.basename(path)}: {k} has only {per:.1f} hits/expert; "
+                      f"using counts_prefill ({alt.sum()/cells:.1f}/expert) instead")
+                a, k = alt, "counts_prefill (decode too sparse)"
+            else:
+                print(f" !! {os.path.basename(path)}: only {per:.1f} hits/expert -- this profile "
+                      f"is undersampled and its ranking is largely noise")
+        # A positional .npz carries no layer identity, so rows would be matched to modules by
+        # registration order -- silently wrong if the census came from another architecture.
+        # Prefer exact keys from the sidecar our builder writes next to the .npz.
+        keys, meta = None, {"source": "npz", "bank": k}
+        side = os.path.splitext(path)[0] + ".meta.json"
+        if os.path.isfile(side):
+            try:
+                m = json.load(open(side))
+                keys = m.get("layer_keys") or None
+                if keys and len(keys) != a.shape[0]:
+                    print(f" !! {os.path.basename(side)}: {len(keys)} layer_keys but "
+                          f"{a.shape[0]} rows; ignoring the sidecar")
+                    keys = None
+                meta["sidecar"] = side
+                if isinstance(m.get("fingerprint"), dict):
+                    meta["fingerprint"] = m["fingerprint"]
+                for f in ("corpus", "prompts", "hits_per_expert_decode"):
+                    if f in m:
+                        meta[f] = m[f]
+            except Exception as e:
+                print(f" !! {os.path.basename(side)}: unreadable ({e}); using positional mapping")
+        return a, keys, meta
+
+    if low.endswith((".safetensors", ".exl3moe")):
+        # Read with pread rather than mmap. A packed profile is ~36 pages, so mmap pays a
+        # VMA setup plus a fault per page where pread is one syscall and a copy; measured
+        # 0.0080 ms vs 0.0181 ms for safetensors.load_file, which additionally opens the
+        # file a second time for metadata. exl3's own bulk weight loader is pread-based for
+        # the same reason (exllamav3_ext/stloader.cpp), and it ships a non-mmap SafeOpen.
+        # mmap would win on a large file, on random access, or on a mapping shared between
+        # processes; none of those apply to a profile read once at load.
+        # Never the census: serving needs the ranking, and counts only to merge.
+        t, md = _read_safetensors_pread(path, names = ("ranking", "counts"))
+        keys = json.loads(md["layer_keys"]) if "layer_keys" in md else None
+
+        # A shipped profile may carry the ranking already computed, in which case loading is
+        # a mmap and nothing else -- no decompression, no argsort. Measured on a 42x288
+        # profile: 0.02 ms vs 1.34 ms for the .npz census it was built from, and the ranking
+        # is bit-identical. Counts are then optional: they are only needed to MERGE several
+        # profiles, which renormalizes per layer and re-sorts.
+        if "ranking" in t:
+            rank = np.asarray(t["ranking"]).astype(np.int64)
+            if "counts" in t:
+                return (np.asarray(t["counts"]).astype(np.float64), keys,
+                        dict(md, source="safetensors", ranking=rank))
+            # Rank-only file: synthesise counts that reproduce this exact order under the
+            # descending stable argsort in build_ranking(), so a single-source spec needs no
+            # special case and a weighted merge still behaves sanely.
+            n_layers, n_exp = rank.shape
+            counts = np.empty((n_layers, n_exp), dtype = np.float64)
+            pos = np.arange(n_exp, dtype = np.float64)[::-1] + 1.0
+            np.put_along_axis(counts, rank, np.broadcast_to(pos, rank.shape), axis = 1)
+            return counts, keys, dict(md, source="safetensors", ranking=rank)
+
+        if "counts" not in t:
+            raise ValueError(f"{path}: no 'counts' or 'ranking' tensor")
+        return np.asarray(t["counts"]).astype(np.float64), keys, dict(md, source="safetensors")
+
+    if low.endswith(".json"):
+        d = json.load(open(path))
+        keys = list(d.keys())
+        a = np.asarray([d[k] for k in keys], dtype=np.float64)
+        return a, keys, {"source": "json"}
+
+    raise ValueError(f"{path}: unrecognized profile format (want one of {_EXTS})")
+
+
+def parse_spec(spec):
+    """'code:3,wiki:1' -> [('code',3.0), ('wiki',1.0)]"""
+    out = []
+    for part in str(spec).split(","):
+        part = part.strip()
+        if not part:
+            continue
+        w = 1.0
+        if ":" in part and not os.path.exists(part):
+            head, _, tail = part.rpartition(":")
+            try:
+                w = float(tail)
+                part = head
+            except ValueError:
+                pass
+        if w < 0:
+            raise ValueError(f"negative weight in --moe_cpu_profile: {part}:{w}")
+        out.append((part, w))
+    if not out:
+        raise ValueError("empty --moe_cpu_profile spec")
+    return out
+
+
+def build_ranking(spec, model_dir=None, num_experts=None, model_fp=None,
+                  allow_quant_mismatch=False):
+    """Merge the requested profiles into a hot->cold expert ranking per layer.
+
+    Returns (ranking [n_layers, n_experts] int64, layer_keys or None, info dict). Row i is the
+    expert ids of layer i ordered most- to least-used.
+    """
+    np = _np()
+    parts = parse_spec(spec)
+    acc = None
+    keys = None
+    used = []
+    precomputed = None
+    for name, w in parts:
+        p = resolve_path(name, model_dir)
+        c, k, meta = load_counts(p)
+        if model_fp is not None:
+            # NB: not `w` -- that is the source weight for this iteration.
+            for _warn in check_fingerprint(meta.get("fingerprint"), model_fp, p,
+                                           allow_quant_mismatch):
+                print(_warn)
+        if num_experts is not None and c.shape[1] != num_experts:
+            raise ValueError(
+                f"{p}: profile has {c.shape[1]} experts/layer but the model has {num_experts}. "
+                f"This profile was built for a different model.")
+        # Normalize per layer so corpus size does not decide the merge.
+        tot = c.sum(axis=1, keepdims=True)
+        tot[tot == 0] = 1.0
+        f = c / tot
+        if acc is None:
+            acc = f * w
+            keys = k
+        else:
+            if f.shape != acc.shape:
+                raise ValueError(
+                    f"{p}: shape {f.shape} does not match {acc.shape} from earlier profiles")
+            acc = acc + f * w
+            keys = keys or k
+        used.append({"name": name, "path": p, "weight": w, "shape": list(c.shape),
+                     **{k: v for k, v in meta.items() if k != "ranking"}})
+        if meta.get("ranking") is not None:
+            precomputed = meta["ranking"]
+    # A single source that already carries its ranking needs no sort at all -- that is the
+    # point of the packed .exl3moe format. Merging several sources still has to renormalize
+    # per layer and re-sort, so the fast path applies only when there is exactly one.
+    if len(parts) == 1 and precomputed is not None:
+        ranking = np.asarray(precomputed).astype(np.int64)
+    else:
+        # Descending sort; stable so equal counts keep natural expert order.
+        ranking = np.argsort(-acc, axis=1, kind="stable").astype(np.int64)
+    return ranking, keys, {"sources": used, "layers": int(acc.shape[0]),
+                           "experts": int(acc.shape[1])}
+
+
+def ranking_lookup(ranking, layer_keys):
+    """Map a module key -> its ranking row. Falls back to MoE-layer ordinal when the profile
+    carries no keys (the .npz format is positional)."""
+    by_key = {}
+    if layer_keys:
+        for i, k in enumerate(layer_keys):
+            if i < ranking.shape[0]:
+                by_key[k] = ranking[i]
+    return by_key

--- a/exllamav3/model/moe_profile.py
+++ b/exllamav3/model/moe_profile.py
@@ -280,6 +280,17 @@ def load_counts(path):
         # Never the census: serving needs the ranking, and counts only to merge.
         t, md = _read_safetensors_pread(path, names = ("ranking", "counts"))
         keys = json.loads(md["layer_keys"]) if "layer_keys" in md else None
+        # safetensors metadata values are strings, so structured fields were stored as JSON
+        # text. Decode them back, or check_fingerprint() indexes a str and raises
+        # "string indices must be integers" at load -- which defeats the identity check the
+        # packed format is supposed to carry.
+        md = dict(md)
+        for _k in ("fingerprint", "capture"):
+            if isinstance(md.get(_k), str):
+                try:
+                    md[_k] = json.loads(md[_k])
+                except (ValueError, TypeError):
+                    md.pop(_k)
 
         # A shipped profile may carry the ranking already computed, in which case loading is
         # a mmap and nothing else -- no decompression, no argsort. Measured on a 42x288

--- a/exllamav3/model_init.py
+++ b/exllamav3/model_init.py
@@ -1,3 +1,4 @@
+import os
 from types import SimpleNamespace
 
 from . import Model, Config, Cache, Tokenizer
@@ -58,6 +59,14 @@ def add_args(
     parser.add_argument("-mcl", "--moe_cpu_offload", type = int, help = "Experimental: run the routed experts of the first N block-sparse MoE layers on the CPU, with expert weights in system RAM. Layer-split mode only; requires mul1-codebook experts (ineligible layers fall back to the GPU)", default = 0)
     parser.add_argument("-mcs", "--moe_cpu_split", type = int, help = "Experimental: per-layer expert split — run the TAIL N routed experts of every eligible block-sparse MoE layer on the CPU, overlapping the CPU GEMMs with each layer's own GPU expert compute. Dynamic hot/cold expert placement is on by default (EXL3_MOE_CPU_SWAP=0 for static placement). Mutually exclusive with --moe_cpu_offload. Layer-split mode only; requires mul1-codebook experts", default = 0)
     parser.add_argument("-mct", "--moe_cpu_threads", type = int, help = "Worker thread count for --moe_cpu_offload / --moe_cpu_split (default: EXL3_MOE_CPU_THREADS env, else cpu_count/2)", default = None)
+    parser.add_argument("-mcp", "--moe_cpu_profile", type = str, help = "Precomputed MoE expert placement. Comma-separated profiles with optional weights, e.g. 'code:3,wiki:1'. Each is a filename or a name resolved under <model_dir>/moe_profiles, $EXL3_MOE_PROFILE_DIR, or ~/.cache/exllamav3/moe_profiles. Accepts usage censuses (.npz), .safetensors and .json. Placement starts on the measured hot set instead of converging there over thousands of decode steps", default = None)
+    parser.add_argument("-mcpm", "--moe_cpu_profile_mode", type = str, choices = ["seed", "static"], help = "seed (default): start from the profile and keep adapting. static: freeze the profile order, no swapping (most stable latency, never perturbs a generation)", default = None)
+    parser.add_argument("-mcpd", "--moe_cpu_profile_dir", type = str, help = "Extra directory to search for profiles (os.pathsep-separated)", default = None)
+    parser.add_argument("-mcpq", "--moe_cpu_profile_any_quant", action = "store_true", help = "Accept a profile built on a different checkpoint/quantization of the same model. Routing depends on quantization, so placement may be worse than dynamic; measure before trusting it. Model-identity mismatches stay fatal")
+    parser.add_argument("-mcw", "--moe_cpu_swap", type = str, choices = ["on", "off"], help = "Dynamic expert placement (default: on)", default = None)
+    parser.add_argument("-mcwi", "--moe_cpu_swap_interval", type = int, help = "Decode steps between placement sweeps (default: 128)", default = None)
+    parser.add_argument("-mcwm", "--moe_cpu_swap_max", type = int, help = "Maximum expert swaps per sweep, across all layers (default: 64)", default = None)
+    parser.add_argument("-mcwh", "--moe_cpu_swap_hysteresis", type = float, help = "Hit-count ratio a CPU-resident expert must beat to be promoted (default: 2.0)", default = None)
     parser.add_argument("-tpb", "--tp_backend", type = str, help = "Tensor-parallel backend, either 'native' (default) or 'nccl'", default = "native")
     parser.add_argument("-tp_attn", "--tp_max_parallelism_attn", type = int, help = "(TP) Maximum parallelism for attention layers", default = None)
     parser.add_argument("-tp_mlp", "--tp_max_parallelism_mlp", type = int, help = "(TP) Maximum parallelism for MLP layers", default = None)
@@ -197,6 +206,20 @@ def init(
 
     # Config
     config = Config.from_directory(args.model_dir, layer_map = args.layer_map)
+    # MoE expert placement. block_sparse_mlp_cpu reads these from the environment while the
+    # model loads, so they must be set before load, not after.
+    _g = lambda n: vars(args).get(n)
+    if _g("moe_cpu_profile_dir"): os.environ["EXL3_MOE_PROFILE_DIR"] = _g("moe_cpu_profile_dir")
+    if _g("moe_cpu_profile"):     os.environ["EXL3_MOE_PROFILE"] = _g("moe_cpu_profile")
+    if _g("moe_cpu_profile_mode"):os.environ["EXL3_MOE_PROFILE_MODE"] = _g("moe_cpu_profile_mode")
+    if _g("moe_cpu_profile_any_quant"): os.environ["EXL3_MOE_PROFILE_ALLOW_QUANT_MISMATCH"] = "1"
+    if _g("moe_cpu_swap_interval") is not None:   os.environ["EXL3_MOE_CPU_SWAP_INTERVAL"] = str(_g("moe_cpu_swap_interval"))
+    if _g("moe_cpu_swap_max") is not None:        os.environ["EXL3_MOE_CPU_SWAP_MAX"] = str(_g("moe_cpu_swap_max"))
+    if _g("moe_cpu_swap_hysteresis") is not None: os.environ["EXL3_MOE_CPU_SWAP_HYST"] = str(_g("moe_cpu_swap_hysteresis"))
+    if _g("moe_cpu_swap") is not None:            os.environ["EXL3_MOE_CPU_SWAP"] = "1" if _g("moe_cpu_swap") == "on" else "0"
+    if _g("moe_cpu_profile") and _g("moe_cpu_profile_mode") == "static":
+        os.environ["EXL3_MOE_CPU_SWAP"] = "0"
+
     if getattr(args, "moe_cpu_offload", 0):
         assert not args.tensor_parallel, "--moe_cpu_offload currently requires layer-split mode"
         config.infer_params.moe_cpu_offload = args.moe_cpu_offload

--- a/exllamav3/modules/block_sparse_mlp_cpu.py
+++ b/exllamav3/modules/block_sparse_mlp_cpu.py
@@ -287,10 +287,15 @@ class BlockSparseMLP_CPU:
     def can_defer_load(self):
         # The frequency-permuted expert split reads the router tensors right after load (to
         # permute them); deferred fills would land after that read and be lost
-        if (
-            int(os.environ.get("EXL3_MOE_CPU_SPLIT", 0)) > 0 and
-            os.environ.get("EXL3_MOE_CPU_SPLIT_STATS")
-        ):
+        # Any permuted expert split REBINDS the router tensors in cpu_post_load, inside the
+        # loader's deferred-load window; a deferred fill then lands in the pre-permutation
+        # tensor and is lost. The old test read EXL3_MOE_CPU_SPLIT, which -mcs never sets
+        # (it sets infer_params.moe_cpu_split), so it was dead on the CLI path.
+        ip = getattr(self.config, "infer_params", None)
+        split_on = int(getattr(ip, "moe_cpu_split", 0) or 0) > 0 if ip else False
+        split_on = split_on or int(os.environ.get("EXL3_MOE_CPU_SPLIT", 0) or 0) > 0
+        if split_on and (os.environ.get("EXL3_MOE_PROFILE")
+                         or os.environ.get("EXL3_MOE_CPU_SPLIT_STATS")):
             return False
         return super().can_defer_load()
 
@@ -465,6 +470,54 @@ class BlockSparseMLP_CPU:
         # via the install message (the child re-reads it from its own checkpoint handle)
         self._split_dynamic = os.environ.get("EXL3_MOE_CPU_SWAP", "1") != "0" \
             and not self.tid2eid_key
+        # EXL3_MOE_PROFILE: precomputed placement from one or more measured profiles.
+        # mode "seed" keeps dynamic swapping enabled (start hot, keep adapting); mode
+        # "static" freezes the profile order. The merged ranking is cached on the config so
+        # the profile files are read once per model, not once per layer.
+        prof_spec = os.environ.get("EXL3_MOE_PROFILE")
+        prof_rank = None
+        if prof_spec and not self.tid2eid_key:
+            mode = os.environ.get("EXL3_MOE_PROFILE_MODE", "seed").lower()
+            cache = getattr(self.config, "_moe_profile_cache", None)
+            if cache is None:
+                from ..model.moe_profile import (build_ranking, ranking_lookup,
+                                                  model_fingerprint)
+                md = getattr(self.config, "model_dir", None) or getattr(self.config, "directory", None)
+                # Policy: a profile is valid for one (model, quantization). Model mismatch is
+                # always fatal; checkpoint/quant mismatch is fatal unless explicitly allowed.
+                allow_q = os.environ.get("EXL3_MOE_PROFILE_ALLOW_QUANT_MISMATCH", "0") != "0"
+                mfp = model_fingerprint(self.config, self.num_experts)
+                ranking, keys, info = build_ranking(prof_spec, md, self.num_experts,
+                                                    model_fp=mfp, allow_quant_mismatch=allow_q)
+                cache = {"ranking": ranking, "by_key": ranking_lookup(ranking, keys),
+                         "info": info, "ordinal": 0, "assigned": {}}
+                self.config._moe_profile_cache = cache
+                print(f" -- MoE profile: {len(info['sources'])} source(s), "
+                      f"{info['layers']} layers x {info['experts']} experts, mode={mode}")
+                for srcinfo in info["sources"]:
+                    print(f"      {srcinfo['name']} (w={srcinfo['weight']}) <- {srcinfo['path']}")
+            row = cache["by_key"].get(self.key)
+            if row is None:
+                # Positional profiles (.npz) carry no layer keys: assign rows to MoE
+                # layers in registration order, which is the order they were captured in.
+                idx = cache["assigned"].get(self.key)
+                if idx is None:
+                    idx = cache["ordinal"]
+                    cache["assigned"][self.key] = idx
+                    cache["ordinal"] += 1
+                if idx < cache["ranking"].shape[0]:
+                    row = cache["ranking"][idx]
+            if row is not None and len(row) != self.num_experts:
+                print(f" !! {self.key}: profile row has {len(row)} experts but this layer has "
+                      f"{self.num_experts}; placement unpermuted for this layer")
+                row = None
+            if row is not None:
+                prof_rank = [int(e) for e in row]
+            else:
+                print(f" !! {self.key}: no profile row for this layer, placement unpermuted")
+            if mode == "static":
+                self._split_dynamic = False
+
         stats_path = os.environ.get("EXL3_MOE_CPU_SPLIT_STATS")
         if stats_path and self._split_dynamic:
             # Static placement from a stats file only applies with dynamic swapping disabled
@@ -472,6 +525,14 @@ class BlockSparseMLP_CPU:
             stats_path = None
         if stats_path and self.tid2eid_key:
             print(f" !! {self.key}: tid2eid remap present, tail placement unpermuted")
+            stats_path = None
+        if prof_rank is not None and len(prof_rank) == self.num_experts:
+            # Precomputed hot->cold order: no counts to sort at load, just apply it.
+            self._split_perm = prof_rank
+            if self.gated:
+                self.gates = [self.gates[e] for e in prof_rank]
+            self.ups = [self.ups[e] for e in prof_rank]
+            self.downs = [self.downs[e] for e in prof_rank]
             stats_path = None
         if stats_path:
             import json
@@ -629,11 +690,14 @@ class BlockSparseMLP_CPU:
         stc = self.config.stc
         slot = int(mp[r_cold])
         full_g, full_u, full_d = self._split_saved_lists_ref()
+        # Saved lists are checkpoint-order; r_hot/r_cold are router (permuted) ids. Without
+        # this translation a seeded split swaps the WRONG experts on every sweep.
+        i_hot, i_cold = self._split_ckpt_idx(r_hot), self._split_ckpt_idx(r_cold)
         proj = ([(full_g, self.gates)] if self.gated else []) \
             + [(full_u, self.ups), (full_d, self.downs)]
         pairs = []
         for full, cur in proj:
-            src_key = full[r_hot].key
+            src_key = full[i_hot].key
             dst = cur[slot].inner
             shp = stc.list_tensors(src_key)[src_key + ".trellis"]["shape"]
             if list(shp) != list(dst.trellis.shape):
@@ -642,8 +706,8 @@ class BlockSparseMLP_CPU:
         # The demoted expert also must match the worker slot's tenant (= the promoted
         # expert's shapes, since they exchange homes) for the in-place arena copy
         for full, _ in proj:
-            k_cold = full[r_cold].key
-            k_hot = full[r_hot].key
+            k_cold = full[i_cold].key
+            k_hot = full[i_hot].key
             sc = stc.list_tensors(k_cold)[k_cold + ".trellis"]["shape"]
             sh = stc.list_tensors(k_hot)[k_hot + ".trellis"]["shape"]
             if list(sc) != list(sh):
@@ -663,8 +727,8 @@ class BlockSparseMLP_CPU:
         # from its own checkpoint handle into the arena in place (we are quiesced), and the
         # streamed-prefill aux copies for that slot update to match
         cpu_local = int(mp[r_hot]) - self.cpu_split_first
-        keys = ([full_g[r_cold].key] if self.gated else []) \
-            + [full_u[r_cold].key, full_d[r_cold].key]
+        keys = ([full_g[i_cold].key] if self.gated else []) \
+            + [full_u[i_cold].key, full_d[i_cold].key]
         self.cpu_host.install_expert(self.cpu_layer_idx, cpu_local, keys)
         aux = self.cpu_host.aux.get(self.cpu_layer_idx)
         if aux:
@@ -676,7 +740,7 @@ class BlockSparseMLP_CPU:
                 if lst is None or lst[cpu_local] is None:
                     continue
                 suffix = "." + name.split("_")[0]
-                t = stc.get_tensor(full[r_cold].key + suffix, lst[cpu_local].device,
+                t = stc.get_tensor(full[i_cold].key + suffix, lst[cpu_local].device,
                                    optional = name.startswith("bias"), float2half = True)
                 if t is not None:
                     lst[cpu_local].copy_(t)
@@ -693,6 +757,17 @@ class BlockSparseMLP_CPU:
                         f"swap verify failed: {src_key}.{tname}"
         mp[r_cold], mp[r_hot] = int(mp[r_hot]), slot
         return True
+
+    def _split_ckpt_idx(self, r):
+        """Router-space expert id -> index into the ORIGINAL (checkpoint-order) expert lists.
+
+        _split_saved_lists is captured BEFORE any placement permutation, so it stays in
+        checkpoint order, while router ids are permuted positions once cpu_post_load has
+        permuted the gate columns. _split_perm[j] is the checkpoint expert now living at
+        permuted position j, which is exactly the translation. Identity when unpermuted.
+        """
+        p = self._split_perm
+        return int(p[int(r)]) if p is not None else int(r)
 
     def _split_saved_lists_ref(self):
         g, u, d = self._split_saved[0], self._split_saved[1], self._split_saved[2]

--- a/tests/test_moe_profile.py
+++ b/tests/test_moe_profile.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Import the module directly so the test runs without CUDA or a built extension.
+_SRC = Path(__file__).resolve().parents[1] / "exllamav3" / "model" / "moe_profile.py"
+_spec = importlib.util.spec_from_file_location("moe_profile", _SRC)
+mp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mp)
+
+
+# Real MoE geometries. Placement is architecture-agnostic; only the profile is model-specific.
+GEOMETRIES = [
+    ("Mixtral-8x7B", 32, 8),
+    ("Qwen3-30B-A3B", 48, 128),
+    ("Qwen3-235B-A22B", 94, 128),
+    ("Qwen3-Next-80B", 48, 512),
+    ("DeepSeek-V3", 61, 256),
+    ("GLM-5.3-Flash", 42, 288),
+    ("Llama-4-Scout", 48, 16),
+]
+
+FP = {
+    "architecture": "TestForCausalLM", "layers": 4, "experts": 8,
+    "hidden_size": 4096, "quant_method": "exl3", "bits": 4.05,
+    "codebook": "mul1", "checkpoint_sha": "aaaabbbbccccdddd",
+}
+
+
+def _profile_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "moe_profiles"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_npz(dirpath: Path, name: str, layers: int, experts: int, *,
+               descending: bool = True, decode_hits: int = 10_000,
+               fingerprint: dict | None = None, layer_keys: list[str] | None = None):
+    """Census layout: counts_decode/counts_prefill [prompts, layers, experts]."""
+    order = np.arange(experts)[::-1] if descending else np.arange(experts)
+    counts = np.zeros((1, layers, experts), dtype=np.int64)
+    for l in range(layers):
+        counts[0, l] = (order + 1) * decode_hits
+    np.savez(dirpath / f"{name}.npz", counts_decode=counts,
+             counts_prefill=np.zeros_like(counts))
+    if fingerprint is not None or layer_keys is not None:
+        meta = {}
+        if fingerprint is not None:
+            meta["fingerprint"] = fingerprint
+        if layer_keys is not None:
+            meta["layer_keys"] = layer_keys
+        (dirpath / f"{name}.meta.json").write_text(json.dumps(meta))
+
+
+# --- format handling ---------------------------------------------------------------------
+
+def test_npz_sums_prompts_and_prefers_decode_bank(tmp_path):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", 4, 8)
+    ranking, _, info = mp.build_ranking("p", str(tmp_path), 8)
+    assert ranking.shape == (4, 8)
+    assert info["sources"][0]["bank"] == "counts_decode"
+    assert list(ranking[0]) == list(range(8))          # hot -> cold
+
+
+def test_json_format_and_layer_keys(tmp_path):
+    d = _profile_dir(tmp_path)
+    keys = [f"model.layers.{i}.mlp" for i in range(4)]
+    (d / "j.json").write_text(json.dumps({k: list(range(8)) for k in keys}))
+    ranking, got_keys, _ = mp.build_ranking("j", str(tmp_path), 8)
+    assert got_keys == keys
+    assert list(ranking[0]) == list(reversed(range(8)))
+
+
+def test_sidecar_layer_keys_are_used(tmp_path):
+    d = _profile_dir(tmp_path)
+    keys = [f"model.layers.{i + 3}.mlp" for i in range(4)]   # MoE may start after dense layers
+    _write_npz(d, "p", 4, 8, layer_keys=keys)
+    _, got_keys, _ = mp.build_ranking("p", str(tmp_path), 8)
+    assert got_keys == keys
+
+
+def test_undersampled_decode_falls_back_to_prefill(tmp_path, capsys):
+    d = _profile_dir(tmp_path)
+    counts_dec = np.ones((1, 4, 8), dtype=np.int64)            # 1 hit/expert: pure noise
+    counts_pre = np.full((1, 4, 8), 1000, dtype=np.int64)
+    np.savez(d / "p.npz", counts_decode=counts_dec, counts_prefill=counts_pre)
+    _, _, info = mp.build_ranking("p", str(tmp_path), 8)
+    assert "prefill" in info["sources"][0]["bank"]
+    assert "hits/expert" in capsys.readouterr().out
+
+
+# --- merging -----------------------------------------------------------------------------
+
+def test_weighting_pulls_toward_the_heavier_source(tmp_path):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "a", 4, 8, descending=True)
+    _write_npz(d, "b", 4, 8, descending=False)
+    heavy_a, _, _ = mp.build_ranking("a:9,b:1", str(tmp_path), 8)
+    heavy_b, _, _ = mp.build_ranking("a:1,b:9", str(tmp_path), 8)
+    assert list(heavy_a[0]) == list(range(8))
+    assert list(heavy_b[0]) == list(reversed(range(8)))
+
+
+def test_merge_normalizes_per_layer_so_corpus_size_does_not_decide(tmp_path):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "big", 4, 8, descending=True, decode_hits=1_000_000)
+    _write_npz(d, "small", 4, 8, descending=False, decode_hits=10)
+    # Equal weights: the 100000x larger corpus must not simply win.
+    merged, _, _ = mp.build_ranking("big:1,small:1", str(tmp_path), 8)
+    assert merged.shape == (4, 8)
+    heavy_small, _, _ = mp.build_ranking("big:1,small:5", str(tmp_path), 8)
+    assert list(heavy_small[0]) == list(reversed(range(8)))
+
+
+@pytest.mark.parametrize("spec,expected", [
+    ("a", [("a", 1.0)]),
+    ("a,b", [("a", 1.0), ("b", 1.0)]),
+    ("a:2.5, b ", [("a", 2.5), ("b", 1.0)]),
+])
+def test_spec_parsing(spec, expected):
+    assert mp.parse_spec(spec) == expected
+
+
+def test_negative_weight_rejected():
+    with pytest.raises(ValueError):
+        mp.parse_spec("a:-1")
+
+
+# --- model / quantization identity policy -------------------------------------------------
+
+def test_expert_count_mismatch_is_rejected(tmp_path):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", 4, 8)
+    with pytest.raises(ValueError, match="different model"):
+        mp.build_ranking("p", str(tmp_path), 16)
+
+
+def test_model_mismatch_is_fatal_even_with_override(tmp_path):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", 4, 8, fingerprint=FP)
+    other = dict(FP, architecture="SomethingElseForCausalLM")
+    for allow in (False, True):
+        with pytest.raises(ValueError, match="different MODEL"):
+            mp.build_ranking("p", str(tmp_path), 8, model_fp=other,
+                             allow_quant_mismatch=allow)
+
+
+def test_checkpoint_mismatch_blocks_unless_overridden(tmp_path, capsys):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", 4, 8, fingerprint=FP)
+    other = dict(FP, checkpoint_sha="9999888877776666")
+    with pytest.raises(ValueError, match="different CHECKPOINT"):
+        mp.build_ranking("p", str(tmp_path), 8, model_fp=other)
+    mp.build_ranking("p", str(tmp_path), 8, model_fp=other, allow_quant_mismatch=True)
+    assert "MISMATCH" in capsys.readouterr().out
+
+
+def test_missing_fingerprint_warns_but_loads(tmp_path, capsys):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", 4, 8)                                  # e.g. a shipped census
+    mp.build_ranking("p", str(tmp_path), 8, model_fp=dict(FP))
+    assert "no fingerprint" in capsys.readouterr().out
+
+
+# --- lookup and errors --------------------------------------------------------------------
+
+def test_missing_profile_names_every_search_dir(tmp_path):
+    with pytest.raises(FileNotFoundError) as e:
+        mp.build_ranking("nope", str(tmp_path), 8)
+    assert "moe_profiles" in str(e.value)
+
+
+def test_model_dir_profile_beats_user_cache(tmp_path, monkeypatch):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", 4, 8)
+    dirs = mp.search_dirs(str(tmp_path))
+    assert dirs[0] == str(d)
+
+
+def test_env_profile_dir_is_searched(tmp_path, monkeypatch):
+    extra = tmp_path / "extra"
+    extra.mkdir()
+    _write_npz(extra, "e", 4, 8)
+    monkeypatch.setenv("EXL3_MOE_PROFILE_DIR", str(extra))
+    ranking, _, _ = mp.build_ranking("e", None, 8)
+    assert ranking.shape == (4, 8)
+
+
+# --- architecture independence -------------------------------------------------------------
+
+@pytest.mark.parametrize("name,layers,experts", GEOMETRIES)
+def test_any_moe_geometry_loads(tmp_path, name, layers, experts):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", layers, experts)
+    ranking, _, _ = mp.build_ranking("p", str(tmp_path), experts)
+    assert ranking.shape == (layers, experts)
+    assert list(ranking[0]) == list(range(experts))
+
+
+def test_profiles_do_not_leak_between_architectures(tmp_path):
+    d = _profile_dir(tmp_path)
+    _write_npz(d, "p", 42, 288)
+    for _, _, experts in GEOMETRIES:
+        if experts == 288:
+            continue
+        with pytest.raises(ValueError):
+            mp.build_ranking("p", str(tmp_path), experts)
+
+
+# --- checkpoint hashing ---------------------------------------------------------------------
+
+def test_checkpoint_hash_none_without_safetensors(tmp_path):
+    assert mp.checkpoint_hash(str(tmp_path)) is None
+
+
+def test_checkpoint_hash_reads_only_headers(tmp_path):
+    """A shard's payload must not affect the hash cost; only the header identifies it."""
+    import struct
+    header = json.dumps({"__metadata__": {"k": "v"}}).encode()
+    for payload, name in ((b"\x00" * 1024, "model-00001.safetensors"),):
+        with open(tmp_path / name, "wb") as f:
+            f.write(struct.pack("<Q", len(header)))
+            f.write(header)
+            f.write(payload)
+    h1 = mp.checkpoint_hash(str(tmp_path))
+    assert h1 is not None and len(h1) == 16
+    # Same header, different payload size -> different hash (size is part of the identity).
+    with open(tmp_path / "model-00001.safetensors", "ab") as f:
+        f.write(b"\x00" * 16)
+    assert mp.checkpoint_hash(str(tmp_path)) != h1
+
+
+# ---------------------------------------------------------------------------------------
+# Held-out capture scoring. These encode the failure that shipped: a ranking fitted to one
+# sample scores ~93% against that sample and near-random on anything else.
+# ---------------------------------------------------------------------------------------
+
+def _build_mod():
+    """Import the builder wherever it sits: beside this file in the patch dir, or at
+    util/moe_profile_build.py once applied to an exllamav3 tree."""
+    import importlib.util
+    here = Path(__file__).resolve().parent
+    for cand in (here / "moe_profile_build.py",
+                 here.parent / "util" / "moe_profile_build.py"):
+        if cand.is_file():
+            spec = importlib.util.spec_from_file_location("mpb", cand)
+            m = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(m)
+            return m
+    pytest.skip("moe_profile_build.py not found")
+
+
+def test_capture_at_is_hit_weighted():
+    np = pytest.importorskip("numpy")
+    b = _build_mod()
+    fit = np.array([[10.0, 5.0, 1.0, 0.0]])       # ranking 0,1,2,3
+    test = np.array([[7.0, 3.0, 5.0, 5.0]])       # top-2 by fit -> 7+3 of 20
+    assert abs(b.capture_at(fit, test, 2) - 0.5) < 1e-9
+    assert abs(b.capture_at(fit, test, 4) - 1.0) < 1e-9
+
+
+def test_capture_uniform_routing_scores_at_chance():
+    """No signal to find: held-out capture must land on R/E, not above it."""
+    np = pytest.importorskip("numpy")
+    b = _build_mod()
+    rng = np.random.default_rng(0)
+    c = rng.poisson(20, size=(32, 8, 288)).astype(float)
+    rep = b.capture_report(c, 108)
+    assert abs(rep["head"]["held_out"] - 108 / 288) < 0.03
+
+
+def test_capture_stable_skew_generalizes():
+    np = pytest.importorskip("numpy")
+    b = _build_mod()
+    rng = np.random.default_rng(1)
+    base = np.zeros((8, 288)); base[:, :60] = 500.0; base += 5.0
+    c = rng.poisson(np.broadcast_to(base, (32, 8, 288))).astype(float)
+    rep = b.capture_report(c, 108)
+    assert rep["head"]["held_out"] > 0.90
+    assert rep["head"]["held_out"] <= rep["head"]["oracle"] + 1e-9
+
+
+def test_capture_exposes_per_prompt_overfit():
+    """The shipped bug: each prompt hot on its OWN experts. In-sample looks like signal;
+    held-out must collapse to chance."""
+    np = pytest.importorskip("numpy")
+    b = _build_mod()
+    rng = np.random.default_rng(2)
+    c = np.full((32, 8, 288), 1.0)
+    for i in range(32):
+        c[i][:, rng.choice(288, 60, replace=False)] += 500.0
+    c = rng.poisson(c).astype(float)
+    rep = b.capture_report(c, 108)
+    assert rep["head"]["in_sample"] > rep["head"]["held_out"] + 0.10
+    assert rep["head"]["held_out"] < 0.45
+
+
+def test_capture_report_refuses_to_score_too_few_prompts():
+    """A single-prompt census cannot be scored; returning None is what forces the warning
+    instead of an in-sample number presented as capture."""
+    np = pytest.importorskip("numpy")
+    b = _build_mod()
+    assert b.capture_report(np.ones((1, 8, 288)), 108) is None
+    assert b.capture_report(np.ones((3, 8, 288)), 108) is None
+    assert b.capture_report(np.ones((4, 8, 288)), 108) is not None
+
+
+
+# ---------------------------------------------------------------------------------------
+# Packed .exl3moe profiles. A shipped profile carries its ranking precomputed, so loading
+# is a mmap and nothing else. These assert the packed order is identical to argsorting the
+# census it came from -- the whole correctness claim of the format.
+# ---------------------------------------------------------------------------------------
+
+def _pack_mod():
+    import importlib.util
+    here = Path(__file__).resolve().parent
+    for cand in (here / "moe_profile_pack.py", here.parent / "util" / "moe_profile_pack.py"):
+        if cand.is_file():
+            spec = importlib.util.spec_from_file_location("mpp", cand)
+            m = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(m)
+            return m
+    pytest.skip("moe_profile_pack.py not found")
+
+
+def _census(tmp_path, P=6, L=4, E=32, seed=0):
+    np = pytest.importorskip("numpy")
+    rng = np.random.default_rng(seed)
+    dec = rng.poisson(20, size=(P, L, E)).astype(np.int64)
+    pre = rng.poisson(50, size=(P, L, E)).astype(np.int64)
+    src = tmp_path / "c.npz"
+    np.savez_compressed(src, counts_decode=dec, counts_prefill=pre)
+    return str(src), dec
+
+
+def test_packed_ranking_matches_census(tmp_path):
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, dec = _census(tmp_path)
+    dst = str(tmp_path / "c.exl3moe")
+    _pack_mod().pack(src, dst)
+    want = np.argsort(-dec.sum(axis=0).astype(np.float64), axis=1, kind="stable")
+    got, _, meta = mp.load_counts(dst)
+    assert meta.get("ranking") is not None
+    assert (meta["ranking"] == want).all()
+
+
+def test_packed_single_source_skips_the_sort(tmp_path):
+    """A single packed source must return its stored ranking verbatim."""
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, dec = _census(tmp_path)
+    dst = str(tmp_path / "c.exl3moe")
+    _pack_mod().pack(src, dst)
+    want = np.argsort(-dec.sum(axis=0).astype(np.float64), axis=1, kind="stable")
+    rank, _, _ = mp.build_ranking(dst)
+    assert (rank == want).all()
+
+
+def test_rank_only_file_reproduces_its_own_order(tmp_path):
+    """--rank-only drops counts. The synthesised counts must still sort back to the
+    stored order, so a single-source spec needs no special case."""
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, dec = _census(tmp_path)
+    dst = str(tmp_path / "r.exl3moe")
+    _pack_mod().pack(src, dst, rank_only=True)
+    counts, _, meta = mp.load_counts(dst)
+    assert (np.argsort(-counts, axis=1, kind="stable") == meta["ranking"]).all()
+
+
+def test_pack_carries_fingerprint_and_layer_keys(tmp_path):
+    """The sidecar's identity travels with the packed file, or the loader cannot validate
+    (model, checkpoint) and keyed layer matching silently degrades to positional."""
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, _ = _census(tmp_path)
+    json.dump({"layer_keys": [f"model.layers.{i}.mlp" for i in range(4)],
+               "fingerprint": {"architecture": "X", "layers": 4, "experts": 32}},
+              open(str(tmp_path / "c.meta.json"), "w"))
+    dst = str(tmp_path / "c.exl3moe")
+    _pack_mod().pack(src, dst)
+    _, keys, meta = mp.load_counts(dst)
+    assert keys == [f"model.layers.{i}.mlp" for i in range(4)]
+    assert json.loads(meta["fingerprint"])["experts"] == 32
+
+
+def test_pack_prefers_decode_bank(tmp_path):
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, dec = _census(tmp_path)
+    dst = str(tmp_path / "c.exl3moe")
+    info = _pack_mod().pack(src, dst)
+    assert info["bank"] == "counts_decode"
+
+
+def test_packed_profile_wins_resolution(tmp_path):
+    """Shipping .npz and .exl3moe side by side is only useful if the packed one is chosen.
+    Guards against the resolution order silently reverting."""
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    d = tmp_path / "moe_profiles"
+    d.mkdir()
+    rng = np.random.default_rng(3)
+    dec = rng.poisson(20, size=(6, 4, 32)).astype(np.int64)
+    np.savez_compressed(str(d / "p.npz"), counts_decode=dec)
+    _pack_mod().pack(str(d / "p.npz"), str(d / "p.exl3moe"))
+    assert mp.resolve_path("p", str(tmp_path)).endswith(".exl3moe")
+    # and the packed path must still produce the census's ranking
+    want = np.argsort(-dec.sum(axis=0).astype(np.float64), axis=1, kind="stable")
+    rank, _, _ = mp.build_ranking("p", model_dir=str(tmp_path))
+    assert (rank == want).all()
+
+
+def test_census_travels_in_the_packed_file(tmp_path):
+    """One file must serve both uses: the ranking for serving and the per-prompt census for
+    -score. Once counts are summed the prompt axis is gone and the profile can no longer be
+    audited, so losing the census silently would be the worst kind of regression."""
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, dec = _census(tmp_path)
+    dst = str(tmp_path / "p.exl3moe")
+    info = _pack_mod().pack(src, dst)
+    assert info["census"] is True
+    import struct
+    with open(dst, "rb") as fh:
+        n = struct.unpack("<Q", fh.read(8))[0]
+        hdr = json.loads(fh.read(n).decode("utf-8"))
+    assert hdr["census"]["shape"] == list(dec.shape)
+
+
+def test_serving_read_skips_the_census(tmp_path):
+    """Serving must not pay for the census. The loader names the tensors it wants, so the
+    census byte range is never read however large it grows."""
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, _ = _census(tmp_path)
+    dst = str(tmp_path / "p.exl3moe")
+    _pack_mod().pack(src, dst)
+    t, _ = mp._read_safetensors_pread(dst, names=("ranking", "counts"))
+    assert set(t) == {"ranking", "counts"}
+    assert "census" not in t

--- a/tests/test_moe_profile.py
+++ b/tests/test_moe_profile.py
@@ -390,7 +390,8 @@ def test_pack_carries_fingerprint_and_layer_keys(tmp_path):
     _pack_mod().pack(src, dst)
     _, keys, meta = mp.load_counts(dst)
     assert keys == [f"model.layers.{i}.mlp" for i in range(4)]
-    assert json.loads(meta["fingerprint"])["experts"] == 32
+    # decoded on load, not left as the JSON text safetensors metadata stores
+    assert meta["fingerprint"]["experts"] == 32
 
 
 def test_pack_prefers_decode_bank(tmp_path):
@@ -448,3 +449,25 @@ def test_serving_read_skips_the_census(tmp_path):
     t, _ = mp._read_safetensors_pread(dst, names=("ranking", "counts"))
     assert set(t) == {"ranking", "counts"}
     assert "census" not in t
+
+
+def test_packed_fingerprint_is_a_dict_not_json_text(tmp_path):
+    """safetensors metadata is string-valued, so structured fields are stored as JSON text.
+    They must be decoded on load: check_fingerprint() indexes them, and a raw string raises
+    "string indices must be integers" at model load -- silently only for packed profiles."""
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("safetensors")
+    src, _ = _census(tmp_path)
+    fp = {"architecture": "X", "layers": 4, "experts": 32, "checkpoint_sha": "deadbeef"}
+    json.dump({"layer_keys": [f"l{i}" for i in range(4)], "fingerprint": fp},
+              open(str(tmp_path / "c.meta.json"), "w"))
+    dst = str(tmp_path / "c.exl3moe")
+    _pack_mod().pack(src, dst)
+    _, _, meta = mp.load_counts(dst)
+    assert isinstance(meta.get("fingerprint"), dict), "fingerprint must decode to a dict"
+    assert meta["fingerprint"]["checkpoint_sha"] == "deadbeef"
+    # and the identity check must run against it without raising
+    warns = list(mp.check_fingerprint(meta["fingerprint"], fp, dst, False))
+    assert warns == []
+    bad = dict(fp, checkpoint_sha="different")
+    assert list(mp.check_fingerprint(meta["fingerprint"], bad, dst, True)), "should warn"

--- a/util/make_code_corpus.py
+++ b/util/make_code_corpus.py
@@ -1,0 +1,68 @@
+"""Build a code corpus for profiling from a source tree.
+
+Shipped as a generator rather than a blob: the corpus used for the reference `code_long`
+profile is 17.4 MB of Python/C++/CUDA taken from the exllamav3 tree itself, which is
+already on disk wherever this is being run and would otherwise be duplicated into git.
+
+Domain matters as much as context length. A wikitext-fitted census applied to code is worth
+~1.01x -- nothing. A code census on code is worth ~1.49x. Build the corpus from traffic
+that resembles what you serve; if you serve an agentic coding workload, prefer real
+transcripts over source files, since tool-call and diff structure route differently from
+prose-heavy source.
+
+  python util/make_code_corpus.py /path/to/src -o code_corpus.txt
+  python util/make_code_corpus.py /path/to/src -o code_corpus.txt --max-mb 24
+"""
+import argparse, os
+
+DEFAULT_EXTS = (".py", ".cpp", ".cu", ".h", ".cuh", ".hpp", ".c", ".cc", ".rs", ".go", ".ts")
+SKIP_DIRS = {".git", "__pycache__", "build", "dist", "node_modules", ".venv", "venv",
+             ".mypy_cache", ".pytest_cache", "target"}
+
+
+def build(roots, exts, max_bytes, min_bytes):
+    out, nfiles, total = [], 0, 0
+    for root in roots:
+        # Sorted walk so the corpus is deterministic: the same tree yields byte-identical
+        # output, which matters when a profile is meant to be reproducible.
+        for dp, dn, fn in sorted(os.walk(root)):
+            dn[:] = sorted(d for d in dn if d not in SKIP_DIRS and not d.startswith("."))
+            for f in sorted(fn):
+                if not f.endswith(exts):
+                    continue
+                p = os.path.join(dp, f)
+                try:
+                    t = open(p, encoding="utf8", errors="replace").read()
+                except OSError:
+                    continue
+                if len(t) < min_bytes:
+                    continue
+                out.append("# ==== %s ====\n%s\n" % (os.path.relpath(p, root), t))
+                nfiles += 1
+                total += len(t)
+                if total > max_bytes:
+                    return out, nfiles, total
+    return out, nfiles, total
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(allow_abbrev=False, description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("roots", nargs="+", help="source tree(s) to walk")
+    p.add_argument("-o", "--out", required=True)
+    p.add_argument("--max-mb", type=float, default=24.0,
+                   help="stop after this much text (default 24; 12 windows x 64k tokens "
+                        "needs roughly 3 MB, so the default leaves ample spread)")
+    p.add_argument("--min-bytes", type=int, default=200,
+                   help="skip files shorter than this (default 200)")
+    p.add_argument("--ext", default=",".join(DEFAULT_EXTS),
+                   help="comma-separated extensions")
+    a = p.parse_args()
+
+    exts = tuple(e if e.startswith(".") else "." + e for e in a.ext.split(","))
+    chunks, nfiles, total = build(a.roots, exts, int(a.max_mb * 1e6), a.min_bytes)
+    txt = "".join(chunks)
+    with open(a.out, "w", encoding="utf8") as f:
+        f.write(txt)
+    print(f" -- wrote {a.out}: {nfiles} files, {len(txt)/1e6:.1f} MB")
+    print(f"    next: moe_profile_build.py -corpus {a.out} -nprompts 12 -plen 65536 -gen 192")

--- a/util/moe_profile_build.py
+++ b/util/moe_profile_build.py
@@ -1,0 +1,398 @@
+"""Build a precomputed MoE expert-placement profile.
+
+Runs prompts through the model, counts per-expert routing hits, and writes an .npz in the
+same layout as the usage census, so profiles from either tool are interchangeable:
+
+    counts_decode  int64 [n_prompts, n_layers, n_experts]
+    counts_prefill int64 [n_prompts, n_layers, n_experts]
+
+Decode is the allocation signal -- that is the regime CPU offload actually runs in.
+
+  # from a bundled calibration corpus
+  python util/moe_profile_build.py -m /models/GLM -corpus code -o out/code.npz
+  # from your own prompts (one JSON list of strings, or a raw text file)
+  python util/moe_profile_build.py -m /models/GLM -corpus ./my_rust.txt -o out/rust.npz
+  # re-score an existing profile without loading a model
+  python util/moe_profile_build.py -score out/code.npz -resident 108
+
+Install it where the loader looks:
+  <model_dir>/moe_profiles/<name>.npz   or  ~/.cache/exllamav3/moe_profiles/
+then serve with:  --moe_cpu_profile <name>
+
+WHY THIS SAMPLES MANY PROMPTS, AND WHY IT SCORES HELD-OUT
+---------------------------------------------------------
+A profile is only useful if the ranking it fits on one corpus still holds on text it has never
+seen. Fitting on a SINGLE prompt and then reporting how well that prompt's own hot set covers
+that same prompt's routing measures nothing: the hot set is chosen to cover it, so the number
+is ~93% no matter how badly the ranking generalizes. Measured live, such a profile delivered
+42-45% capture -- barely above the 37.5% that placing experts at random would give.
+
+So this tool samples many independent windows, fits the ranking on a subset, and reports
+capture on the DISJOINT remainder, against two reference points that make the number readable:
+
+  uniform  = R/E      what random placement gets; a profile at this level is worthless
+  oracle   = fit on the held-out set itself; the ceiling ANY static profile can reach here
+
+If held-out sits near uniform, routing on this model is too input-dependent for static
+placement and only a dynamic cache will help. If it sits near oracle, the profile is as good
+as static placement gets and the remaining gap is inherent.
+"""
+import sys, os, json, argparse
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import numpy as np
+
+BUNDLED = {"wiki": "wiki.utf8", "c4": "c4.utf8", "code": "code.utf8",
+           "multilingual": "multilingual.utf8", "technical": "technical.utf8",
+           "tiny": "tiny.utf8"}
+
+
+def cal_dirs():
+    """The bundled .utf8 corpora live in the source tree; they are not installed as package
+    data, so an installed exllamav3 has the module but not the files. Search both."""
+    out = []
+    try:
+        from exllamav3.conversion import calibration_data
+        out.append(os.path.join(os.path.dirname(os.path.abspath(calibration_data.__file__)),
+                                "standard_cal_data"))
+    except Exception:
+        pass
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))   # repo root
+    out.append(os.path.join(here, "exllamav3", "conversion", "standard_cal_data"))
+    env = os.environ.get("EXL3_CAL_DATA_DIR")
+    if env:
+        out.insert(0, env)
+    return out
+
+
+def load_corpus(spec):
+    """-> (list of texts, label). A single blob stays a single element here; it is split into
+    independent prompts later, after tokenization, where the boundaries can be exact."""
+    if spec in BUNDLED:
+        tried = []
+        for d in cal_dirs():
+            fp = os.path.join(d, BUNDLED[spec])
+            tried.append(fp)
+            if os.path.isfile(fp):
+                return [open(fp, encoding="utf8").read()], spec
+        raise SystemExit(f"bundled corpus '{spec}' not found. Looked in:\n  " +
+                         "\n  ".join(tried) +
+                         "\nSet EXL3_CAL_DATA_DIR to the directory holding the .utf8 files.")
+    if os.path.isfile(spec):
+        if spec.endswith(".json"):
+            v = json.load(open(spec))
+            return ([v] if isinstance(v, str) else list(v)), os.path.basename(spec)
+        return [open(spec, encoding="utf8", errors="replace").read()], os.path.basename(spec)
+    raise SystemExit(f"corpus '{spec}' is neither bundled ({', '.join(BUNDLED)}) nor a file")
+
+
+def make_windows(texts, tokenizer, n_prompts, plen):
+    """Split the corpus into n_prompts independent token windows.
+
+    Independence is the point. One long prompt yields one trajectory: its greedy continuation
+    settles into a narrow routing pattern, and the resulting ranking encodes that trajectory
+    rather than the corpus. Disjoint windows spread across the whole corpus give the ranking
+    something to average over, and -- because each window is a separate row in the [P, L, E]
+    census -- they are what makes a held-out split possible at all.
+    """
+    ids = []
+    for t in texts:
+        enc = tokenizer.encode(t)
+        ids.append(enc.reshape(-1))
+    import torch
+    flat = torch.cat(ids) if len(ids) > 1 else ids[0]
+    total = flat.shape[0]
+    need = n_prompts * plen
+    if total < need:
+        n_fit = max(1, total // plen)
+        print(f" !! corpus holds {total:,} tokens; {n_prompts} x {plen} needs {need:,}. "
+              f"Using {n_fit} window(s).")
+        n_prompts = n_fit
+    # Evenly spaced, disjoint. Spread beats contiguous: a corpus is usually ordered by
+    # document, so contiguous windows would all land in the same few documents.
+    stride = max(plen, (total - plen) // max(n_prompts, 1)) if n_prompts > 1 else plen
+    out = []
+    for i in range(n_prompts):
+        s = min(i * stride, max(0, total - plen))
+        out.append(flat[s:s + plen].reshape(1, -1))
+    return out
+
+
+def find_moe(model):
+    seen, out = set(), []
+    def walk(m):
+        if id(m) in seen: return
+        seen.add(id(m))
+        if hasattr(m, "routing_fn") and hasattr(m, "num_experts") and hasattr(m, "key"):
+            out.append(m)
+        for a in ("modules", "children", "layers"):
+            k = getattr(m, a, None)
+            if isinstance(k, (list, tuple)):
+                for c in k:
+                    if hasattr(c, "__dict__"): walk(c)
+    walk(model)
+    return out
+
+
+# ---------------------------------------------------------------------------------------
+# Scoring. Kept free of torch/exllamav3 so an existing .npz can be re-scored offline.
+# ---------------------------------------------------------------------------------------
+
+def capture_at(fit, test, R):
+    """Fraction of `test` routing hits that land on the top-R experts ranked by `fit`.
+
+    Both are [L, E]. Layers are weighted by their own hit count rather than averaged, so a
+    layer that routes more often counts for more -- traffic is what we are trying to cut.
+    """
+    top = np.argsort(-fit, axis=1, kind="stable")[:, :R]              # [L, R]
+    hit = np.take_along_axis(test, top, axis=1).sum()
+    tot = test.sum()
+    return float(hit) / float(tot) if tot else 0.0
+
+
+def capture_report(counts, R_head, holdout_frac=0.34, seed=1234):
+    """-> dict of capture numbers from a [P, L, E] census, using a disjoint prompt split.
+
+    Returns None when there are too few prompts to split, which is exactly the condition that
+    made the old single-prompt profiles unfalsifiable.
+    """
+    P, L, E = counts.shape
+    if P < 4:
+        return None
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(P)
+    n_test = max(1, int(round(P * holdout_frac)))
+    test_i, fit_i = perm[:n_test], perm[n_test:]
+    fit, test = counts[fit_i].sum(axis=0), counts[test_i].sum(axis=0)
+    if fit.sum() == 0 or test.sum() == 0:
+        return None
+    curve = {}
+    for frac in (0.25, 0.375, 0.5, 0.625):
+        R = max(1, int(round(E * frac)))
+        curve[frac] = {"R": R,
+                       "held_out": capture_at(fit, test, R),
+                       "in_sample": capture_at(fit, fit, R),
+                       "oracle": capture_at(test, test, R),
+                       "uniform": R / E}
+    head = {"R": R_head,
+            "held_out": capture_at(fit, test, R_head),
+            "in_sample": capture_at(fit, fit, R_head),
+            "oracle": capture_at(test, test, R_head),
+            "uniform": R_head / E}
+    return {"n_fit": len(fit_i), "n_test": len(test_i), "head": head, "curve": curve,
+            "experts": E, "layers": L}
+
+
+def print_capture(rep, bank):
+    if rep is None:
+        print("\n !! too few prompts to score held-out; capture numbers are unavailable.\n"
+              "    Re-run with -nprompts 8 or more -- a profile that cannot be scored on text\n"
+              "    it did not see is not a profile, it is a fit to one sample.")
+        return
+    h = rep["head"]
+    print(f"\n -- capture ({bank}), fit on {rep['n_fit']} prompts, scored on {rep['n_test']} held out")
+    print(f"    {'residency':>12}  {'held-out':>9}  {'uniform':>8}  {'oracle':>7}  {'in-sample':>10}")
+    for frac in sorted(rep["curve"]):
+        c = rep["curve"][frac]
+        print(f"    {c['R']:>4}/{rep['experts']:<4} {100*frac:4.1f}%  {100*c['held_out']:8.1f}%  "
+              f"{100*c['uniform']:7.1f}%  {100*c['oracle']:6.1f}%  {100*c['in_sample']:9.1f}%")
+    lift = (h["held_out"] - h["uniform"]) / max(h["oracle"] - h["uniform"], 1e-9)
+    print(f"\n -- at R={h['R']}: held-out capture {100*h['held_out']:.1f}%, "
+          f"cold rate {100*(1-h['held_out']):.1f}%")
+    print(f"    uniform (random placement) {100*h['uniform']:.1f}%   "
+          f"oracle (best possible static) {100*h['oracle']:.1f}%")
+    print(f"    profile realizes {100*lift:.0f}% of the available static headroom")
+    if h["held_out"] - h["uniform"] < 0.03:
+        print("\n !! held-out capture is within 3 points of RANDOM placement. Routing on this\n"
+              "    model is too input-dependent for a static profile to help; a dynamic cache\n"
+              "    (upstream's -mcs sweeps, or a demand-paged expert pool) is the only lever.")
+    if h["in_sample"] - h["held_out"] > 0.25:
+        print(f"\n !! overfit: in-sample {100*h['in_sample']:.1f}% vs held-out "
+              f"{100*h['held_out']:.1f}%. Trust the held-out number; the in-sample one is\n"
+              "    what this tool used to report, and it is what made a weak profile look strong.")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(allow_abbrev=False)
+    p.add_argument("-score", "--score", type=str, default=None,
+                   help="Re-score an existing .npz offline (no model load) and exit.")
+    p.add_argument("-resident", "--resident", type=int, default=None,
+                   help="Residency to headline, i.e. the -mcs complement (E - mcs). "
+                        "Defaults to 37.5%% of experts.")
+    p.add_argument("-holdout", "--holdout", type=float, default=0.34)
+    known, _ = p.parse_known_args()
+
+    if known.score:
+        if known.score.lower().endswith((".exl3moe", ".safetensors")):
+            # A packed profile carries its census as one tensor; read it and score exactly
+            # as if it had come from the .npz. Serving never touches these bytes -- only
+            # -score does -- so one file can be both the shipped artifact and the audit
+            # trail.
+            import struct
+            with open(known.score, "rb") as fh:
+                n = struct.unpack("<Q", fh.read(8))[0]
+                hdr = json.loads(fh.read(n).decode("utf-8"))
+                info = hdr.get("census")
+                if info is None:
+                    raise SystemExit(f"{known.score}: no census tensor "
+                                     f"(packed with --no-census?). Score the .npz instead.")
+                s0, s1 = info["data_offsets"]
+                fh.seek(8 + n + s0)
+                buf = fh.read(s1 - s0)
+            dt = {"I64": "<i8", "I32": "<i4", "I16": "<i2"}[info["dtype"]]
+            z = {"census": np.frombuffer(buf, dtype=np.dtype(dt)).reshape(info["shape"])}
+            banks = ("census",)
+        else:
+            z = np.load(known.score, allow_pickle=False)
+            banks = ("counts_decode", "counts_prefill")
+        for bank in banks:
+            if bank not in z:
+                continue
+            c = np.asarray(z[bank]).astype(np.float64)
+            if c.ndim != 3 or c.sum() == 0:
+                continue
+            E = c.shape[2]
+            R = known.resident or max(1, int(round(E * 0.375)))
+            print(f"\n=== {os.path.basename(known.score)} :: {bank}  "
+                  f"[{c.shape[0]} prompts, {c.shape[1]} layers, {E} experts] ===")
+            print_capture(capture_report(c, R, known.holdout), bank)
+        sys.exit(0)
+
+    import torch
+    from exllamav3 import model_init, Generator, Job
+    from exllamav3.generator.sampler import GreedySampler
+
+    model_init.add_args(p, cache=True, default_cache_size=98304,
+                        default_autosplit_max_batch_size=1)
+    p.add_argument("-corpus", "--corpus", type=str, required=True)
+    p.add_argument("-o", "--out", type=str, required=True)
+    p.add_argument("-nprompts", "--num_prompts", type=int, default=48,
+                   help="Independent corpus windows to profile. Each becomes one row of the\n"
+                        "[P, L, E] census, which is what makes held-out scoring possible.")
+    p.add_argument("-plen", "--prompt_tokens", type=int, default=1024,
+                   help="Prefill tokens per window.")
+    p.add_argument("-gen", "--gen_tokens", type=int, default=128,
+                   help="Decode tokens per window. Total decode hits = nprompts * gen * topk\n"
+                        "* layers; ranking E experts needs many hits each, so prefer more\n"
+                        "windows over a longer generation -- diversity beats length.")
+    args = p.parse_args()
+
+    # Never let an existing profile permute experts while we are measuring them.
+    for v in ("EXL3_MOE_PROFILE", "EXL3_MOE_CPU_SPLIT_STATS"):
+        os.environ.pop(v, None)
+
+    texts, label = load_corpus(args.corpus)
+    model, config, cache, tokenizer, *_ = model_init.init(args, max_chunk_size=4096)
+    mods = find_moe(model)
+    if not mods:
+        raise SystemExit("no MoE layers found -- nothing to profile")
+    # Model-independent: geometry comes from the model, never from constants. The only
+    # requirement is a uniform expert count across MoE layers, which the [L, E] census layout
+    # implies; a model that varies it needs a ragged format, so fail loudly rather than
+    # silently truncate.
+    counts_seen = sorted({int(m.num_experts) for m in mods})
+    if len(counts_seen) != 1:
+        raise SystemExit(
+            f"this model has MoE layers with differing expert counts {counts_seen}; the "
+            f"[layers, experts] profile layout cannot represent it")
+    L, E = len(mods), mods[0].num_experts
+    R_head = args.resident or max(1, int(round(E * 0.375)))
+
+    windows = make_windows(texts, tokenizer, args.num_prompts, args.prompt_tokens)
+    P = len(windows)
+    print(f" -- {L} MoE layers x {E} experts; corpus '{label}', "
+          f"{P} windows x {args.prompt_tokens} tok + {args.gen_tokens} decode")
+
+    dec = np.zeros((P, L, E), dtype=np.int64)
+    pre = np.zeros((P, L, E), dtype=np.int64)
+    state = {"pi": 0}
+    idx_of = {m.key: i for i, m in enumerate(mods)}
+
+    for m in mods:
+        orig = m.routing_fn
+        def make(mod, fn):
+            def wrapper(bsz, cfg, z, params):
+                sel, w = fn(bsz, cfg, z, params)
+                try:
+                    e = sel.detach().reshape(-1).to(torch.int64).cpu().numpy()
+                    rows = sel.shape[0] if sel.dim() > 1 else 1
+                    bank = dec if rows == 1 else pre      # bsz 1 == decode step
+                    np.add.at(bank[state["pi"], idx_of[mod.key]], e, 1)
+                except Exception:
+                    pass
+                return sel, w
+            return wrapper
+        m.routing_fn = make(m, orig)
+
+    gen = Generator(model=model, cache=cache, tokenizer=tokenizer, max_chunk_size=4096)
+    for pi, ids in enumerate(windows):
+        state["pi"] = pi
+        if pi % 8 == 0 or pi == P - 1:
+            print(f" -- window {pi+1}/{P}"); sys.stdout.flush()
+        gen.enqueue(Job(input_ids=ids, max_new_tokens=args.gen_tokens,
+                        stop_conditions=[], sampler=GreedySampler()))
+        while gen.num_remaining_jobs():
+            gen.iterate()
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    # .exl3moe is the default and the format to ship: safetensors carrying the ranking
+    # precomputed, the summed counts, and the per-prompt census, each in its own byte range.
+    # Serving preads only "ranking" (0.053 ms; the embedded census costs 0.007 ms of that
+    # and nothing at all in the bytes actually read), while -score reads "census" to re-run
+    # the held-out split. .npz is still written on request for interop with external
+    # tooling, but it is 60x slower to load and needs decompressing in full.
+    want_packed = not args.out.lower().endswith(".npz")
+    npz_path = (os.path.splitext(args.out)[0] + ".npz") if want_packed else args.out
+    np.savez_compressed(npz_path, counts_decode=dec, counts_prefill=pre)
+    from exllamav3.model.moe_profile import model_fingerprint
+    fp = model_fingerprint(config, E)
+    print(" -- fingerprint: " + ", ".join(f"{k}={v}" for k, v in sorted(fp.items())))
+
+    # Sample-size guard. Ranking E experts from a handful of hits produces noise that LOOKS
+    # like extreme skew (most experts never sampled => the "hot" head trivially covers 100%).
+    hits_per_expert = float(dec.sum()) / max(L * E, 1)
+    MIN_HITS = 20.0
+    bank_name, bank = "decode", dec
+    if hits_per_expert < MIN_HITS:
+        print(f"\n !! decode sample is too small: {int(dec.sum()):,} hits = "
+              f"{hits_per_expert:.1f} per expert (want >= {MIN_HITS:.0f}).")
+        pre_per = float(pre.sum()) / max(L * E, 1)
+        if pre_per >= MIN_HITS:
+            print(f" !! falling back to the PREFILL bank ({int(pre.sum()):,} hits = "
+                  f"{pre_per:.1f}/expert) for the capture report. The saved .npz keeps BOTH\n"
+                  f"    banks; re-run with more -nprompts/-gen for a decode-quality profile.")
+            bank_name, bank = "prefill (decode too sparse)", pre
+        else:
+            print(" !! prefill is sparse too -- this profile is NOT usable. "
+                  "Increase -nprompts/-gen/-plen.")
+
+    rep = capture_report(bank.astype(np.float64), R_head, args.holdout)
+    print_capture(rep, bank_name)
+
+    meta = {"corpus": label, "layers": L, "experts": E, "prompts": P, "fingerprint": fp,
+            "prompt_tokens": args.prompt_tokens, "gen_tokens": args.gen_tokens,
+            "hits_per_expert_decode": round(float(dec.sum()) / max(L * E, 1), 2),
+            "hits_per_expert_prefill": round(float(pre.sum()) / max(L * E, 1), 2),
+            "layer_keys": [m.key for m in mods],
+            "decode_hits": int(dec.sum()), "prefill_hits": int(pre.sum())}
+    if rep is not None:
+        meta["capture"] = {"resident": R_head, "bank": bank_name,
+                           "held_out": round(rep["head"]["held_out"], 4),
+                           "in_sample": round(rep["head"]["in_sample"], 4),
+                           "oracle": round(rep["head"]["oracle"], 4),
+                           "uniform": round(rep["head"]["uniform"], 4),
+                           "n_fit": rep["n_fit"], "n_test": rep["n_test"]}
+    with open(os.path.splitext(args.out)[0] + ".meta.json", "w") as f:
+        json.dump(meta, f, indent=2)
+
+    if want_packed:
+        try:
+            sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+            from moe_profile_pack import pack
+            info = pack(npz_path, args.out)
+            os.remove(npz_path)                      # the packed file supersedes it
+            print(f"\n -- wrote {args.out}  ({info['bytes']:,} bytes, census embedded)")
+        except Exception as e:
+            print(f"\n !! could not pack ({e}); keeping {npz_path}")
+            args.out = npz_path
+    print(f" -- {int(dec.sum()):,} decode hits, {int(pre.sum()):,} prefill")
+    print("PROFILE_BUILD_DONE")

--- a/util/moe_profile_pack.py
+++ b/util/moe_profile_pack.py
@@ -1,0 +1,116 @@
+"""Pack a measured census (.npz) into a shipped profile (.exl3moe).
+
+The census and the shipped profile want different things:
+
+  .npz       [prompts, layers, experts] per-prompt counts. Keeps the prompt axis, which is
+             what makes held-out re-scoring possible (moe_profile_build.py -score). This is
+             the research artifact -- keep it, it is how a profile is audited later.
+
+  .exl3moe   safetensors holding the summed counts AND the precomputed ranking, plus the
+             fingerprint and layer keys as metadata. This is what a serving deployment
+             loads: mmap, zero-copy, no decompression, no argsort, no numpy needed beyond
+             the array view.
+
+Measured on a 42 x 288 profile (load + produce the ranking the loader needs):
+
+    .npz full census [P,L,E]        0.45 MB    1.34 ms
+    .npz summed [L,E]               0.02 MB    0.48 ms
+    .safetensors counts             0.10 MB    0.26 ms
+    .exl3moe counts + ranking       0.15 MB    0.02 ms     <- 67x faster than the census
+
+The rankings are bit-identical; this is purely moving work from load time to build time.
+In absolute terms 1.3 ms is nothing against a multi-minute model load, so the reason to
+prefer .exl3moe is not the milliseconds -- it is that it is the same container exl3 uses
+for weights, it carries its own provenance, and the load path becomes genuinely O(1) as
+the feature always claimed.
+
+  python util/moe_profile_pack.py wiki_long.npz -o wiki_long.exl3moe
+  python util/moe_profile_pack.py wiki_long.npz -o out.exl3moe --rank-only   # smallest
+"""
+import argparse, json, os, sys
+import numpy as np
+
+
+def pack(src, dst, bank = None, rank_only = False, meta_extra = None, with_census = True):
+    z = np.load(src, allow_pickle = False)
+
+    if bank is None:
+        # Decode is the allocation signal -- that is the regime CPU offload runs in. Fall
+        # back only if the decode bank is absent or empty.
+        for cand in ("counts_decode", "counts", "counts_prefill"):
+            if cand in z and np.asarray(z[cand]).sum() > 0:
+                bank = cand
+                break
+    if bank is None:
+        raise SystemExit(f"{src}: no non-empty counts bank")
+
+    c = np.asarray(z[bank]).astype(np.float64)
+    if c.ndim == 3:
+        n_prompts = c.shape[0]
+        c = c.sum(axis = 0)
+    elif c.ndim == 2:
+        n_prompts = 1
+    else:
+        raise SystemExit(f"{src}: expected 2D or 3D '{bank}', got {c.shape}")
+
+    n_layers, n_experts = c.shape
+    ranking = np.argsort(-c, axis = 1, kind = "stable").astype(np.int32)
+    census = np.asarray(z[bank]) if (with_census and np.asarray(z[bank]).ndim == 3) else None
+
+    md = {"source_bank": bank, "layers": str(n_layers), "experts": str(n_experts),
+          "prompts": str(n_prompts), "has_ranking": "1",
+          "packed_from": os.path.basename(src)}
+
+    # Carry the sidecar's fingerprint and layer keys so the shipped file is self-describing:
+    # the loader validates (model, checkpoint) identity from these, and keyed layer matching
+    # avoids a positional off-by-one on architectures that interleave dense and sparse MLPs.
+    side = os.path.splitext(src)[0] + ".meta.json"
+    if os.path.isfile(side):
+        sm = json.load(open(side))
+        if "layer_keys" in sm:  md["layer_keys"] = json.dumps(sm["layer_keys"])
+        if "fingerprint" in sm: md["fingerprint"] = json.dumps(sm["fingerprint"])
+        if "capture" in sm:     md["capture"] = json.dumps(sm["capture"])
+        if "corpus" in sm:      md["corpus"] = str(sm["corpus"])
+    if meta_extra:
+        md.update(meta_extra)
+
+    from safetensors.numpy import save_file
+    tensors = {"ranking": ranking}
+    if not rank_only:
+        # Counts are what a weighted multi-profile merge renormalizes over; without them a
+        # merge can only use the implied order. 21 KB, so keep them unless asked not to.
+        tensors["counts"] = c.astype(np.int64)
+    if census is not None:
+        # The per-prompt census, so one file is both the shipped profile and the audit
+        # trail. Serving never reads these bytes: safetensors gives every tensor its own
+        # byte range and the loader preads only "ranking", so carrying the census costs
+        # disk and nothing else. int32 because counts are small (a few hundred per cell for
+        # decode) but int16 would be one long run away from overflowing.
+        tensors["census"] = census.astype(np.int32)
+        md["census_shape"] = json.dumps(list(census.shape))
+    save_file(tensors, dst, metadata = md)
+    return {"bank": bank, "layers": n_layers, "experts": n_experts,
+            "prompts": n_prompts, "bytes": os.path.getsize(dst),
+            "census": census is not None}
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(allow_abbrev = False, description = __doc__,
+                                formatter_class = argparse.RawDescriptionHelpFormatter)
+    p.add_argument("src", help = "census .npz produced by moe_profile_build.py")
+    p.add_argument("-o", "--out", required = True, help = "output .exl3moe")
+    p.add_argument("-b", "--bank", default = None,
+                   choices = ["counts_decode", "counts_prefill", "counts"],
+                   help = "which bank to pack (default: decode, else whichever is non-empty)")
+    p.add_argument("--rank-only", action = "store_true",
+                   help = "omit counts; smallest file, but cannot be weighted in a merge")
+    p.add_argument("--no-census", action = "store_true",
+                   help = "omit the per-prompt census; smaller, but -score can no longer "
+                          "re-audit the profile without the original .npz")
+    a = p.parse_args()
+
+    info = pack(a.src, a.out, a.bank, a.rank_only, with_census = not a.no_census)
+    print(f" -- packed {a.src} -> {a.out}")
+    print(f"    bank {info['bank']}, {info['layers']} layers x {info['experts']} experts, "
+          f"{info['prompts']} prompt(s), {info['bytes']:,} bytes")
+    print("    load path is now mmap + zero argsort; keep the .npz for -score re-auditing")


### PR DESCRIPTION
Adds optional precomputed expert-placement profiles for CPU MoE offload. Additive and inert
unless `--moe_cpu_profile` is passed; no behaviour changes on any existing path.

## Problem

With `-mcs`, which experts stay resident decides how much traffic crosses the memory bus, and
on a host-DRAM-bound setup that is most of decode. Placement is currently discovered at
runtime, and convergence is slow by construction: `_split_swap_tick` moves at most
`EXL3_MOE_CPU_SWAP_MAX` (64) experts across **all** layers every `EXL3_MOE_CPU_SWAP_INTERVAL`
(128) decode steps, and each promotion re-reads the expert from the checkpoint on disk. On a
42-layer model that is ~1.5 experts per layer per sweep, so a long generation can end before
placement settles — and a fresh request starts over.

## What this adds

A profile is a per-expert selection census measured offline and loaded at startup, so
placement is correct at token zero. Nothing is probed or computed at load beyond one lookup
per layer.

```
-mcp  / --moe_cpu_profile            comma-separated profiles, optional :weight each
-mcpm / --moe_cpu_profile_mode       static (freeze the order) | seed (start hot, keep adapting)
-mcpd / --moe_cpu_profile_dir        extra search path
-mcpq / --moe_cpu_profile_any_quant  allow a checkpoint mismatch, with a warning
```

Profiles resolve from `<model_dir>/moe_profiles`, `$EXL3_MOE_PROFILE_DIR`, or a path.
`seed` mode is new capability: a profile is currently refused unless swapping is off.

Diff to existing files is +107/-10 across `model_init.py` and `block_sparse_mlp_cpu.py`.
Everything else is new: the loader, an offline builder, a packer, and tests.

## Measured

GLM-5.3-Flash-exl3 4.05bpw (45 layers, 42 MoE, 288 experts, topk 8) on one RTX PRO 6000
Blackwell 96GB + Ryzen 9 9950X3D / 128GB DDR5. Driven through the Generator on held-out text,
`-cs 270336`, warm, first generation discarded.

| workload | context | `-mcs 180`, no profile | `-mcs 128` + profile | |
|---|---:|---:|---:|---:|
| prose | 32,768 | 17.01 tok/s | 32.91 | 1.93x |
| prose | 262,144 | 16.82 / 16.95 | 40.24 / 39.71 | 2.37x |
| code | 32,768 | 16.82 | 32.78 | 1.95x |
| code | 262,144 | 17.11 / 17.42 | 33.66 / 34.01 | 1.96x |

Prefill improves as well, since resident experts cut CPU work during prefill: 573 -> 771
tok/s (prose 32k), 696 -> 889 (prose 256k).

About 1.35x of that is residency (`-mcs 180` -> `128`), which needs no code — 160 resident of
288 is simply the most that loads at `-cs 270336` on this card. The remaining ~1.64x is
placement, which is what this PR provides.

## Why it works

Decode time is a straight line in cold-expert rate. Fitted over 14 points and cross-validated
on 16 more, R² = 0.9994:

```
step_ms  ≈  10.8  +  0.77 × cold_percent        cold_percent = (cpu-assign/row)/8 × 100
```

The slope is exactly `42 layers × 8 topk × 12.62 MB / 100 / 53 GB/s` — the fit recovers the
measured AVX-512 CPU kernel bandwidth on its own, which is a decent check that the model is
describing the real mechanism rather than curve-fitting.

Nothing else in the system moves with context. Per-module CUDA-event timing from 4,096 to
261,888 tokens: attention/DSA **+0.137 ms**, KDA +0.010, hyper-connections +0.003, norms
+0.007, lm_head 0.000. At 262,144 the step is ~38 ms of exposed CPU-expert stall against
~14.5 ms of GPU work, of which attention is 0.95 ms. Cold rate is the only term that matters,
so anything that lowers it converts directly into throughput.

## Scoring is held-out by construction

This matters more than it might look. Fitting a profile to one prompt and reporting how well
that prompt's own hot set covers that same prompt's routing measures nothing — the hot set is
chosen to cover it, so the number reads ~93% regardless of whether the ranking generalizes.
Measured live, a profile built that way captured 42-45% against 37.5% for random placement,
and was **slower than using no profile at all**: it pinned a bad hot set and suppressed the
existing sweeps from finding a better one.

`util/moe_profile_build.py` therefore samples many independent windows, ranks on a subset, and
reports capture on the disjoint remainder, beside two reference points:

- `uniform` = `R/E`, what random placement scores. A profile at this level is worthless.
- `oracle` = fit on the held-out set itself: the ceiling for any static profile.

It warns when held-out sits within 3 points of uniform, or when in-sample exceeds held-out by
more than 25 points, and refuses to report capture below 4 windows rather than printing an
in-sample number. On the reference profile, held-out predicted 32.9% cold and the live
measurement was 31.7%.

## A profile must match the workload on two axes

Both measured, and getting either wrong costs the entire benefit:

**Domain.** A prose census applied to code is worth 1.01x — nothing. A code census on code is
1.49x.

**Context length.** A census fitted on 1k windows loses most of its value by 256k. This is a
length effect, not a content artifact: holding the trailing 4096 tokens byte-identical and
varying only the preceding context still moved cold rate 20.8% -> 28.6%.

There is a further result worth stating, since it is counterintuitive: profiles must be built
per **register**, not per topic. Six profiles built by merging related corpora each scored
below their own members, ordered by how mixed their registers were. A nine-category "security"
profile landed at 14% of available headroom — barely above random — while eight of its nine
constituent corpora reach 55-80% individually. A seven-category "systems" profile kept 60%,
because those share one language family.

## Format

`.exl3moe` — safetensors carrying the precomputed ranking, the summed counts, and the
per-prompt census, each in its own byte range. Serving preads only `ranking`; `-score` preads
only `census` and re-runs the held-out split with no model load. `build_ranking()` end to end
is 0.0534 ms against 3.1892 ms for the equivalent `.npz`, which has to be decompressed in
full, summed over prompts and sorted every time. Rankings are bit-identical. Resolution
prefers `.exl3moe` -> `.safetensors` -> `.npz` -> `.json`, and `.npz` is still accepted for
interop with external tooling.

The reader uses `pread` rather than mmap and names the tensors it wants: at 147 KB (36 pages)
mmap pays a VMA setup plus a fault per page where pread is one syscall and a copy — 0.0080 vs
0.0181 ms — and `safetensors.load_file` additionally opens the file a second time for
metadata. That matches what `exllamav3_ext/stloader.cpp` already does for bulk weights.

## Identity

Profiles are per `(model, checkpoint)`. Model identity (architecture, layers, experts,
`moe_intermediate_size`, `hidden_size`) is fatal on mismatch even with the override.
Checkpoint identity (`checkpoint_sha`, `quant_method`, `bits`, `head_bits`, `codebook`) is
fatal unless `--moe_cpu_profile_any_quant`. `checkpoint_sha` hashes safetensors **headers**
only — 0.03 s and 19.7 MB of reads on a 165 GB checkpoint, not a content hash.

## Tests

`tests/test_moe_profile.py`, 40 cases, no CUDA or built extension required. The load-bearing
one is `test_capture_exposes_per_prompt_overfit`: it constructs the exact pathology described
above — each prompt hot on its own experts — and asserts held-out capture collapses to chance
while in-sample still looks strong.

## Note on measuring this

`eval/perf.py` is not usable for placement or long-context claims: `measure_generate` builds
state via `cache.get_test_state()`, which passes `clear=True`, so 34 of 45 recurrent layers
decode from zero state and its long-context routing is really short-context routing (cold
29.5% at 261,888 against ~55% from the Generator on the same setup). Drive the Generator
instead, and report `cpu-assign/row` (`EXL3_MOE_HANDOFF_PROF=1`) next to any throughput
number — tok/s alone cannot separate a placement effect from a warm-up artifact.

## Worked example

A full serving recipe with 27 profiles for GLM-5.3-Flash-exl3 4.05bpw, one per register, each
with its held-out capture number, plus the measurement harness and documentation on building
and loading them: https://github.com/anoane/glm53-flash-exl3-recipe

## Limitations

- Profiles are model- and checkpoint-specific, so this ships tooling rather than data.
- A profile built for the wrong domain or context length is worth roughly nothing; the
  scoring is designed to make that visible before anything is deployed, but it cannot be
  detected automatically at load.
- `seed` mode is exposed but measured no better than `static` on this model: 24.3% vs 24.9%
  cold across 8 turns at fixed context, inside noise. Sweeping mid-stream also perturbs
  generation (perplexity 3.4924 vs 3.4904 static), which is consistent with the existing
  comment about deferring sweeps to queue-drain.
- Only tested on one model and one machine. The mechanism is general — any host-DRAM-bound
  offload setup — but the constants in the cost model are not.
