### PR TITLE
Contain per-job failures in Generator.iterate

### DIFF
--- a/exllamav3/generator/async_generator.py
+++ b/exllamav3/generator/async_generator.py
@@ -34,23 +34,7 @@ class AsyncGenerator:
                 # consumer (e.g. a disconnected client that stopped draining its queue) would wedge the whole
                 # generator (issue #227).
                 results = self.generator.iterate()
-                for result in results:
-                    job = result["job"]
-                    async_job = self.jobs.get(job)
-                    if not async_job:
-                        continue
-                    if result.get("stage") == "error":
-                        # Per-job failure contained by Generator.reap_failed_job. The raw
-                        # exception must go into the queue as an exception object, not as a
-                        # result dict: __aiter__ re-raises queued exceptions, which the
-                        # server surfaces as an error for this request. A dict here would
-                        # instead stream as a clean (empty) completion.
-                        async_job.put_result(result["error"])
-                        del self.jobs[job]
-                        continue
-                    async_job.put_result(result)
-                    if result["eos"]:
-                        del self.jobs[job]
+                self.deliver_results(results)
 
                 # Yield back to the event loop so result consumers and cancellation requests can run between
                 # generator iterations, even if the synchronous generator immediately has more work available.
@@ -68,6 +52,30 @@ class AsyncGenerator:
             for async_job in self.jobs.values():
                 async_job.put_result(e)
             self.jobs.clear()
+
+    def deliver_results(self, results):
+        """
+        Fan generator results out to the owning AsyncJob queues. Missing jobs can happen if a job
+        was cancelled after iterate() started. Delivery must never block: this single task serves
+        every job, so waiting on one stalled consumer would wedge the whole generator (issue #227).
+        """
+        for result in results:
+            job = result["job"]
+            async_job = self.jobs.get(job)
+            if not async_job:
+                continue
+            if result.get("stage") == "error":
+                # Per-job failure contained by Generator.reap_failed_job. The raw exception
+                # must go into the queue as an exception object, not as a result dict:
+                # __aiter__ re-raises queued exceptions, which the server surfaces as an
+                # error for this request. A dict here would instead stream as a clean
+                # (empty) completion.
+                async_job.put_result(result["error"])
+                del self.jobs[job]
+                continue
+            async_job.put_result(result)
+            if result["eos"]:
+                del self.jobs[job]
 
     def enqueue(self, job: AsyncJob):
         # The iteration task died on a generator exception; surface it to the new job's consumer immediately

--- a/exllamav3/generator/async_generator.py
+++ b/exllamav3/generator/async_generator.py
@@ -39,6 +39,15 @@ class AsyncGenerator:
                     async_job = self.jobs.get(job)
                     if not async_job:
                         continue
+                    if "error" in result:
+                        # Per-job failure contained by Generator.reap_failed_job. The raw
+                        # exception must go into the queue as an exception object, not as a
+                        # result dict: __aiter__ re-raises queued exceptions, which the
+                        # server surfaces as an error for this request. A dict here would
+                        # instead stream as a clean (empty) completion.
+                        async_job.put_result(result["error"])
+                        del self.jobs[job]
+                        continue
                     async_job.put_result(result)
                     if result["eos"]:
                         del self.jobs[job]

--- a/exllamav3/generator/async_generator.py
+++ b/exllamav3/generator/async_generator.py
@@ -39,7 +39,7 @@ class AsyncGenerator:
                     async_job = self.jobs.get(job)
                     if not async_job:
                         continue
-                    if "error" in result:
+                    if result.get("stage") == "error":
                         # Per-job failure contained by Generator.reap_failed_job. The raw
                         # exception must go into the queue as an exception object, not as a
                         # result dict: __aiter__ re-raises queued exceptions, which the

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 import torch
 from ..model.model import Model
 from ..cache.cache import Cache
@@ -6,6 +7,8 @@ from ..cache.recurrent import RecurrentCache
 from ..tokenizer.tokenizer import Tokenizer
 from ..constants import PAGE_SIZE
 from ..util import cuda_sync_active
+
+logger = logging.getLogger(__name__)
 from ..util.memory import malloc_trim
 from .pagetable import PageTable
 from .cpu_cache import CPUPageCache
@@ -1225,18 +1228,30 @@ class Generator:
         """
         Contain a per-job failure so the generator stays usable for other jobs: release the
         failed job's pages and recurrent state, drop it from the active set, and append an
-        error-tagged result. The async wrapper recognizes the tag and delivers the raw
-        exception to that job's consumer only (its __aiter__ re-raises queued exceptions),
-        instead of letting the failure escape to _run_iteration, which latches
-        AsyncGenerator.error permanently and kills the iteration task for every job.
+        error result carrying the standard serial/stage/eos fields. The async wrapper
+        delivers the raw exception to that job's consumer only (AsyncJob.__aiter__ re-raises
+        queued exceptions) and the sync generate() API raises it, instead of the failure
+        escaping to _run_iteration, which latches AsyncGenerator.error permanently and kills
+        the iteration task for every job.
         """
         try:
             job.deallocate_pages()
         except Exception:
