### PR TITLE
Fix recurrent-state slot leak in Job.allocate_pages

### DIFF
--- a/exllamav3/generator/job.py
+++ b/exllamav3/generator/job.py
@@ -1432,7 +1432,13 @@ class Job:
             allocated_pages, cached_pages, non_sequential_pages, stashed_recurrent_state = \
                 seq.allocate_pages(self.pagetable, self.generator.recurrent_cache, protected_hashes)
 
-            self.recurrent_state = None
+            # Free the previous state before acquiring a new one. A bare assignment drops
+            # the handle without returning the slot index to the cache free list, so every
+            # reallocation (multi-sequence jobs, resumption after eviction) permanently
+            # burns a slot; with num_slots == max_batch_size (default 4 on recurrent
+            # models) a few such jobs exhaust the pool. The rewind path already does this
+            # correctly via free_recurrent_state().
+            self.free_recurrent_state()
             if self.generator.recurrent_cache is not None:
                 if stashed_recurrent_state is None:
                     self.recurrent_state = self.generator.cache.get_new_state()


### PR DESCRIPTION
Found while auditing recurrent-state slot lifetime for #318. Independent of #319.

`Job.allocate_pages` drops the existing recurrent state with a bare assignment before acquiring a new handle:

```python
for seq in self.sequences:
    ...
    self.recurrent_state = None            # drops the handle
    if self.generator.recurrent_cache is not None:
        if stashed_recurrent_state is None:
            self.recurrent_state = self.generator.cache.get_new_state()   # pops a NEW slot
```

Slots are returned to the cache free list only via `state.free()` → `free_list.appendleft()`. The bare assignment releases the Python reference but never returns the slot index, so each pass through this loop after the first permanently burns a slot — once per extra sequence of a multi-sequence job. A clean, successful 4-sequence job leaks 3 slots; with `num_slots = max_batch_size` (`Cache` default 16, downstream servers often less), a few such jobs exhaust the pool and every later job dies on `assert len(self.free_list) > 0` in `get_new_state`.

Fix: call `free_recurrent_state()` instead, which frees if present and clears the attribute.

All assignment sites in `job.py` audited:

| line | context | |
|---|---|---|
| 302 | `__init__` | fine — nothing allocated yet |
| 892 → 895/898 | rewind path | **already frees first** — this PR matches it |
| 1435 | `allocate_pages` | the bug |
| 1552 | inside `free_recurrent_state()` | fine |

The rewind path freeing before re-acquiring is what shows 1435 is an omission rather than a design choice.

Safety of freeing after a stash: `RecurrentCache.put()` stores `state.stash()`, which snapshots to host memory (`short_conv.py:186`: `self.conv_state[slot, :, :cdim].cpu()`), and `new_from_stashed()` pops a fresh handle — the stashed copy never aliases the live slot, so there is no use-after-free.

Reproduces at library level with a 4-sequence `Job` run twice on a 4-slot pool (the second run asserts pre-patch). Not reachable through TabbyAPI, which only ever builds single-sequence jobs.
