### PR TITLE
Wait for free recurrent state slots instead of asserting

### DIFF
--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -1243,7 +1243,9 @@ class Generator:
             for job in self.pending_jobs.copy():
 
                 if (len(job.sequences) + current_max_batch > self.max_batch_size or
-                        job.current_new_pages_required() > self.pagetable.num_unreferenced_pages()):
+                        job.current_new_pages_required() > self.pagetable.num_unreferenced_pages() or
+                        (self.recurrent_cache is not None and
+                         len(job.sequences) > len(self.cache.free_list))):
                     skipped_jobs.append(job)
                     continue
 


### PR DESCRIPTION
Ran into this on a 24GB card serving `turboderp/Qwen3.8-27B-exl3` (hybrid GDN) through TabbyAPI, single user, `max_batch_size: 1`, MTP drafting enabled. An agent client aborted a streaming request and sent the next one almost immediately, and the new job died on:

```
File ".../exllamav3/cache/cache.py", line 328, in get_new_state
    assert len(self.free_list) > 0, "Cannot create new state: no available slots"
AssertionError: Cannot create new state: no available slots
```

As far as I can tell the cancel simply hadn't finished propagating when the next job tried to start, so for a moment there was no free slot even though nothing was actually wrong. With `max_batch_size: 1` that window is easy to hit from an eager client, and in my case the generator needed a restart before it would serve again.

`iterate_start_jobs` already defers jobs that would exceed `max_batch_size` or need more unreferenced pages, so this adds the missing third condition: not enough free state slots -> let the job wait in the queue. The existing skip counting and fairness handling take care of the rest. I gated it on `recurrent_cache` the same way `allocate_pages` does, and counted one slot per sequence, which matches what the allocation loop actually takes.

One trade-off worth naming honestly: if a slot ever leaked for real, the affected job would now wait quietly instead of failing loudly. That's the same starvation behavior as the existing page-based skip, so I think it's consistent, but it is a change in failure mode.

Tested on the setup above:

- abort + immediate retry (the original repro) now succeeds, sub-second
- three concurrent requests queue in order and all complete
- single-stream behavior unchanged

Happy to adjust, or add a test if there's a good place for one -- I didn't find an existing generator-level test that runs without a model on the GPU.