-            pass
+            logger.error(
+                "reap_failed_job: deallocate_pages() raised while cleaning up failed "
+                "job %s; pages or recurrent state may be stranded",
+                job,
+                exc_info = True,
+            )
         if job in self.active_jobs:
             self.active_jobs.remove(job)
-        results.append({"job": job, "error": error})
+        results.append({
+            "job": job,
+            "serial": job.serial_number,
+            "stage": "error",
+            "eos": True,
+            "error": error,
+        })
 
 
     def iterate_start_jobs(self, results: list):
@@ -1470,6 +1485,12 @@ class Generator:
 
             for r in results:
                 idx = order[r["serial"]]
+                if r["stage"] == "error":
+                    # A per-job failure was contained by reap_failed_job; surface the
+                    # original exception to this caller rather than returning a silently
+                    # truncated completion. Jobs from the same batch that are still in
+                    # flight are left to the generator's normal queue handling.
+                    raise r["error"]
                 if r["stage"] == "streaming":
                     text = r.get("text", "")
                     completions[idx] += text

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -405,8 +405,11 @@ class Generator:
         self.iterate_start_jobs(results)
 
         # Perform one round of prefill
-        for job in self.active_jobs:
-            job.prefill(results)
+        for job in list(self.active_jobs):
+            try:
+                job.prefill(results)
+            except Exception as e:
+                self.reap_failed_job(job, e, results)
 
         # Recurrent checkpoints
         if self.recurrent_cache is not None:
@@ -1218,6 +1221,24 @@ class Generator:
             self.on_queue_drained()
 
 
+    def reap_failed_job(self, job, error, results: list):
+        """
+        Contain a per-job failure so the generator stays usable for other jobs: release the
+        failed job's pages and recurrent state, drop it from the active set, and append an
+        error-tagged result. The async wrapper recognizes the tag and delivers the raw
+        exception to that job's consumer only (its __aiter__ re-raises queued exceptions),
+        instead of letting the failure escape to _run_iteration, which latches
+        AsyncGenerator.error permanently and kills the iteration task for every job.
+        """
+        try:
+            job.deallocate_pages()
+        except Exception:
+            pass
+        if job in self.active_jobs:
+            self.active_jobs.remove(job)
+        results.append({"job": job, "error": error})
+
+
     def iterate_start_jobs(self, results: list):
         """
         Move pending jobs into the active set when batch and cache capacity allow.
@@ -1260,7 +1281,11 @@ class Generator:
                 job.activate()
 
                 # Allocate pages for job
-                job.allocate_pages()
+                try:
+                    job.allocate_pages()
+                except Exception as e:
+                    self.reap_failed_job(job, e, results)
+                    continue
                 current_max_batch += len(job.sequences)
 
                 r = {

--- a/tests/test_failure_containment.py
+++ b/tests/test_failure_containment.py
@@ -1,0 +1,132 @@
+"""
+Regression tests for per-job failure containment in Generator.
+
+A job whose allocate_pages() or prefill() raises must not take the generator
+down with it: the failure is contained by Generator.reap_failed_job, which
+releases the job's resources, drops it from the active set and emits an error
+result carrying the standard serial/stage/eos contract. Without containment
+the exception escapes to AsyncGenerator._run_iteration, which latches
+self.error permanently and makes the generator unusable for every subsequent
+job.
+
+No GPU or model is required: Generator is instantiated via __new__ and given
+stub jobs, so the test exercises only the scheduling/cleanup logic.
+"""
+
+import os
+import sys
+import unittest
+import logging
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from exllamav3.generator.generator import Generator
+
+
+class StubPagetable:
+    def num_unreferenced_pages(self):
+        return 1 << 30
+
+
+class StubSequence:
+    pass
+
+
+class StubJob:
+    def __init__(self, name, fail_in=None):
+        self.name = name
+        self.fail_in = fail_in
+        self.sequences = [StubSequence()]
+        self.serial_number = None
+        self.identifier = name
+        self.deallocated = False
+
+    def current_new_pages_required(self):
+        return 1
+
+    def activate(self):
+        pass
+
+    def allocate_pages(self):
+        if self.fail_in == "allocate_pages":
+            raise RuntimeError(f"allocation failure for {self.name}")
+
+    def prefill(self, results):
+        if self.fail_in == "prefill":
+            raise RuntimeError(f"prefill failure for {self.name}")
+
+    def deallocate_pages(self):
+        if self.fail_in == "deallocate_pages":
+            raise RuntimeError(f"deallocation failure for {self.name}")
+        self.deallocated = True
+
+
+def make_generator(pending, active=(), max_batch_size=16):
+    generator = Generator.__new__(Generator)
+    generator.pagetable = StubPagetable()
+    generator.pending_jobs = list(pending)
+    generator.active_jobs = list(active)
+    generator.max_batch_size = max_batch_size
+    return generator
+
+
+class FailureContainmentTest(unittest.TestCase):
+    def test_reap_result_contract(self):
+        job = StubJob("a")
+        job.serial_number = 7
+        generator = make_generator([], active=[job])
+        results = []
+        error = RuntimeError("boom")
+        generator.reap_failed_job(job, error, results)
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        self.assertIs(r["job"], job)
+        self.assertEqual(r["serial"], 7)
+        self.assertEqual(r["stage"], "error")
+        self.assertTrue(r["eos"])
+        self.assertIs(r["error"], error)
+        self.assertNotIn(job, generator.active_jobs)
+        self.assertTrue(job.deallocated)
+
+    def test_failing_allocate_pages_is_contained(self):
+        bad = StubJob("bad", fail_in="allocate_pages")
+        good = StubJob("good")
+        bad.serial_number = 1
+        good.serial_number = 2
+        generator = make_generator([bad, good])
+        results = []
+        generator.iterate_start_jobs(results)
+        self.assertNotIn(bad, generator.active_jobs)
+        self.assertIn(good, generator.active_jobs)
+        self.assertNotIn(good, generator.pending_jobs)
+        self.assertNotIn(bad, generator.pending_jobs)
+        error_results = [r for r in results if r.get("stage") == "error"]
+        self.assertEqual(len(error_results), 1)
+        self.assertIs(error_results[0]["job"], bad)
+        self.assertIsInstance(error_results[0]["error"], RuntimeError)
+        started = [r for r in results if r.get("stage") == "started"]
+        self.assertEqual(len(started), 1)
+        self.assertIs(started[0]["job"], good)
+
+    def test_deallocate_failure_is_contained_and_logged(self):
+        job = StubJob("a", fail_in="deallocate_pages")
+        job.serial_number = 3
+        generator = make_generator([], active=[job])
+        records = []
+
+        class Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        capture = Capture()
+        logging.getLogger("exllamav3.generator.generator").addHandler(capture)
+        try:
+            generator.reap_failed_job(job, RuntimeError("boom"), [])
+        finally:
+            logging.getLogger("exllamav3.generator.generator").removeHandler(capture)
+        self.assertNotIn(job, generator.active_jobs)
+        self.assertTrue(any("stranded" in r.getMessage() for r in records))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_failure_containment.py
+++ b/tests/test_failure_containment.py
@@ -20,7 +20,12 @@ import logging
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import torch
+
+from exllamav3 import ArgmaxSampler
 from exllamav3.generator.generator import Generator
+from exllamav3.generator.async_generator import AsyncGenerator
+from exllamav3.generator.job import Job
 
 
 class StubPagetable:
@@ -126,6 +131,89 @@ class FailureContainmentTest(unittest.TestCase):
             logging.getLogger("exllamav3.generator.generator").removeHandler(capture)
         self.assertNotIn(job, generator.active_jobs)
         self.assertTrue(any("stranded" in r.getMessage() for r in records))
+
+    def test_failing_prefill_is_contained_in_iterate(self):
+        bad = StubJob("bad", fail_in="prefill")
+        good = StubJob("good")
+        for i, job in enumerate((bad, good)):
+            job.serial_number = i
+        generator = make_generator([], active=[bad, good])
+        generator.cache = type("C", (), {"initialized": True})()
+        generator.draft_cache = None
+        generator.recurrent_cache = None
+        generator.draft_model = None
+        generator.ngram_match_min = 0
+        generator.visualizer = None
+        generator.iterate_gen = lambda results: None
+        results = generator.iterate()
+        self.assertNotIn(bad, generator.active_jobs)
+        self.assertIn(good, generator.active_jobs)
+        error_results = [r for r in results if r.get("stage") == "error"]
+        self.assertEqual(len(error_results), 1)
+        self.assertIs(error_results[0]["job"], bad)
+
+    def test_async_deliver_error_as_raw_exception(self):
+        job = object()
+        delivered = []
+
+        class StubAsyncJob:
+            def put_result(self, result):
+                delivered.append(result)
+
+        wrapper = AsyncGenerator.__new__(AsyncGenerator)
+        wrapper.jobs = {job: StubAsyncJob()}
+        error = RuntimeError("boom")
+        wrapper.deliver_results([{"job": job, "serial": 0, "stage": "error", "eos": True, "error": error}])
+        self.assertEqual(len(delivered), 1)
+        self.assertIs(delivered[0], error)
+        self.assertNotIn(job, wrapper.jobs)
+
+        # Normal results still pass through as dicts; eos removes the job
+        job2 = object()
+        wrapper.jobs = {job2: StubAsyncJob()}
+        wrapper.deliver_results([{"job": job2, "serial": 1, "stage": "streaming", "eos": False}])
+        self.assertIsInstance(delivered[1], dict)
+        self.assertIn(job2, wrapper.jobs)
+        wrapper.deliver_results([{"job": job2, "serial": 1, "stage": "eos", "eos": True}])
+        self.assertNotIn(job2, wrapper.jobs)
+
+    def test_sync_generate_raises_on_error_result(self):
+        generator = Generator.__new__(Generator)
+
+        def fake_enqueue(job):
+            job.serial_number = 0
+            return 0
+
+        remaining = iter([True, True, False])
+        error = RuntimeError("sync-raise-probe")
+
+        def fake_iterate():
+            return [{
+                "job": None,
+                "serial": 0,
+                "stage": "error",
+                "eos": True,
+                "error": error,
+            }]
+
+        generator.enqueue = fake_enqueue
+        generator.num_remaining_jobs = lambda: next(remaining)
+        generator.iterate = fake_iterate
+        generator.clear_queue = lambda: None
+
+        class StubTokenizer:
+            def encode(self, p, **kwargs):
+                return torch.tensor([[1, 2, 3]], dtype=torch.long)
+
+        generator.tokenizer = StubTokenizer()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            generator.generate(
+                "hello",
+                max_new_tokens=8,
+                sampler=ArgmaxSampler(),
+            )
+        self.assertIs(ctx.exception, error)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses #318.

`iterate_start_jobs` (via `job.allocate_pages()`) and the `job.prefill()` loop in `Generator.iterate` run unguarded. Any per-job exception there escapes to `AsyncGenerator._run_iteration`, which latches `self.error` permanently and ends the iteration task for every job (mechanism in #318). Observed in production serving as: one CUDA OOM during prefill, then every subsequent request failing until restart, while `/v1/models` keeps returning 200.

## Change

- New `Generator.reap_failed_job(job, error, results)`: releases the failed job's pages and recurrent state, drops it from `active_jobs`, and emits an error result.
- Guards at both sites (`allocate_pages` in `iterate_start_jobs`, and the prefill loop). On failure the job is reaped and the iteration continues with the remaining jobs.
- Error results carry the full result contract (`serial`, `stage: "error"`, `eos: True`, `error`). `enqueue()`'s docstring documents `serial` as present on started/prefill/streaming results, and the sync `generate()` reads all three keys.
- Async side: `deliver_results()` (extracted from `_run_iteration` for testability) queues the raw exception object for that job only, so `AsyncJob.__aiter__` re-raises it. Deliberately not a normal result dict — a dict with `eos: True` would stream to the consumer as a clean, empty completion.
- Sync side: `generate()` raises `r["error"]` on `stage == "error"` instead of treating it as a clean finish and returning a silently truncated completion.
- `deallocate_pages()` failing during reaping is logged with `exc_info` rather than swallowed.

## Deliberately not changed

Generation-stage failures remain unguarded and still reach the latch. Full coverage of `iterate_gen`'s shared-batch internals is a larger change, and post-containment the latch firing is a useful signal that a site was missed. Whether the latch should ever auto-recover is left as the design question in #318.

## Evidence

Fault-injection A/B (one `raise` in `Job.prefill` gated on prompt length; 4-slot pool; tables in #318): stock 1.4.5 wedges permanently at exactly pool-size incidents; this branch contains 7/7 incidents with the server serving after each.

Scope note: this PR alone does not protect *concurrent* requests when serving through TabbyAPI, because its consumer handler recreates the generator on any error and cancels in-flight jobs. That needs a companion downstream change (recreate only when `generator.error` is set), which will be submitted separately. The library-level guarantee — the generator keeps serving other jobs — is covered by `test_failing_prefill_is_contained_in_iterate`.

## Tests

`tests/test_failure_containment.py` — six stub-based tests, no GPU or model required (`Generator` via `__new__` with stub jobs): error-result contract, containment of a failing `allocate_pages` alongside a healthy job, containment of a failing `prefill` inside `iterate`, async delivery as a raw exception, sync `generate()` raising, and cleanup-failure logging.
