### PR TITLE
Turing (sm_75) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 
-# <img src="doc/cat.png" width="40"> ExLlamaV3
+# <img src="doc/cat.png" width="40"> ExLlamaV3 (Turing / sm_75 fork)
+
+> **This fork adds Turing (sm_75) support.** Upstream EXL3 requires Ampere or newer; see
+> [upstream #162](https://github.com/turboderp-org/exllamav3/issues/162) and
+> [#81](https://github.com/turboderp-org/exllamav3/issues/81). Tesla T4, RTX 20-series and
+> Quadro RTX now run EXL3. See [doc/sm75.md](doc/sm75.md) for what was changed and what it
+> costs. Everything below is upstream documentation.
 
 ExLlamaV3 is an inference library for running local LLMs on modern consumer GPUs. Headline features:
 

--- a/doc/sm75.md
+++ b/doc/sm75.md
@@ -24,9 +24,12 @@ same lane-to-element mapping m16n8k8 uses for its two registers; B splits the sa
 `b0` and `b1`, and the C fragment is identical in both. Chaining two k=8 mmas through one
 accumulator therefore computes the same sum over the same k range.
 
-This is bit-equivalent, not an approximation — accumulation order within a k=16 step is not
-observable, because each mma internally accumulates in a fixed order anyway. The unit tests
-assert against a dequantize-then-matmul reference to confirm this empirically.
+This is not guaranteed bit-identical. PTX does not specify the internal accumulation order of
+a k=16 step, and splitting forces the partial sum to be rounded at the k=8 boundary where the
+fused instruction need not round. The bound is one extra rounding per 16-element dot product,
+orders of magnitude below the quantization error EXL3 already carries at 2-4 bpw. The unit
+tests bound the end-to-end deviation against a dequantize-then-matmul reference rather than
+asserting equality.
 
 Sites: `exllamav3_ext/ptx.cuh` (both fp32- and fp16-accumulate forms) and
 `exllamav3_ext/quant/exl3_gemv_kernel.cuh` (`mma_ab_h`, which has its own inline asm).
@@ -59,6 +62,22 @@ it raises `OutOfResources` at launch instead of recompiling smaller. Tile config
 chosen against the real device limit, and the dispatcher entry points treat a
 shared-memory `OutOfResources` as a dispatch miss, so an unanticipated geometry falls through
 to SDPA/xformers instead of killing the forward pass.
+
+### 4. Paths disabled on small-smem devices
+
+Two optimizations size their shared memory against fixed ~80 KB budgets that the *device* code
+also depends on (the kernels recompute their own row counts from the same constants), so the
+host cannot request less without desyncing the two. Both are declined on Turing:
+
+- **int8 GEMV** (`EXL3_INT8_GEMV`, default on): a decode-time alternative to the fp16
+  tensor-core kernel, which handles the same work. Declining costs throughput only.
+  Without this gate `cudaFuncSetAttribute` fails and the following `cuda_check` aborts the
+  process.
+- **Quant-direct KV cache attention**: this path writes K/V into the packed cache *before*
+  dispatching, and then dispatches over a Triton-only candidate list, so a backend miss is
+  fatal rather than recoverable. On Turing the dispatcher takes the dequantize-then-attend
+  path instead, which can fall through to SDPA/xformers. Quantized caches still work; they
+  just materialize fp16 temporaries.
 
 ### Not changed
 

--- a/doc/sm75.md
+++ b/doc/sm75.md
@@ -52,10 +52,17 @@ unconditionally, which fails the launch outright.
 
 `SMEM_MAX` still bounds the compile-time `static_assert` (every template instantiation must
 keep compiling), but what gets *requested* is now per-device, from
-`DevCtx::get_smem_max()` &rarr; `cudaDevAttrMaxSharedMemoryPerBlockOptin`. Shapes that do not
-fit are filtered out of kernel selection by `exl3_gemm_shape_compat()` rather than attempted
-and failed. In practice only GEMM shape 4 at 8 bpw (66 KB) is excluded on Turing; every MoE
-instantiation fits in 44 KB and is unaffected.
+`DevCtx::get_smem_request()` &rarr; `cudaDevAttrMaxSharedMemoryPerBlockOptin` capped at
+`SMEM_MAX`. Shapes that do not fit are filtered out of kernel selection by
+`exl3_gemm_shape_compat()` rather than attempted and failed. In practice only GEMM shape 4 at
+8 bpw (66 KB) is excluded on Turing; every MoE instantiation fits in 44 KB and is unaffected.
+
+The footprint itself is derived, not tabulated: `exl3_gemm_smem_bytes()` in
+`exl3_kernel_map.cuh` takes the `EXL3_GEMM_SHAPE_n` macro expansion (where `SH_STAGES` is
+already declared) and reproduces the layout `exl3_gemm_kernel_inner` builds. That kernel
+`static_assert`s, per instantiation, that the shared function agrees with its own layout, so
+a divergence between the filter and the reality is a compile error rather than an
+out-of-bounds read past the `extern __shared__` block.
 
 The Triton attention kernels have the same problem and Triton does not degrade gracefully —
 it raises `OutOfResources` at launch instead of recompiling smaller. Tile configs are now

--- a/doc/sm75.md
+++ b/doc/sm75.md
@@ -79,6 +79,24 @@ host cannot request less without desyncing the two. Both are declined on Turing:
   path instead, which can fall through to SDPA/xformers. Quantized caches still work; they
   just materialize fp16 temporaries.
 
+### 5. Attention kernels sized per device
+
+Three separate attention paths bake in tile shapes chosen for ~100 KB of shared memory:
+
+- **`triton_paged.py`** (paged prefill/decode): tile configs now shrink on small-smem devices,
+  and the dispatcher entry points treat a shared-memory `OutOfResources` as a dispatch miss,
+  falling through to SDPA/xformers.
+- **`dsa_triton.py`** (DeepSeek sparse attention): at `D_c = 512` the KV tiles dominate
+  (`block_n x 512 x 2 B` per stage), so `block_n`, the head tile and the pipeline depth all
+  come down. Without this the one-shot kernel asks for 140 KB.
+- **`bc_attn.py` / `bc_dsa.py` / `bc_mla.py`** (batch-compiled AOT kernels): tile shapes are
+  fixed `constexpr`s, so these cannot be resized. The cubin still compiles on Turing, but
+  `CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES` then fails with an opaque
+  `RuntimeError: CUDA driver error`. `_compile_kernel` now checks the compiled kernel's
+  shared-memory requirement against the device and raises `BCKernelTooLarge`, which the BC
+  builders catch to decline to the eager path — the same path that does size its tiles per
+  device.
+
 ### Not changed
 
 `ldmatrix`, `__nanosleep`, `__dp4a`, `tanh.approx.f32` and `cuda::atomic_ref` are all
@@ -91,11 +109,22 @@ On a Tesla T4 (sm_75, 15 GB, `smem_optin=65536`), CUDA 13.0, torch 2.9.1+cu130:
 | Test | Result |
 |---|---|
 | `tests/test_sm75_gemm.py` | 15 passed — GEMM matches reconstruct-then-matmul for K=2,3,4 at m=1/8/16/32; bit-identical across repeat launches; all K=1..8 shapes launchable |
-| Llama-3.2-1B-Instruct-exl3 4.0bpw (dense) | 100–135 tok/s, coherent |
-| Qwen3-30B-A3B-exl3 3.0bpw (MoE) | 42 tok/s, coherent |
+| Llama-3.2-1B-Instruct-exl3 4.0bpw (dense) | 134 tok/s, coherent |
+| Qwen3-30B-A3B-exl3 3.0bpw (MoE) | 42.7 tok/s, coherent |
+| DeepSeek-V4-Flash-0731-exl3 2.77bpw | 5.4 tok/s, coherent — 93 GiB of weights on 4x15 GiB, 40 MoE layers offloaded to system RAM; exercises MLA, DSA sparse attention and the CPU expert handoff |
 
 `m` is swept deliberately: m=1 takes the GEMV path, m&le;8 the small-m reduction, m>16 the
 multi-pass loop, and each drives the mma differently.
+
+DeepSeek-V4 needed two environment adjustments unrelated to the architecture:
+
+- `Cache(max_num_tokens=...)` must be at least the load-time autosplit probe's chunk size
+  (4096 works); a smaller cache trips `Cache too small for batch shape` during `load()`.
+- The CPU offload handoff buffer is pinned shared memory sized `2 x EXL3_MOE_CPU_WSLOT_MB`
+  plus slots. The default 32 MB slots need ~74 MB, which fails `cudaHostRegister` with
+  `invalid argument` when `/dev/shm` is the common 64 MB container default. Either raise
+  `/dev/shm` or set `EXL3_MOE_CPU_WSLOT_MB=20`. The error names neither cause, so it is worth
+  checking `df -h /dev/shm` first.
 
 ## Cost
 
@@ -105,6 +134,8 @@ Turing is slower than the same work on Ampere for reasons this port does not rem
 - Two mma instructions per tile instead of one.
 - 64 KB of shared memory caps tile sizes and occupancy.
 - No flash-attn on Turing; attention runs the Triton or SDPA path.
+- The int8 GEMV and batch-compiled (CUDA-graph) attention paths are declined, so decoding
+  runs the eager kernels.
 
 The goal is "slow beats impossible", per the upstream issue. It is not competitive with
 Ampere on throughput.

--- a/doc/sm75.md
+++ b/doc/sm75.md
@@ -116,6 +116,22 @@ On a Tesla T4 (sm_75, 15 GB, `smem_optin=65536`), CUDA 13.0, torch 2.9.1+cu130:
 `m` is swept deliberately: m=1 takes the GEMV path, m&le;8 the small-m reduction, m>16 the
 multi-pass loop, and each drives the mma differently.
 
+### No Ampere regression
+
+Also built and run on an RTX 3090 (sm_86, CUDA 12.4, torch 2.6):
+
+| Check | Result |
+|---|---|
+| `tests/test_sm75_gemm.py` | 15 passed |
+| `g_get_cc` | 2 (`CC_AMPERE`, not `CC_OLD`) |
+| `g_get_smem_max` | 101376 — the raw driver value, unchanged |
+| `_dev_small_smem` | False — tiles unshrunk, quant-direct cache and int8 GEMV both still active |
+
+Every PTX substitution is behind `#if EXL3_SM75`, which is `__CUDA_ARCH__ < 800`, so an
+sm_80+ cubin is byte-identical to upstream's. The runtime gates key on compute capability
+`< 8` rather than a byte threshold, because Volta reports exactly 96 KB and no byte
+comparison separates it from Ampere's 99 KB robustly.
+
 DeepSeek-V4 needed two environment adjustments unrelated to the architecture:
 
 - `Cache(max_num_tokens=...)` must be at least the load-time autosplit probe's chunk size
@@ -148,5 +164,7 @@ Ampere on throughput.
 TORCH_CUDA_ARCH_LIST=7.5 MAX_JOBS=24 pip install --no-build-isolation -e .
 ```
 
-Use a CUDA toolkit and torch build that match (this was developed against CUDA 13.0 with
-torch 2.9.1+cu130). Expect roughly 30 minutes for a full build.
+Use a CUDA toolkit and torch build that match your driver (developed against CUDA 13.0 with
+torch 2.9.1+cu130 on a 13.0 driver; a cu130 wheel will not initialize on a 12.8 driver).
+Triton 3.3 or newer is required by upstream independently of this port — 3.2 fails to compile
+the paged-attention kernels. Expect roughly 30 minutes for a full build.

--- a/doc/sm75.md
+++ b/doc/sm75.md
@@ -92,7 +92,10 @@ Three separate attention paths bake in tile shapes chosen for ~100 KB of shared 
 
 - **`triton_paged.py`** (paged prefill/decode): tile configs now shrink on small-smem devices,
   and the dispatcher entry points treat a shared-memory `OutOfResources` as a dispatch miss,
-  falling through to SDPA/xformers.
+  falling through to SDPA/xformers. The decode kernel needs the tile clamp specifically, not
+  just the fallback: its default holds `block_n * head_dim` at 8192, so the KV tiles alone are
+  64 KB at the default depth of 2 and every decode step would take the fallback and run on
+  SDPA. Halving `block_n` keeps it on Triton for the cost of more k-loop iterations.
 - **`dsa_triton.py`** (DeepSeek sparse attention): at `D_c = 512` the KV tiles dominate
   (`block_n x 512 x 2 B` per stage), so `block_n`, the head tile and the pipeline depth all
   come down. Without this the one-shot kernel asks for 140 KB.

--- a/doc/sm75.md
+++ b/doc/sm75.md
@@ -1,0 +1,102 @@
+# Turing (sm_75) support
+
+Upstream EXL3 targets sm_80 and newer. On Turing the build fails at PTX assembly:
+
+```
+ptxas error : Feature 'cp.async' requires .target sm_80 or higher
+ptxas error : Feature '.m16n8k16' requires .target sm_80 or higher
+```
+
+This fork makes Turing work. The three blockers named in
+[upstream #162](https://github.com/turboderp-org/exllamav3/issues/162) are addressed as
+follows.
+
+## What was changed
+
+### 1. `mma.m16n8k16` &rarr; two `mma.m16n8k8`
+
+Turing's 2nd-gen tensor cores have no k=16 fragment shape. Upstream's concern was that "the
+lane mappings for m16n8k8 are different so you can't just run two of those mmas instead."
+
+For the `.row.col` operand layout EXL3 uses, they line up. In m16n8k16 the A fragment is four
+registers `{a0,a1,a2,a3}` where `{a0,a1}` holds k=0..7 and `{a2,a3}` holds k=8..15, with the
+same lane-to-element mapping m16n8k8 uses for its two registers; B splits the same way into
+`b0` and `b1`, and the C fragment is identical in both. Chaining two k=8 mmas through one
+accumulator therefore computes the same sum over the same k range.
+
+This is bit-equivalent, not an approximation — accumulation order within a k=16 step is not
+observable, because each mma internally accumulates in a fixed order anyway. The unit tests
+assert against a dequantize-then-matmul reference to confirm this empirically.
+
+Sites: `exllamav3_ext/ptx.cuh` (both fp32- and fp16-accumulate forms) and
+`exllamav3_ext/quant/exl3_gemv_kernel.cuh` (`mma_ab_h`, which has its own inline asm).
+
+### 2. `cp.async` &rarr; synchronous 16 B copies
+
+Turing has no asynchronous global&rarr;shared copy. `cp_async()` degrades to a load/store
+pair through registers, and `cp_async_fence()` / `cp_async_wait()` become no-ops.
+
+This is safe because the GEMM pipeline never relied on `cp.async.wait_group` alone for
+ordering: `wait_stage()` in `exl3_gemm_inner.cuh` issues a `__syncthreads()` after every wait,
+and a synchronous store has already retired by then. The lost global&rarr;shared overlap is a
+throughput cost, not a correctness hazard. `test_gemm_deterministic` guards the assumption —
+a race would show up as run-to-run variation.
+
+### 3. 90 KB &rarr; 64 KB shared memory
+
+Turing caps dynamic shared memory at 64 KB per block; the kernels request 90 KB
+unconditionally, which fails the launch outright.
+
+`SMEM_MAX` still bounds the compile-time `static_assert` (every template instantiation must
+keep compiling), but what gets *requested* is now per-device, from
+`DevCtx::get_smem_max()` &rarr; `cudaDevAttrMaxSharedMemoryPerBlockOptin`. Shapes that do not
+fit are filtered out of kernel selection by `exl3_gemm_shape_compat()` rather than attempted
+and failed. In practice only GEMM shape 4 at 8 bpw (66 KB) is excluded on Turing; every MoE
+instantiation fits in 44 KB and is unaffected.
+
+The Triton attention kernels have the same problem and Triton does not degrade gracefully —
+it raises `OutOfResources` at launch instead of recompiling smaller. Tile configs are now
+chosen against the real device limit, and the dispatcher entry points treat a
+shared-memory `OutOfResources` as a dispatch miss, so an unanticipated geometry falls through
+to SDPA/xformers instead of killing the forward pass.
+
+### Not changed
+
+`ldmatrix`, `__nanosleep`, `__dp4a`, `tanh.approx.f32` and `cuda::atomic_ref` are all
+available on sm_75 and needed no gating.
+
+## Verified
+
+On a Tesla T4 (sm_75, 15 GB, `smem_optin=65536`), CUDA 13.0, torch 2.9.1+cu130:
+
+| Test | Result |
+|---|---|
+| `tests/test_sm75_gemm.py` | 15 passed — GEMM matches reconstruct-then-matmul for K=2,3,4 at m=1/8/16/32; bit-identical across repeat launches; all K=1..8 shapes launchable |
+| Llama-3.2-1B-Instruct-exl3 4.0bpw (dense) | 100–135 tok/s, coherent |
+| Qwen3-30B-A3B-exl3 3.0bpw (MoE) | 42 tok/s, coherent |
+
+`m` is swept deliberately: m=1 takes the GEMV path, m&le;8 the small-m reduction, m>16 the
+multi-pass loop, and each drives the mma differently.
+
+## Cost
+
+Turing is slower than the same work on Ampere for reasons this port does not remove:
+
+- No `cp.async`, so global&rarr;shared traffic no longer overlaps with compute.
+- Two mma instructions per tile instead of one.
+- 64 KB of shared memory caps tile sizes and occupancy.
+- No flash-attn on Turing; attention runs the Triton or SDPA path.
+
+The goal is "slow beats impossible", per the upstream issue. It is not competitive with
+Ampere on throughput.
+
+## Building
+
+`TORCH_CUDA_ARCH_LIST` must include 7.5; prebuilt upstream wheels contain no sm_75 cubin.
+
+```bash
+TORCH_CUDA_ARCH_LIST=7.5 MAX_JOBS=24 pip install --no-build-isolation -e .
+```
+
+Use a CUDA toolkit and torch build that match (this was developed against CUDA 13.0 with
+torch 2.9.1+cu130). Expect roughly 30 minutes for a full build.

--- a/exllamav3/exllamav3_ext/arch.cuh
+++ b/exllamav3/exllamav3_ext/arch.cuh
@@ -1,0 +1,32 @@
+#pragma once
+
+// Architecture feature gates.
+//
+// EXL3 was written against sm_80+. Turing (sm_75) is missing three things the EXL3 GEMM
+// relies on, and each one is handled in a different place:
+//
+//   1. cp.async         -> ptx.cuh falls back to plain synchronous 16 B smem stores. The
+//                          pipeline's existing __syncthreads() calls already provide the
+//                          ordering the async waits used to provide, so the fallback is
+//                          correct, just without global->shared overlap.
+//   2. mma.m16n8k16     -> ptx.cuh issues two mma.m16n8k8 instead. The k=16 fragment splits
+//                          exactly into the two k=8 fragments (A: {a0,a1} then {a2,a3},
+//                          B: b0 then b1), so this is bit-equivalent, not an approximation.
+//   3. 90 KB shared mem -> Turing caps dynamic shared memory at 64 KB per block. The limit is
+//                          a host-side launch parameter, so it is resolved per device at
+//                          runtime (DevCtx::get_smem_max) and shapes that do not fit are
+//                          filtered out of kernel selection rather than failing at launch.
+//
+// ldmatrix, __nanosleep, __dp4a and tanh.approx.f32 are all sm_75-capable and need no gate.
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
+    #define EXL3_SM75 1
+#else
+    #define EXL3_SM75 0
+#endif
+
+// Dynamic shared memory per block. SMEM_MAX stays at the sm_86 value because it only bounds
+// the compile-time static_assert in exl3_gemm_inner.cuh, which must keep accepting every
+// template instantiation. What actually gets requested at launch is the per-device value.
+#define EXL3_SMEM_MAX_DEFAULT (90 * 1024)
+#define EXL3_SMEM_MAX_SM75    (64 * 1024)

--- a/exllamav3/exllamav3_ext/bindings.cpp
+++ b/exllamav3/exllamav3_ext/bindings.cpp
@@ -144,6 +144,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("exl3_gemm_shape_compat", &exl3_gemm_shape_compat, "exl3_gemm_shape_compat");
     m.def("g_get_cc", &g_get_cc, "g_get_cc");
     m.def("g_get_num_sms", &g_get_num_sms, "g_get_num_sms");
+    m.def("g_get_smem_max", &g_get_smem_max, "g_get_smem_max");
     m.def("exl3_gemv_int8_max_k", &exl3_gemv_int8_max_k, "exl3_gemv_int8_max_k");
     m.def("exl3_moe_cpu_make_layer", &exl3_moe_cpu_make_layer, "exl3_moe_cpu_make_layer");
     m.def("exl3_moe_cpu_free_layer", &exl3_moe_cpu_free_layer, "exl3_moe_cpu_free_layer");

--- a/exllamav3/exllamav3_ext/ptx.cuh
+++ b/exllamav3/exllamav3_ext/ptx.cuh
@@ -54,8 +54,14 @@ __device__ inline void ptx_mma_m8n8k4
 // Turing has no m16n8k16. The k=16 operation is the sum of two k=8 operations over disjoint
 // halves of the k dimension, and the register-to-element mapping of m16n8k8 is exactly the
 // low half of m16n8k16's: A {a0,a1} covers k=0..7 and {a2,a3} covers k=8..15, B b0 then b1,
-// C identical. Chaining two mmas through the same accumulator is therefore bit-equivalent to
-// the single k=16 instruction, not an approximation of it.
+// C identical. Chaining two mmas through the same accumulator computes the same products over
+// the same operands.
+//
+// It is not guaranteed bit-identical: PTX does not specify the internal accumulation order of
+// a k=16 step, and the split forces a rounding of the partial sum at the k=8 boundary that the
+// fused form need not perform. The difference is at most one extra rounding per 16-element dot
+// product, far below the quantization noise EXL3 already carries. tests/test_sm75_gemm.py
+// bounds it against a dequantize-then-matmul reference.
 __device__ inline void ptx_mma_m16n8k16
 (
     const FragA& frag_a,

--- a/exllamav3/exllamav3_ext/ptx.cuh
+++ b/exllamav3/exllamav3_ext/ptx.cuh
@@ -1,5 +1,6 @@
 #pragma once
 #include <cuda/atomic>
+#include "arch.cuh"
 
 // Tensor core fragments
 
@@ -49,6 +50,12 @@ __device__ inline void ptx_mma_m8n8k4
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
 
 // FP16 @ FP16 + FP32 -> FP32
+//
+// Turing has no m16n8k16. The k=16 operation is the sum of two k=8 operations over disjoint
+// halves of the k dimension, and the register-to-element mapping of m16n8k8 is exactly the
+// low half of m16n8k16's: A {a0,a1} covers k=0..7 and {a2,a3} covers k=8..15, B b0 then b1,
+// C identical. Chaining two mmas through the same accumulator is therefore bit-equivalent to
+// the single k=16 instruction, not an approximation of it.
 __device__ inline void ptx_mma_m16n8k16
 (
     const FragA& frag_a,
@@ -61,6 +68,28 @@ __device__ inline void ptx_mma_m16n8k16
     float* c = reinterpret_cast<float*>(&frag_c);
     const float* d = reinterpret_cast<const float*>(&frag_c);
 
+#if EXL3_SM75
+    asm
+    (
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        :  "r"(a[0]), "r"(a[1]),
+           "r"(b[0]),
+           "f"(d[0]), "f"(d[1]), "f"(d[2]), "f"(d[3])
+    );
+    asm
+    (
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        :  "r"(a[2]), "r"(a[3]),
+           "r"(b[1]),
+           "f"(d[0]), "f"(d[1]), "f"(d[2]), "f"(d[3])
+    );
+#else
     asm
     (
         "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
@@ -71,6 +100,7 @@ __device__ inline void ptx_mma_m16n8k16
            "r"(b[0]), "r"(b[1]),
            "f"(d[0]), "f"(d[1]), "f"(d[2]), "f"(d[3])
     );
+#endif
 }
 
 // FP16 @ FP16 + FP16 -> FP16
@@ -86,6 +116,28 @@ __device__ inline void ptx_mma_m16n8k16
     uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
     const uint32_t* d = reinterpret_cast<const uint32_t*>(&frag_c);
 
+#if EXL3_SM75
+    asm
+    (
+        "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+        "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
+
+        : "=r"(c[0]), "=r"(c[1])
+        :  "r"(a[0]), "r"(a[1]),
+           "r"(b[0]),
+           "r"(d[0]), "r"(d[1])
+    );
+    asm
+    (
+        "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+        "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
+
+        : "=r"(c[0]), "=r"(c[1])
+        :  "r"(a[2]), "r"(a[3]),
+           "r"(b[1]),
+           "r"(d[0]), "r"(d[1])
+    );
+#else
     asm
     (
         "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
@@ -96,6 +148,7 @@ __device__ inline void ptx_mma_m16n8k16
            "r"(b[0]), "r"(b[1]),
            "r"(d[0]), "r"(d[1])
     );
+#endif
 }
 
 // Global barrier
@@ -143,6 +196,13 @@ __device__ inline void barrier_release
 
 __device__ inline void cp_async_pred(void* smem_ptr, const void* glob_ptr, bool pred = true)
 {
+#if EXL3_SM75
+    if (pred)
+    {
+        uint4 v = *reinterpret_cast<const uint4*>(glob_ptr);
+        *reinterpret_cast<uint4*>(smem_ptr) = v;
+    }
+#else
     const int bytes = 16;
     uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
     asm volatile(
@@ -152,12 +212,23 @@ __device__ inline void cp_async_pred(void* smem_ptr, const void* glob_ptr, bool 
         "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
         "}\n" :: "r"((int) pred), "r"(smem), "l"(glob_ptr), "n"(bytes)
     );
+#endif
 }
 
 // Load global to shared memory
+//
+// Turing (sm_75) has no cp.async, so the copy degrades to a synchronous 16 B load/store pair
+// routed through registers. Correctness is unaffected: cp_async_wait() below becomes a no-op,
+// but every consumer of a staged tile already passes a __syncthreads() (see wait_stage() in
+// exl3_gemm_inner.cuh) before reading it, and a synchronous store has completed by then. The
+// cost is the lost global->shared overlap, which is a throughput loss, not a hazard.
 
 __device__ inline void cp_async(void* smem_ptr, const void* glob_ptr)
 {
+#if EXL3_SM75
+    uint4 v = *reinterpret_cast<const uint4*>(glob_ptr);
+    *reinterpret_cast<uint4*>(smem_ptr) = v;
+#else
     const int bytes = 16;
     uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
     asm volatile(
@@ -165,12 +236,18 @@ __device__ inline void cp_async(void* smem_ptr, const void* glob_ptr)
         "   cp.async.cg.shared.global [%0], [%1], %2;\n"
         "}\n" :: "r"(smem), "l"(glob_ptr), "n"(bytes)
     );
+#endif
 }
 
 // Load global to shared memory with cache hint to evict data from L2 ASAP
 
 __device__ inline void cp_async_stream(void* smem_ptr, const void* glob_ptr)
 {
+#if EXL3_SM75
+    // No cp.async and no createpolicy on Turing; the L2 hint is only an optimization
+    uint4 v = *reinterpret_cast<const uint4*>(glob_ptr);
+    *reinterpret_cast<uint4*>(smem_ptr) = v;
+#else
     uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
     const int bytes = 16;
     asm volatile
@@ -181,13 +258,16 @@ __device__ inline void cp_async_stream(void* smem_ptr, const void* glob_ptr)
         "   cp.async.cg.shared.global.L2::cache_hint [%0], [%1], %2, p;\n"
         "}\n" :: "r"(smem), "l"(glob_ptr), "n"(bytes)
     );
+#endif
 }
 
 // Async copy fence, commit all pending async copies
 
 __device__ inline void cp_async_fence()
 {
+#if !EXL3_SM75
     asm volatile("cp.async.commit_group;\n" ::);
+#endif
 }
 
 // Wait until at most n async groups are still pending.
@@ -195,7 +275,9 @@ __device__ inline void cp_async_fence()
 template <int n>
 __device__ inline void cp_async_wait()
 {
+#if !EXL3_SM75
     asm volatile("cp.async.wait_group %0;\n" :: "n"(n));
+#endif
 }
 
 // Load 16x16 matrix fragment from shared memory, directly in tensor core layout

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
@@ -50,11 +50,20 @@ int DevCtx::get_smem_max(int device)
     std::lock_guard<std::mutex> lock(mtx);
     if (!smem_max[device])
     {
+        // The driver value, unclamped: this is a device capability, and callers that only need
+        // "what may I request for an EXL3 kernel" clamp to SMEM_MAX themselves (see
+        // get_smem_request). Clamping here would have made an sm_86 device indistinguishable
+        // from a 90 KB one and dragged it onto the Turing code paths.
         int optin = 0;
         cuda_check(cudaDeviceGetAttribute(&optin, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
-        smem_max[device] = MIN(optin, EXL3_SMEM_MAX_DEFAULT);
+        smem_max[device] = optin;
     }
     return smem_max[device];
+}
+
+int DevCtx::get_smem_request(int device)
+{
+    return MIN(get_smem_max(device), EXL3_SMEM_MAX_DEFAULT);
 }
 
 void* DevCtx::get_ws(int device)

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
@@ -45,6 +45,18 @@ int DevCtx::get_cc(int device)
     return cc[device];
 }
 
+int DevCtx::get_smem_max(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!smem_max[device])
+    {
+        int optin = 0;
+        cuda_check(cudaDeviceGetAttribute(&optin, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+        smem_max[device] = MIN(optin, SMEM_MAX);
+    }
+    return smem_max[device];
+}
+
 void* DevCtx::get_ws(int device)
 {
     std::lock_guard<std::mutex> lock(mtx);
@@ -79,9 +91,15 @@ int g_get_num_sms(int device)
     return DevCtx::instance().get_num_sms(device);
 }
 
+int g_get_smem_max(int device)
+{
+    return DevCtx::instance().get_smem_max(device);
+}
+
 void prepare_ctx(int device)
 {
     DevCtx::instance().get_num_sms(device);
     DevCtx::instance().get_cc(device);
+    DevCtx::instance().get_smem_max(device);
     DevCtx::instance().get_locks(device);
 }

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cu
@@ -52,7 +52,7 @@ int DevCtx::get_smem_max(int device)
     {
         int optin = 0;
         cuda_check(cudaDeviceGetAttribute(&optin, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
-        smem_max[device] = MIN(optin, SMEM_MAX);
+        smem_max[device] = MIN(optin, EXL3_SMEM_MAX_DEFAULT);
     }
     return smem_max[device];
 }

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
@@ -40,10 +40,12 @@ public:
     static DevCtx& instance();
     int get_num_sms(int device);
     int get_cc(int device);
-    // Usable dynamic shared memory per block, queried from the driver rather than assumed.
-    // sm_86 reports 99 KB and the kernels ask for SMEM_MAX (90 KB); Turing reports 64 KB, so
-    // requesting SMEM_MAX there fails the launch outright. Callers must clamp to this.
+    // Device capability: dynamic shared memory per block the driver will grant, unclamped
+    // (sm_86 reports 99 KB, Turing 64 KB). Use this to decide what a device can do.
     int get_smem_max(int device);
+    // What an EXL3 kernel may actually request: the above, capped at the SMEM_MAX the kernels
+    // are written against. Use this for cudaFuncSetAttribute and launch parameters.
+    int get_smem_request(int device);
     void* get_ws(int device);
     int* get_locks(int device);
 

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
@@ -30,6 +30,7 @@ class DevCtx
 private:
     int num_sms[MAX_DEVICES] = {};
     int cc[MAX_DEVICES] = {};
+    int smem_max[MAX_DEVICES] = {};
     void* locks[MAX_DEVICES] = {};
     void* ws[MAX_DEVICES] = {};
     std::mutex mtx;
@@ -38,6 +39,10 @@ public:
     static DevCtx& instance();
     int get_num_sms(int device);
     int get_cc(int device);
+    // Usable dynamic shared memory per block, queried from the driver rather than assumed.
+    // sm_86 reports 99 KB and the kernels ask for SMEM_MAX (90 KB); Turing reports 64 KB, so
+    // requesting SMEM_MAX there fails the launch outright. Callers must clamp to this.
+    int get_smem_max(int device);
     void* get_ws(int device);
     int* get_locks(int device);
 
@@ -49,5 +54,6 @@ private:
 
 int g_get_cc(int device);
 int g_get_num_sms(int device);
+int g_get_smem_max(int device);
 
 void prepare_ctx(int device);

--- a/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_devctx.cuh
@@ -2,6 +2,7 @@
 
 #include <tuple>
 #include <mutex>
+#include "../arch.cuh"
 
 // Max allowable output size, in tiles. Used to allocate global lock buffer per device for sync across threadblocks
 #define MAX_TILES_C (1024 * 1024)

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
@@ -158,7 +158,7 @@ int exl3_gemm_gr
     int* locks = DevCtx::instance().get_locks(device);
     // Turing allows only 64 KB of dynamic shared memory per block, so the fixed SMEM_MAX
     // request would fail the launch there. Ask for what this device actually permits.
-    int smem_max = DevCtx::instance().get_smem_max(device);
+    int smem_max = DevCtx::instance().get_smem_request(device);
 
     // Dispatch
     int K = B.size(2) / 16;
@@ -483,7 +483,7 @@ int exl3_mgemm_gr
     int device;
     cudaGetDevice(&device);
     int total_sms = DevCtx::instance().get_num_sms(device);
-    int smem_max = DevCtx::instance().get_smem_max(device);
+    int smem_max = DevCtx::instance().get_smem_request(device);
     int num_sms = force_num_sms ? force_num_sms : total_sms;
     int cc = DevCtx::instance().get_cc(device);
     int* locks = DevCtx::instance().get_locks(device);

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm.cu
@@ -156,6 +156,9 @@ int exl3_gemm_gr
     int num_sms = force_num_sms ? force_num_sms : DevCtx::instance().get_num_sms(device);
     int cc = DevCtx::instance().get_cc(device);
     int* locks = DevCtx::instance().get_locks(device);
+    // Turing allows only 64 KB of dynamic shared memory per block, so the fixed SMEM_MAX
+    // request would fail the launch there. Ask for what this device actually permits.
+    int smem_max = DevCtx::instance().get_smem_max(device);
 
     // Dispatch
     int K = B.size(2) / 16;
@@ -240,7 +243,7 @@ int exl3_gemm_gr
     {
         uint64_t autotune_key = gemm_autotune_hash(MAX(size_m, 2), size_k, size_n, K, c_fp32, device, cc, num_sms, cb);
         CoopAutotuneLaunch tuned;
-        if (CoopKernelAutotuner::launch_locked(autotune_key, kernelArgs, SMEM_MAX, stream, &tuned))
+        if (CoopKernelAutotuner::launch_locked(autotune_key, kernelArgs, smem_max, stream, &tuned))
         {
             add_graph_args((void*) tuned.kernel);
             cuda_check(cudaPeekAtLastError());
@@ -271,7 +274,7 @@ int exl3_gemm_gr
         }
         TORCH_CHECK(!candidates.empty(), "exl3_gemm autotune: no compatible kernel shapes");
 
-        tuned = CoopKernelAutotuner::launch(autotune_key, candidates, kernelArgs, SMEM_MAX, stream, (size_t) size_k * size_n);
+        tuned = CoopKernelAutotuner::launch(autotune_key, candidates, kernelArgs, smem_max, stream, (size_t) size_k * size_n);
         if (graph)
         add_graph_args((void*) tuned.kernel);
         cuda_check(cudaPeekAtLastError());
@@ -289,7 +292,7 @@ int exl3_gemm_gr
     // Launch
     if (kernel_attr_set[device].find((void*) kernel) == kernel_attr_set[device].end())
     {
-        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_max);
         kernel_attr_set[device].insert((void*) kernel);
         cuda_check(cudaPeekAtLastError());
     }
@@ -299,7 +302,7 @@ int exl3_gemm_gr
         num_sms,
         block_dim,
         kernelArgs,
-        SMEM_MAX,
+        smem_max,
         stream
     );
     add_graph_args((void*) kernel);
@@ -480,6 +483,7 @@ int exl3_mgemm_gr
     int device;
     cudaGetDevice(&device);
     int total_sms = DevCtx::instance().get_num_sms(device);
+    int smem_max = DevCtx::instance().get_smem_max(device);
     int num_sms = force_num_sms ? force_num_sms : total_sms;
     int cc = DevCtx::instance().get_cc(device);
     int* locks = DevCtx::instance().get_locks(device);
@@ -547,7 +551,7 @@ int exl3_mgemm_gr
         );
 
         CoopAutotuneLaunch tuned;
-        if (CoopKernelAutotuner::launch_locked(autotune_key, kernelArgs, SMEM_MAX, stream, &tuned))
+        if (CoopKernelAutotuner::launch_locked(autotune_key, kernelArgs, smem_max, stream, &tuned))
         {
             add_graph_args((void*) tuned.kernel);
             cuda_check(cudaPeekAtLastError());
@@ -580,7 +584,7 @@ int exl3_mgemm_gr
             }
             TORCH_CHECK(!candidates.empty(), "exl3_mgemm autotune: no compatible kernel shapes");
 
-            tuned = CoopKernelAutotuner::launch(autotune_key, candidates, kernelArgs, SMEM_MAX, stream, (size_t) size_k * size_n * bszm);
+            tuned = CoopKernelAutotuner::launch(autotune_key, candidates, kernelArgs, smem_max, stream, (size_t) size_k * size_n * bszm);
             add_graph_args((void*) tuned.kernel);
 
             // DBGI10(size_m, size_k, size_n, K, bszm_in, bszm_out, tuned.tag, tuned.block_dim, tuned.num_sms, tuned.concurrency);
@@ -612,7 +616,7 @@ int exl3_mgemm_gr
     // Launch
     if (kernel_attr_set[device].find((void*) kernel) == kernel_attr_set[device].end())
     {
-        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_max);
         kernel_attr_set[device].insert((void*) kernel);
     }
 
@@ -622,7 +626,7 @@ int exl3_mgemm_gr
         block_grid,
         block_dim,
         kernelArgs,
-        SMEM_MAX,
+        smem_max,
         stream
     );
     add_graph_args((void*) kernel);

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
@@ -7,6 +7,8 @@
 #define SMEM_MAX (90 * 1024)  // max shared memory on compute capability 8.6
 
 #include "exl3_dq.cuh"
+// For exl3_gemm_smem_bytes(), the shared definition of this kernel's shared memory footprint
+#include "exl3_kernel_map.cuh"
 
 // On GA10x, HMMA with fp32 accumulation runs at half rate and dominates the m=1 (decode-bound) case.
 // Accumulate MMA results in fp16 instead and fold into the fp32 accumulators once per k-slice: ~14%
@@ -62,6 +64,16 @@ void exl3_gemm_kernel_inner
     (
         SMEM_MAX >= SH_STAGES * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size,
         "Invalid kernel params (insufficient shared memory for shape)"
+    );
+    // The host filters shapes by asking exl3_gemm_smem_bytes() what this layout costs; if that
+    // function and the layout above ever diverge, the filter would vet a footprint the kernel
+    // does not actually have. Assert they agree, per instantiation, at compile time.
+    static_assert
+    (
+        exl3_gemm_smem_bytes(TILESIZE_M, TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES,
+                             bits, shmem_out_had)
+            == SH_STAGES * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size,
+        "exl3_gemm_smem_bytes() disagrees with the kernel's shared memory layout"
     );
 
     // Shared memory

--- a/exllamav3/exllamav3_ext/quant/exl3_gemv_int8.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemv_int8.cu
@@ -242,6 +242,16 @@ bool exl3_gemv_int8
     int device;
     cudaGetDevice(&device);
     if (K < 1 || K > exl3_gemv_int8_max_k(device)) return false;
+
+    // Both int8 kernels below size their shared memory against a fixed ~80 KB budget baked into
+    // gemv_int8_sq_rows_max() and the coop path's 768-row bound, and - critically - the kernels
+    // recompute rows_per from those same constants on the device, so the host cannot simply ask
+    // for less without desyncing the two. On Turing (64 KB) the cudaFuncSetAttribute would fail
+    // and the following cuda_check would abort the process. This path is a decode-time
+    // optimization over the regular fp16 tensor-core kernel, which handles the same work, so
+    // declining is a performance loss and nothing more.
+    if (DevCtx::instance().get_smem_max(device) < 80 * 1024) return false;
+
     int num_sms = DevCtx::instance().get_num_sms(device);
     bool c_fp32 = C.dtype() == at::kFloat;
     bool residual = exl3_gemv_int8_mode() == 1;

--- a/exllamav3/exllamav3_ext/quant/exl3_gemv_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemv_kernel.cuh
@@ -31,13 +31,33 @@
 
 namespace exl3_gemv_ns {
 
-// mma.m16n8k16 with the A operand supplied as two FragB halves, fp16 accumulate
+// mma.m16n8k16 with the A operand supplied as two FragB halves, fp16 accumulate.
+// On Turing this splits into the two k=8 halves it is already expressed as (a01 pairs with
+// b[0], a23 with b[1]), accumulating through the same c - bit-equivalent, see ptx.cuh.
 __device__ __forceinline__ void mma_ab_h(const FragB& a01, const FragB& a23, const FragB& b, FragC_h& c)
 {
     const uint32_t* a0 = reinterpret_cast<const uint32_t*>(&a01);
     const uint32_t* a1 = reinterpret_cast<const uint32_t*>(&a23);
     const uint32_t* bb = reinterpret_cast<const uint32_t*>(&b);
     uint32_t* cc = reinterpret_cast<uint32_t*>(&c);
+#if EXL3_SM75
+    asm
+    (
+        "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+        "{%0,%1}, {%2,%3}, {%4}, {%0,%1};\n"
+        : "+r"(cc[0]), "+r"(cc[1])
+        :  "r"(a0[0]), "r"(a0[1]),
+           "r"(bb[0])
+    );
+    asm
+    (
+        "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+        "{%0,%1}, {%2,%3}, {%4}, {%0,%1};\n"
+        : "+r"(cc[0]), "+r"(cc[1])
+        :  "r"(a1[0]), "r"(a1[1]),
+           "r"(bb[1])
+    );
+#else
     asm
     (
         "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
@@ -46,6 +66,7 @@ __device__ __forceinline__ void mma_ab_h(const FragB& a01, const FragB& a23, con
         :  "r"(a0[0]), "r"(a0[1]), "r"(a1[0]), "r"(a1[1]),
            "r"(bb[0]), "r"(bb[1])
     );
+#endif
 }
 
 // mul1 codebook pair decode via dp4a byte sum (bit-identical to the vabsdiff4 form)

--- a/exllamav3/exllamav3_ext/quant/exl3_gemv_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemv_kernel.cuh
@@ -33,7 +33,8 @@ namespace exl3_gemv_ns {
 
 // mma.m16n8k16 with the A operand supplied as two FragB halves, fp16 accumulate.
 // On Turing this splits into the two k=8 halves it is already expressed as (a01 pairs with
-// b[0], a23 with b[1]), accumulating through the same c - bit-equivalent, see ptx.cuh.
+// b[0], a23 with b[1]), accumulating through the same c. Same operands and products; one
+// extra rounding at the k=8 boundary. See the longer note in ptx.cuh.
 __device__ __forceinline__ void mma_ab_h(const FragB& a01, const FragB& a23, const FragB& b, FragC_h& c)
 {
     const uint32_t* a0 = reinterpret_cast<const uint32_t*>(&a01);

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -111,9 +111,25 @@ bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, i
     int tilesize_n = exl3_gemm_tilesize_n[shape_idx];
     if (size_k % tilesize_k || size_n % tilesize_n) return false;
 
+    // Device-dependent: callers with tensors on a non-current device must set a device guard
+    // first (every in-tree caller runs under OptionalCUDAGuard). Only matters on a mixed-arch
+    // host, where a 90 KB-capable device would otherwise vouch for a 64 KB one.
     int device;
     cudaGetDevice(&device);
     return exl3_gemm_shape_smem(shape_idx, K) <= DevCtx::instance().get_smem_max(device);
+}
+
+// Hard gate for explicitly forced shapes, which skip the autotuner's shape_compat filter.
+// Launching a shape whose static layout exceeds what the launch can request would read past
+// the end of the extern __shared__ block - silent corruption rather than a failed launch.
+void exl3_gemm_check_smem(int shape_idx, int K, const char* who)
+{
+    int device;
+    cudaGetDevice(&device);
+    int need = exl3_gemm_shape_smem(shape_idx, K);
+    int have = DevCtx::instance().get_smem_max(device);
+    TORCH_CHECK(need <= have, who, ": shape ", shape_idx, " at ", K,
+                " bpw needs ", need, " B of shared memory, device provides ", have);
 }
 
 // Instance tables, [K][cb] -> array indexed by shape_idx. Row 0 unused (no K = 0 instances)
@@ -173,6 +189,7 @@ fp_exl3_gemm_kernel select_exl3_gemm_kernel
     int shape_idx = force_shape_idx <= 0 ? select_gemm_shape(cc, size_m, size_k, size_n, K, false, 1, 1) : force_shape_idx;
 
     TORCH_CHECK(shape_idx > 0, "exl3_gemm: no compatible kernel");
+    exl3_gemm_check_smem(shape_idx, K, "exl3_gemm");
     if (out_shape_idx) *out_shape_idx = shape_idx;
     if (out_block_dim) *out_block_dim = exl3_gemm_blockdim[shape_idx];
 
@@ -208,6 +225,7 @@ fp_exl3_mgemm_kernel select_exl3_mgemm_kernel
 {
     int shape_idx = force_shape_idx <= 0 ? select_gemm_shape(cc, size_m, size_k, size_n, K, true, bszm_in, bszm_out) : force_shape_idx;
     TORCH_CHECK(shape_idx > 0, "exl3_mgemm: no compatible kernel");
+    exl3_gemm_check_smem(shape_idx, K, "exl3_mgemm");
     if (out_shape_idx) *out_shape_idx = shape_idx;
     if (out_block_dim) *out_block_dim = exl3_gemm_blockdim[shape_idx];
 

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -116,7 +116,7 @@ bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, i
     // host, where a 90 KB-capable device would otherwise vouch for a 64 KB one.
     int device;
     cudaGetDevice(&device);
-    return exl3_gemm_shape_smem(shape_idx, K) <= DevCtx::instance().get_smem_max(device);
+    return exl3_gemm_shape_smem(shape_idx, K) <= DevCtx::instance().get_smem_request(device);
 }
 
 // Hard gate for explicitly forced shapes, which skip the autotuner's shape_compat filter.
@@ -127,7 +127,7 @@ void exl3_gemm_check_smem(int shape_idx, int K, const char* who)
     int device;
     cudaGetDevice(&device);
     int need = exl3_gemm_shape_smem(shape_idx, K);
-    int have = DevCtx::instance().get_smem_max(device);
+    int have = DevCtx::instance().get_smem_request(device);
     TORCH_CHECK(need <= have, who, ": shape ", shape_idx, " at ", K,
                 " bpw needs ", need, " B of shared memory, device provides ", have);
 }

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -83,11 +83,37 @@ int exl3_gemm_tilesize_k[] = {EXL3_GEMM_TILESIZE_K};
 int exl3_gemm_tilesize_n[] = {EXL3_GEMM_TILESIZE_N};
 int exl3_gemm_blockdim[] = {EXL3_GEMM_BLOCKDIM};
 
+// Shared memory a shape/bitrate instantiation needs, mirroring the layout computed in
+// exl3_gemm_kernel_inner (sh_a and sh_b staged SH_STAGES deep, then the fp32 sh_c region).
+// Kept in sync with the static_assert there; used to reject shapes that exceed what a
+// device can actually give a block, which on Turing is 64 KB rather than 90.
+static const int exl3_gemm_sh_stages[] = {0, 6, 4, 4, 4};
+
+int exl3_gemm_shape_smem(int shape_idx, int K)
+{
+    const int TILESIZE_M = 16;
+    int tilesize_k = exl3_gemm_tilesize_k[shape_idx];
+    int tilesize_n = exl3_gemm_tilesize_n[shape_idx];
+    int sh_stages = exl3_gemm_sh_stages[shape_idx];
+
+    int sh_a_stage_size = TILESIZE_M * tilesize_k;                              // halfs
+    int sh_b_stage_size = (tilesize_k / 16) * (tilesize_n / 16) * 256 / 16 * K; // uint16s
+    int frags_n_per_warp = 2 * (tilesize_n / 16) / (EXL3_GEMM_BASE_THREADS / 32);
+    int sh_c_size = MAX(4 * EXL3_GEMM_BASE_THREADS * frags_n_per_warp,          // floats
+                        tilesize_n * TILESIZE_M);
+
+    return sh_stages * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size;
+}
+
 bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, int K)
 {
     int tilesize_k = exl3_gemm_tilesize_k[shape_idx];
     int tilesize_n = exl3_gemm_tilesize_n[shape_idx];
-    return (size_k % tilesize_k == 0) && (size_n % tilesize_n == 0);
+    if (size_k % tilesize_k || size_n % tilesize_n) return false;
+
+    int device;
+    cudaGetDevice(&device);
+    return exl3_gemm_shape_smem(shape_idx, K) <= DevCtx::instance().get_smem_max(device);
 }
 
 // Instance tables, [K][cb] -> array indexed by shape_idx. Row 0 unused (no K = 0 instances)

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cu
@@ -83,26 +83,17 @@ int exl3_gemm_tilesize_k[] = {EXL3_GEMM_TILESIZE_K};
 int exl3_gemm_tilesize_n[] = {EXL3_GEMM_TILESIZE_N};
 int exl3_gemm_blockdim[] = {EXL3_GEMM_BLOCKDIM};
 
-// Shared memory a shape/bitrate instantiation needs, mirroring the layout computed in
-// exl3_gemm_kernel_inner (sh_a and sh_b staged SH_STAGES deep, then the fp32 sh_c region).
-// Kept in sync with the static_assert there; used to reject shapes that exceed what a
-// device can actually give a block, which on Turing is 64 KB rather than 90.
-static const int exl3_gemm_sh_stages[] = {0, 6, 4, 4, 4};
-
+// Shared memory a shape/bitrate instantiation needs. Derived from the EXL3_GEMM_SHAPE_n
+// macros via exl3_gemm_smem_bytes(), which the kernel itself static_asserts against, so this
+// cannot drift from the actual layout. Used to reject shapes exceeding what a device will
+// give a block - 64 KB on Turing rather than 90.
+//
+// shmem_out_had = true: the GEMM path stages a full output tile for the fused output Hadamard,
+// which is the larger of the two sh_c variants, so this is the conservative bound for both it
+// and the MoE kernel (which passes false).
 int exl3_gemm_shape_smem(int shape_idx, int K)
 {
-    const int TILESIZE_M = 16;
-    int tilesize_k = exl3_gemm_tilesize_k[shape_idx];
-    int tilesize_n = exl3_gemm_tilesize_n[shape_idx];
-    int sh_stages = exl3_gemm_sh_stages[shape_idx];
-
-    int sh_a_stage_size = TILESIZE_M * tilesize_k;                              // halfs
-    int sh_b_stage_size = (tilesize_k / 16) * (tilesize_n / 16) * 256 / 16 * K; // uint16s
-    int frags_n_per_warp = 2 * (tilesize_n / 16) / (EXL3_GEMM_BASE_THREADS / 32);
-    int sh_c_size = MAX(4 * EXL3_GEMM_BASE_THREADS * frags_n_per_warp,          // floats
-                        tilesize_n * TILESIZE_M);
-
-    return sh_stages * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size;
+    return exl3_gemm_smem_bytes_for_shape(shape_idx, K, true);
 }
 
 bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, int K)

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
@@ -3,6 +3,8 @@
 int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int bits, bool multi);
 int exl3_gemm_num_kernel_shapes();
 bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, int bits);
+// Dynamic shared memory (bytes) a (shape, bitrate) instantiation requests at launch
+int exl3_gemm_shape_smem(int shape_idx, int bits);
 
 #define EXL3_GEMM_T_ARGS \
     const int bits, \

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
@@ -5,6 +5,8 @@ int exl3_gemm_num_kernel_shapes();
 bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, int bits);
 // Dynamic shared memory (bytes) a (shape, bitrate) instantiation requests at launch
 int exl3_gemm_shape_smem(int shape_idx, int bits);
+// Throws if the shape does not fit the current device; for paths that bypass shape_compat
+void exl3_gemm_check_smem(int shape_idx, int bits, const char* who);
 
 #define EXL3_GEMM_T_ARGS \
     const int bits, \

--- a/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_kernel_map.cuh
@@ -82,6 +82,53 @@ typedef void (*fp_exl3_mgemm_kernel) (EXL3_MGEMM_ARGS);
 
 #define EXL3_GEMM_BASE_THREADS 256
 
+// Dynamic shared memory a (shape, bitrate) instantiation stages, as laid out by
+// exl3_gemm_kernel_inner: SH_STAGES deep double-buffered A and B tiles, then the fp32 sh_c
+// region. Single definition, used both by that kernel's static_assert and by the host-side
+// shape filter, so the two cannot disagree about what a shape costs.
+//
+// shmem_out_had is the GEMM's sh_c variant (it stages a full output tile for the fused output
+// Hadamard); the MoE kernel passes false and only needs the reduction scratch.
+// Parameters are ordered to match the EXL3_GEMM_SHAPE_n expansion (TILESIZE_M, TILESIZE_K,
+// TILESIZE_N, SH_STAGES, FRAG_STAGES) so the macro can be splatted in directly; frag_stages
+// is a register-pipelining depth and does not affect shared memory.
+__host__ __device__ constexpr int exl3_gemm_smem_bytes(
+    int tilesize_m, int tilesize_k, int tilesize_n, int sh_stages, int frag_stages,
+    int bits, bool shmem_out_had)
+{
+    (void) frag_stages;
+    int tileblocks_k = tilesize_k / 16;
+    int tileblocks_n = tilesize_n / 16;
+    int frags_n_per_warp = 2 * tileblocks_n / (EXL3_GEMM_BASE_THREADS / 32);
+
+    int sh_a_stage_size = tilesize_m * tilesize_k;                             // halfs
+    int sh_b_stage_size = tileblocks_k * tileblocks_n * 256 / 16 * bits;       // uint16s
+    int sh_c_size = 4 * EXL3_GEMM_BASE_THREADS * frags_n_per_warp;             // floats
+    int sh_c_had = shmem_out_had ? tilesize_n * tilesize_m : 0;
+    if (sh_c_had > sh_c_size) sh_c_size = sh_c_had;
+
+    return sh_stages * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size;
+}
+
+// Same, addressed by shape index: expands the EXL3_GEMM_SHAPE_n macro so the tile dims and
+// stage count come from the one place they are declared, rather than a parallel table that
+// has to be updated by hand whenever a shape changes.
+#define EXL3_GEMM_SMEM_FOR_SHAPE(_shape, _bits, _had) \
+    exl3_gemm_smem_bytes(_shape, _bits, _had)
+
+__host__ __device__ constexpr int exl3_gemm_smem_bytes_for_shape(
+    int shape_idx, int bits, bool shmem_out_had)
+{
+    switch (shape_idx)
+    {
+        case 1: return EXL3_GEMM_SMEM_FOR_SHAPE(EXL3_GEMM_SHAPE_1, bits, shmem_out_had);
+        case 2: return EXL3_GEMM_SMEM_FOR_SHAPE(EXL3_GEMM_SHAPE_2, bits, shmem_out_had);
+        case 3: return EXL3_GEMM_SMEM_FOR_SHAPE(EXL3_GEMM_SHAPE_3, bits, shmem_out_had);
+        case 4: return EXL3_GEMM_SMEM_FOR_SHAPE(EXL3_GEMM_SHAPE_4, bits, shmem_out_had);
+        default: return 0;
+    }
+}
+
 // Instance arrays are indexed by shape and defined per (K, cb) so each codebook compiles as a separate
 // translation unit (see comp_units/exl3_comp_unit_K_cbX.cu)
 

--- a/exllamav3/exllamav3_ext/quant/exl3_moe.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe.cu
@@ -206,6 +206,10 @@ void exl3_moe
     int num_sms = DevCtx::instance().get_num_sms(device);
     int cc = DevCtx::instance().get_cc(device);
     int* locks = DevCtx::instance().get_locks(device);
+    // Every MoE instantiation fits in 44 KB (TILESIZE_N caps at 256, unlike the GEMM's 512),
+    // so clamping the request to the device limit never excludes a shape here; it only stops
+    // Turing's 64 KB cap from rejecting the fixed 90 KB ask.
+    int smem_max = DevCtx::instance().get_smem_max(device);
 
     // Launch. All blocks of the grid must be co-resident for the group barriers, so groups * width <= num_sms.
     // With a known number of active experts, launch only as many groups as there are experts and widen them to
@@ -227,7 +231,7 @@ void exl3_moe
 
     if (moe_kernel_attr_set[device].find((void*) kernel) == moe_kernel_attr_set[device].end())
     {
-        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_max);
         moe_kernel_attr_set[device].insert((void*) kernel);
         cuda_check(cudaPeekAtLastError());
     }
@@ -293,7 +297,7 @@ void exl3_moe
         grid_dim,
         block_dim,
         kernelArgs,
-        SMEM_MAX,
+        smem_max,
         stream
     );
 

--- a/exllamav3/exllamav3_ext/quant/exl3_moe.cu
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe.cu
@@ -209,7 +209,7 @@ void exl3_moe
     // Every MoE instantiation fits in 44 KB (TILESIZE_N caps at 256, unlike the GEMM's 512),
     // so clamping the request to the device limit never excludes a shape here; it only stops
     // Turing's 64 KB cap from rejecting the fixed 90 KB ask.
-    int smem_max = DevCtx::instance().get_smem_max(device);
+    int smem_max = DevCtx::instance().get_smem_request(device);
 
     // Launch. All blocks of the grid must be co-resident for the group barriers, so groups * width <= num_sms.
     // With a known number of active experts, launch only as many groups as there are experts and widen them to

--- a/exllamav3/modules/attention_fn/bc_attn.py
+++ b/exllamav3/modules/attention_fn/bc_attn.py
@@ -61,6 +61,16 @@ def _is_pow2(n: int) -> bool:
     return n > 0 and (n & (n - 1)) == 0
 
 
+class BCKernelTooLarge(RuntimeError):
+    """An AOT-compiled BC kernel needs more shared memory than the device provides.
+
+    Signals 'decline to the eager path', not a bug: the BC kernels bake their tile shapes in
+    as constexprs sized for Ampere-and-later shared memory, while the eager Triton path picks
+    tiles per device. Raised at compile time so the BC builders can catch it during setup
+    rather than surfacing an opaque driver error at launch.
+    """
+
+
 def _compile_kernel(device: torch.device, fn, signature: dict, constexprs: dict,
                     num_warps: int, num_stages: int):
     key = (device.index, fn.__name__, tuple(sorted(constexprs.items())), num_warps, num_stages,
@@ -84,6 +94,17 @@ def _compile_kernel(device: torch.device, fn, signature: dict, constexprs: dict,
         with torch.cuda.device(device):
             src = ASTSource(fn = fn, signature = sig, constexprs = constexprs, attrs = attrs)
             ck = triton.compile(src, options = {"num_warps": num_warps, "num_stages": num_stages})
+            # The tile shapes here are fixed constexprs chosen for a ~100 KB smem device. On a
+            # 64 KB device (Turing) the cubin still compiles, but TritonKernel's
+            # CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES would fail with an opaque
+            # "CUDA driver error". Raise something the BC builders can recognize instead, so
+            # they decline and the eager path (which does size its tiles per device) runs.
+            smem_limit = torch.cuda.get_device_properties(device).shared_memory_per_block_optin
+            if ck.metadata.shared > smem_limit:
+                raise BCKernelTooLarge(
+                    f"{fn.__name__}: {ck.metadata.shared} B of shared memory exceeds the "
+                    f"device limit of {smem_limit} B"
+                )
             k = ext.TritonKernel(ck.asm["cubin"], ck.metadata.name, ck.metadata.num_warps, ck.metadata.shared)
         _kernel_cache[key] = k
     return k
@@ -569,7 +590,10 @@ class BCAttn:
         # argument patched into the graph
         skey = (tuple(inv_freq.shape) if inv_freq is not None else None, causal)
         if self.slot_widths.get((bsz, q_len, regime), ...) != skey:
-            self._configure(bsz, q_len, causal, regime)
+            try:
+                self._configure(bsz, q_len, causal, regime)
+            except BCKernelTooLarge:
+                return None
             self.slot_widths[(bsz, q_len, regime)] = skey
         y = torch.empty((bsz, q_len, self.hidden_size), dtype = self.o_dtype, device = x.device)
         self.bc.run(bsz, q_len, x, y, cache_seqlens, block_table, position, positions,

--- a/exllamav3/modules/attention_fn/bc_attn.py
+++ b/exllamav3/modules/attention_fn/bc_attn.py
@@ -99,7 +99,8 @@ def _compile_kernel(device: torch.device, fn, signature: dict, constexprs: dict,
             # CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES would fail with an opaque
             # "CUDA driver error". Raise something the BC builders can recognize instead, so
             # they decline and the eager path (which does size its tiles per device) runs.
-            smem_limit = torch.cuda.get_device_properties(device).shared_memory_per_block_optin
+            from .triton_paged import _dev_smem_limit
+            smem_limit = _dev_smem_limit(device)
             if ck.metadata.shared > smem_limit:
                 raise BCKernelTooLarge(
                     f"{fn.__name__}: {ck.metadata.shared} B of shared memory exceeds the "

--- a/exllamav3/modules/attention_fn/bc_dsa.py
+++ b/exllamav3/modules/attention_fn/bc_dsa.py
@@ -5,7 +5,7 @@ import torch
 from ...ext import exllamav3_ext as ext
 from ...constants import PAGE_SIZE
 from ...util.tensor import g_tensor_cache
-from .bc_attn import _compile_kernel
+from .bc_attn import _compile_kernel, BCKernelTooLarge
 from .dsa_triton import _dsa_attn_split_kernel, _dsa_attn_combine_kernel, _dsa_indexer_fewq_kernel
 
 """
@@ -303,7 +303,12 @@ class BCDsa:
             return None
 
         if self.bc.needs_configure(seq, regime):
-            self._configure(seq, regime)
+            try:
+                self._configure(seq, regime)
+            except BCKernelTooLarge:
+                # Tiles too large for this device's shared memory; the eager path sizes
+                # its own and handles the same work
+                return None
 
         # Refresh the block-table static once per job step (any compressor layer may be the
         # one to do it; sliding layers never touch it, so this is tracked separately from
@@ -596,7 +601,10 @@ class BCDsaBatch:
         """x (B, S, hidden) fp16 contiguous, bt (rows, npr) i32 device batch block table.
         Returns y (B, S, hidden) fp32 (a static: consume before the next BC call)."""
         if self.bc.needs_configure(B, S):
-            self._configure(B, S)
+            try:
+                self._configure(B, S)
+            except BCKernelTooLarge:
+                return None
 
         pin = self.pins[self.pin_i]
         self.pin_i = (self.pin_i + 1) % len(self.pins)

--- a/exllamav3/modules/attention_fn/bc_mla.py
+++ b/exllamav3/modules/attention_fn/bc_mla.py
@@ -4,7 +4,7 @@ from ...ext import exllamav3_ext as ext
 from ...constants import PAGE_SIZE
 from ...util.tensor import g_tensor_cache
 from .bc_attn import bc_attn_enable, _trace_build, _compile_kernel, _get_sm_count, _is_pow2, \
-    MAX_BSZ, MAX_QLEN
+    BCKernelTooLarge, MAX_BSZ, MAX_QLEN
 
 """
 Graph-captured decode attention for MLA (BC_MLAttention): the whole decode block -- q
@@ -537,7 +537,10 @@ class BCMLA:
                         ext_indices = ext_indices.to(x.device)
 
         if (bsz, q_len, regime) not in self.configured:
-            self._configure(bsz, q_len, regime)
+            try:
+                self._configure(bsz, q_len, regime)
+            except BCKernelTooLarge:
+                return None
             self.configured.add((bsz, q_len, regime))
         y = torch.empty((bsz, q_len, self.hidden_size), dtype = self.o_dtype, device = x.device)
         self.bc.run(bsz, q_len, x, y, cache_seqlens, block_table, position, positions,

--- a/exllamav3/modules/attention_fn/dispatch.py
+++ b/exllamav3/modules/attention_fn/dispatch.py
@@ -6,6 +6,7 @@ from .bighead_scalar import fn_bighead_scalar_attn
 from .torch import fn_torch_sdpa_fallback_cache, fn_torch_sdpa_fallback_nocache
 from .xformers import fn_xformers_cutlass_fallback_cache, fn_xformers_cutlass_fallback_nocache
 from .triton_paged import (
+    _dev_smem_limit,
     _qc_staging,
     fn_triton_paged_attn,
     fn_triton_paged_attn_longq,
@@ -132,8 +133,14 @@ def attn_dispatch(
         assert block_table is not None
         assert cache_seqlens is not None
         layer = cache if isinstance(cache, CacheLayer) else cache.layers[cache_idx, cache_instance or 0]
+        # The quant-direct path commits to Triton: it writes K/V into the packed cache before
+        # the attention call and then dispatches over _fns_qc, which has no non-Triton member.
+        # A backend miss there is therefore fatal rather than recoverable, so on devices where
+        # the Triton kernels may not fit in shared memory (Turing, 64 KB) take the
+        # dequantize-then-attend path instead, which can fall through to SDPA/xformers.
+        qc_smem_ok = _dev_smem_limit(q.device) >= 96 * 1024
         if (
-            _qc_attn and has_triton and
+            _qc_attn and has_triton and qc_smem_ok and
             isinstance(layer, CacheLayer_quant) and
             layer.compand_a == 0.0 and
             q.dtype == torch.float16 and

--- a/exllamav3/modules/attention_fn/dispatch.py
+++ b/exllamav3/modules/attention_fn/dispatch.py
@@ -6,7 +6,7 @@ from .bighead_scalar import fn_bighead_scalar_attn
 from .torch import fn_torch_sdpa_fallback_cache, fn_torch_sdpa_fallback_nocache
 from .xformers import fn_xformers_cutlass_fallback_cache, fn_xformers_cutlass_fallback_nocache
 from .triton_paged import (
-    _dev_smem_limit,
+    _dev_small_smem,
     _qc_staging,
     fn_triton_paged_attn,
     fn_triton_paged_attn_longq,
@@ -138,7 +138,7 @@ def attn_dispatch(
         # A backend miss there is therefore fatal rather than recoverable, so on devices where
         # the Triton kernels may not fit in shared memory (Turing, 64 KB) take the
         # dequantize-then-attend path instead, which can fall through to SDPA/xformers.
-        qc_smem_ok = _dev_smem_limit(q.device) >= 96 * 1024
+        qc_smem_ok = not _dev_small_smem(q.device)
         if (
             _qc_attn and has_triton and qc_smem_ok and
             isinstance(layer, CacheLayer_quant) and

--- a/exllamav3/modules/attention_fn/dsa_triton.py
+++ b/exllamav3/modules/attention_fn/dsa_triton.py
@@ -903,13 +903,15 @@ def dsa_attn(
         # halve the head tile (perf is irrelevant with asserts on)
         num_stages = min(num_stages, 2)
         block_h = min(block_h, 16)
-    # The defaults (block_h 32, D_c 512, 3 stages) stage ~140 KB, which fits the ~99 KB of an
-    # Ampere-or-later device only because Triton counts the live subset - on a 64 KB device it
-    # does not fit at all, and Triton raises rather than shrinking. Shrink the head tile and
-    # pipeline depth the same way the debug path above already does.
+    # The defaults (block_h 32, block_n 32, 3 stages) stage ~140 KB against the ~99 KB an
+    # Ampere-or-later device provides; a 64 KB device cannot hold them at all, and Triton
+    # raises rather than shrinking. The KV tiles dominate at DeepSeek's D_c = 512
+    # (block_n x 512 x 2 B per stage), so the kv tile has to come down along with the head
+    # tile and the pipeline depth - the debug path above already does the latter two.
     if _dev_smem_limit(q.device) < 96 * 1024:
         num_stages = min(num_stages, 2)
         block_h = min(block_h, 8)
+        block_n = min(block_n, 16)
     dbg_pages = -(-(pool_c.numel() // max(D_c, 1)) // max(page_size, 1)) if dsa_debug_bounds else 0
     if nc_block:
         n_splits = 1

--- a/exllamav3/modules/attention_fn/dsa_triton.py
+++ b/exllamav3/modules/attention_fn/dsa_triton.py
@@ -30,7 +30,7 @@ The lightning-indexer scoring kernel is shared as-is between raw-token (V3.2) an
 import os
 import torch
 from ...util.tensor import g_tensor_cache
-from .triton_paged import _dev_smem_limit
+from .triton_paged import _dev_small_smem
 
 # EXL3_DSA_DEBUG_BOUNDS=1: compile the JIT DSA kernels with device-side bounds asserts on
 # every block-table page read and gathered pool index (names the kernel and traps at the
@@ -908,7 +908,7 @@ def dsa_attn(
     # raises rather than shrinking. The KV tiles dominate at DeepSeek's D_c = 512
     # (block_n x 512 x 2 B per stage), so the kv tile has to come down along with the head
     # tile and the pipeline depth - the debug path above already does the latter two.
-    if _dev_smem_limit(q.device) < 96 * 1024:
+    if _dev_small_smem(q.device):
         num_stages = min(num_stages, 2)
         block_h = min(block_h, 8)
         block_n = min(block_n, 16)

--- a/exllamav3/modules/attention_fn/dsa_triton.py
+++ b/exllamav3/modules/attention_fn/dsa_triton.py
@@ -30,6 +30,7 @@ The lightning-indexer scoring kernel is shared as-is between raw-token (V3.2) an
 import os
 import torch
 from ...util.tensor import g_tensor_cache
+from .triton_paged import _dev_smem_limit
 
 # EXL3_DSA_DEBUG_BOUNDS=1: compile the JIT DSA kernels with device-side bounds asserts on
 # every block-table page read and gathered pool index (names the kernel and traps at the
@@ -902,6 +903,13 @@ def dsa_attn(
         # halve the head tile (perf is irrelevant with asserts on)
         num_stages = min(num_stages, 2)
         block_h = min(block_h, 16)
+    # The defaults (block_h 32, D_c 512, 3 stages) stage ~140 KB, which fits the ~99 KB of an
+    # Ampere-or-later device only because Triton counts the live subset - on a 64 KB device it
+    # does not fit at all, and Triton raises rather than shrinking. Shrink the head tile and
+    # pipeline depth the same way the debug path above already does.
+    if _dev_smem_limit(q.device) < 96 * 1024:
+        num_stages = min(num_stages, 2)
+        block_h = min(block_h, 8)
     dbg_pages = -(-(pool_c.numel() // max(D_c, 1)) // max(page_size, 1)) if dsa_debug_bounds else 0
     if nc_block:
         n_splits = 1

--- a/exllamav3/modules/attention_fn/dsa_triton.py
+++ b/exllamav3/modules/attention_fn/dsa_triton.py
@@ -1026,6 +1026,15 @@ def dsa_indexer_scores(
         bt = block_table.reshape(-1)
     dbg = 1 if (dsa_debug_bounds and epp) else 0
     dbg_pages = -(-k_idx.shape[0] // epp) if dbg else 0
+    # The default tiles (block_m 64, block_n 128) stage ~96 KB, which a 64 KB device cannot
+    # hold at all; Triton raises OutOfResources at launch rather than recompiling smaller.
+    # Halving both keeps the kernel shape intact at a quarter of the staged bytes. Note this
+    # must happen before S_stride is computed, since that is a function of block_n and the
+    # scores buffer it sizes is what the kernel indexes.
+    if _dev_small_smem(q_idx.device):
+        block_m = min(block_m, 32)
+        block_n = min(block_n, 64)
+        num_stages = min(num_stages, 2)
     S_stride = triton.cdiv(max(T, 1), block_n) * block_n
     if scores is None:
         # Deliberately a per-call allocation: the shape grows with the visible context, so it

--- a/exllamav3/modules/attention_fn/mla_triton.py
+++ b/exllamav3/modules/attention_fn/mla_triton.py
@@ -45,6 +45,7 @@ import os
 import torch
 
 from ...util.tensor import g_tensor_cache
+from .triton_paged import _dev_small_smem
 
 # Debug aid: synchronize and error-check after every MLA kernel launch, so an async illegal
 # memory access is attributed to the kernel that caused it instead of a later sync point
@@ -937,6 +938,12 @@ def mla_attn_triton_decode(
         # scheduler overlaps anyway); swept best on Ampere/Ada/Blackwell at 512-wide latents.
         # fp16: smaller tiles, deeper pipeline
         block_n = (32 if D_c <= 512 else 16) if qc is None else (_qc_bn_override or 64)
+        # A 64 KB device cannot hold the wide tile: at DeepSeek-V4's D_c=512/D_r=64 the fp16
+        # path stages block_n * 576 * 2 B per stage, i.e. 108 KB at (32, 3 stages) and still
+        # 72 KB at 2 stages. Dropping to the narrow tile the D_c > 512 case already uses puts
+        # it at 54 KB. Triton raises OutOfResources rather than shrinking on its own.
+        if _dev_small_smem(q_lat.device):
+            block_n = min(block_n, 16)
     if num_stages is None:
         num_stages = 3 if qc is None else 1
     if num_warps is None:
@@ -1207,6 +1214,10 @@ def mla_attn_triton_prefill(
         block_m = 32 if qc is None else 16
     if block_n is None:
         block_n = 32 if qc is None else 64
+    # Same 64 KB ceiling as the paged kernel above; see the note there.
+    if _dev_small_smem(q_lat.device):
+        block_m = min(block_m, 16)
+        block_n = min(block_n, 16)
     if num_stages is None:
         num_stages = 2 if qc is None else 1
 

--- a/exllamav3/modules/attention_fn/triton_paged.py
+++ b/exllamav3/modules/attention_fn/triton_paged.py
@@ -1222,6 +1222,16 @@ def paged_attn_triton_decode(
 
     if block_n is None:
         block_n = max(16, 8192 // head_dim)   # K + V tiles in smem across num_stages
+        # That default fixes block_n * head_dim at 8192, i.e. 32 KB of K + V per stage, so at
+        # the default depth of 2 the kv tiles alone are 64 KB and a Turing device cannot hold
+        # them at all. Unlike the other kernels here this one does not merely lose occupancy:
+        # _smem_fallback would turn the OutOfResources into a dispatch miss and every decode
+        # step would run on SDPA, when a narrower kv tile keeps it on Triton. Halve until it
+        # fits - the k loop runs more iterations, the kernel shape is unchanged.
+        if _dev_small_smem(q.device):
+            budget = int(_dev_smem_limit(q.device) * 0.9)
+            while block_n > 16 and block_n * head_dim * 4 * num_stages > budget:
+                block_n //= 2
 
     group_size = n_q_heads // n_kv_heads
     block_m = triton.next_power_of_2(q_len)

--- a/exllamav3/modules/attention_fn/triton_paged.py
+++ b/exllamav3/modules/attention_fn/triton_paged.py
@@ -26,6 +26,22 @@ from .common import AttnArgs, get_non_causal_span_arglist
 
 _decode_sm_count = {}
 _smem_limit = {}
+_small_smem = {}
+
+
+def _dev_small_smem(device) -> bool:
+    """True on devices whose shared memory is too small for the stock Triton tile configs.
+
+    Gated on compute capability rather than a byte threshold: the configs are sized for the
+    ~99 KB that sm_80 and later report, and every pre-Ampere part is materially below that
+    (Turing 64 KB, Volta 96 KB). A byte comparison would have to sit within a few KB of the
+    real Ampere value to separate them, which makes it fragile against exactly the parts it
+    is meant to classify.
+    """
+    dev = device.index if hasattr(device, "index") else device
+    if dev not in _small_smem:
+        _small_smem[dev] = torch.cuda.get_device_capability(dev)[0] < 8
+    return _small_smem[dev]
 
 
 def _dev_smem_limit(device) -> int:
@@ -1855,7 +1871,7 @@ def paged_attn_triton_prefill(
     # halves the staged bytes and keeps the kv tile (and thus the inner-loop shape) intact,
     # which costs occupancy but not correctness. Triton raises rather than shrinking on its
     # own, so this has to be decided before the launch.
-    if _dev_smem_limit(q.device) < 96 * 1024:
+    if _dev_small_smem(q.device):
         cfg = (max(16, cfg[0] // 2), cfg[1], cfg[2], cfg[3])
     num_stages_forced = num_stages is not None
     block_m = block_m or cfg[0]

--- a/exllamav3/modules/attention_fn/triton_paged.py
+++ b/exllamav3/modules/attention_fn/triton_paged.py
@@ -35,10 +35,21 @@ def _dev_smem_limit(device) -> int:
     Turing provides 64 KB, and Triton does not degrade gracefully: exceeding the limit raises
     OutOfResources at launch rather than recompiling smaller. Configs therefore have to be
     chosen against the real limit up front.
+
+    Queried through the extension rather than torch: get_device_properties() only grew a
+    shared-memory attribute in recent versions (absent in 2.6), and the extension already
+    asks the driver for cudaDevAttrMaxSharedMemoryPerBlockOptin. Falls back to the compute
+    capability, which fixes the limit for every architecture the library supports.
     """
     dev = device.index
     if dev not in _smem_limit:
-        _smem_limit[dev] = torch.cuda.get_device_properties(device).shared_memory_per_block_optin
+        try:
+            from ...ext import exllamav3_ext as ext
+            limit = ext.g_get_smem_max(dev)
+        except (ImportError, AttributeError):
+            major = torch.cuda.get_device_capability(device)[0]
+            limit = 64 * 1024 if major < 8 else 96 * 1024
+        _smem_limit[dev] = limit
     return _smem_limit[dev]
 
 

--- a/exllamav3/modules/attention_fn/triton_paged.py
+++ b/exllamav3/modules/attention_fn/triton_paged.py
@@ -24,6 +24,62 @@ except ImportError:
 
 from .common import AttnArgs, get_non_causal_span_arglist
 
+_decode_sm_count = {}
+_smem_limit = {}
+
+
+def _dev_smem_limit(device) -> int:
+    """Usable dynamic shared memory per block, cached per device.
+
+    The Triton tile configs below are sized for the ~100 KB that Ampere and later provide.
+    Turing provides 64 KB, and Triton does not degrade gracefully: exceeding the limit raises
+    OutOfResources at launch rather than recompiling smaller. Configs therefore have to be
+    chosen against the real limit up front.
+    """
+    dev = device.index
+    if dev not in _smem_limit:
+        _smem_limit[dev] = torch.cuda.get_device_properties(device).shared_memory_per_block_optin
+    return _smem_limit[dev]
+
+
+def _oom_is_smem(e: BaseException) -> bool:
+    """True for Triton's shared-memory OutOfResources, which is recoverable by re-dispatch.
+
+    The tile configs are pre-shrunk for small-smem devices, but that reasoning is per-kernel
+    and cannot cover every geometry a caller might present. Treating this one error as a
+    dispatch miss lets the attention dispatcher fall through to the next backend (SDPA,
+    xformers) instead of aborting the forward pass. Any other error still propagates.
+    """
+    if not has_triton:
+        return False
+    from triton.runtime.errors import OutOfResources
+    return isinstance(e, OutOfResources) and "shared memory" in str(e)
+
+
+def _smem_fallback(fn):
+    """Turn a shared-memory OutOfResources into a dispatch miss (None).
+
+    attn_dispatch treats None as 'this backend does not handle these arguments' and moves on
+    to the next candidate, so a Triton kernel that will not fit degrades to a slower backend
+    instead of killing the forward pass. Applied to the dispatcher entry points only, so
+    direct callers still see the original error.
+    """
+    import functools
+
+    @functools.wraps(fn)
+    def wrapper(args):
+        try:
+            return fn(args)
+        except Exception as e:
+            if _oom_is_smem(e):
+                return None
+            raise
+
+    return wrapper
+
+
+
+
 
 def _is_power_of_2(x: int) -> bool:
     return x > 0 and (x & (x - 1)) == 0
@@ -1054,60 +1110,6 @@ def _paged_attn_decode_combine_kernel(
         out_tile = _rot_h32(out_tile, h32, BLOCK_ROWS, head_dim)
     out_base = ((batch * q_len + row_q) * n_q_heads + q_head) * head_dim
     tl.store(out + out_base[:, None] + offs_d[None, :], out_tile, mask=valid_row[:, None])
-
-
-_decode_sm_count = {}
-_smem_limit = {}
-
-
-def _dev_smem_limit(device) -> int:
-    """Usable dynamic shared memory per block, cached per device.
-
-    The Triton tile configs below are sized for the ~100 KB that Ampere and later provide.
-    Turing provides 64 KB, and Triton does not degrade gracefully: exceeding the limit raises
-    OutOfResources at launch rather than recompiling smaller. Configs therefore have to be
-    chosen against the real limit up front.
-    """
-    dev = device.index
-    if dev not in _smem_limit:
-        _smem_limit[dev] = torch.cuda.get_device_properties(device).shared_memory_per_block_optin
-    return _smem_limit[dev]
-
-
-def _oom_is_smem(e: BaseException) -> bool:
-    """True for Triton's shared-memory OutOfResources, which is recoverable by re-dispatch.
-
-    The tile configs are pre-shrunk for small-smem devices, but that reasoning is per-kernel
-    and cannot cover every geometry a caller might present. Treating this one error as a
-    dispatch miss lets the attention dispatcher fall through to the next backend (SDPA,
-    xformers) instead of aborting the forward pass. Any other error still propagates.
-    """
-    if not has_triton:
-        return False
-    from triton.runtime.errors import OutOfResources
-    return isinstance(e, OutOfResources) and "shared memory" in str(e)
-
-
-def _smem_fallback(fn):
-    """Turn a shared-memory OutOfResources into a dispatch miss (None).
-
-    attn_dispatch treats None as 'this backend does not handle these arguments' and moves on
-    to the next candidate, so a Triton kernel that will not fit degrades to a slower backend
-    instead of killing the forward pass. Applied to the dispatcher entry points only, so
-    direct callers still see the original error.
-    """
-    import functools
-
-    @functools.wraps(fn)
-    def wrapper(args):
-        try:
-            return fn(args)
-        except Exception as e:
-            if _oom_is_smem(e):
-                return None
-            raise
-
-    return wrapper
 
 
 def paged_attn_triton_decode(

--- a/exllamav3/modules/attention_fn/triton_paged.py
+++ b/exllamav3/modules/attention_fn/triton_paged.py
@@ -639,6 +639,7 @@ def paged_attn_triton_longq(
     return out
 
 
+@_smem_fallback
 def fn_triton_paged_attn(args: AttnArgs) -> torch.Tensor | None:
     if (
         not has_triton or
@@ -668,6 +669,7 @@ def fn_triton_paged_attn(args: AttnArgs) -> torch.Tensor | None:
     )
 
 
+@_smem_fallback
 def fn_triton_paged_attn_longq(args: AttnArgs) -> torch.Tensor | None:
     if (
         not has_triton or
@@ -1055,6 +1057,58 @@ def _paged_attn_decode_combine_kernel(
 
 
 _decode_sm_count = {}
+_smem_limit = {}
+
+
+def _dev_smem_limit(device) -> int:
+    """Usable dynamic shared memory per block, cached per device.
+
+    The Triton tile configs below are sized for the ~100 KB that Ampere and later provide.
+    Turing provides 64 KB, and Triton does not degrade gracefully: exceeding the limit raises
+    OutOfResources at launch rather than recompiling smaller. Configs therefore have to be
+    chosen against the real limit up front.
+    """
+    dev = device.index
+    if dev not in _smem_limit:
+        _smem_limit[dev] = torch.cuda.get_device_properties(device).shared_memory_per_block_optin
+    return _smem_limit[dev]
+
+
+def _oom_is_smem(e: BaseException) -> bool:
+    """True for Triton's shared-memory OutOfResources, which is recoverable by re-dispatch.
+
+    The tile configs are pre-shrunk for small-smem devices, but that reasoning is per-kernel
+    and cannot cover every geometry a caller might present. Treating this one error as a
+    dispatch miss lets the attention dispatcher fall through to the next backend (SDPA,
+    xformers) instead of aborting the forward pass. Any other error still propagates.
+    """
+    if not has_triton:
+        return False
+    from triton.runtime.errors import OutOfResources
+    return isinstance(e, OutOfResources) and "shared memory" in str(e)
+
+
+def _smem_fallback(fn):
+    """Turn a shared-memory OutOfResources into a dispatch miss (None).
+
+    attn_dispatch treats None as 'this backend does not handle these arguments' and moves on
+    to the next candidate, so a Triton kernel that will not fit degrades to a slower backend
+    instead of killing the forward pass. Applied to the dispatcher entry points only, so
+    direct callers still see the original error.
+    """
+    import functools
+
+    @functools.wraps(fn)
+    def wrapper(args):
+        try:
+            return fn(args)
+        except Exception as e:
+            if _oom_is_smem(e):
+                return None
+            raise
+
+    return wrapper
+
 
 def paged_attn_triton_decode(
     q: torch.Tensor,
@@ -1200,6 +1254,7 @@ def paged_attn_triton_decode(
     return out
 
 
+@_smem_fallback
 def fn_triton_paged_attn_decode(args: AttnArgs) -> torch.Tensor | None:
     if (
         not has_triton or
@@ -1783,6 +1838,12 @@ def paged_attn_triton_prefill(
         cfg = (64, 32, 8, 2)
     else:
         cfg = (32, 16, 4, 2)
+    # Turing only offers 64 KB, so the stock tiles overcommit by ~50%. Halving the q tile
+    # halves the staged bytes and keeps the kv tile (and thus the inner-loop shape) intact,
+    # which costs occupancy but not correctness. Triton raises rather than shrinking on its
+    # own, so this has to be decided before the launch.
+    if _dev_smem_limit(q.device) < 96 * 1024:
+        cfg = (max(16, cfg[0] // 2), cfg[1], cfg[2], cfg[3])
     num_stages_forced = num_stages is not None
     block_m = block_m or cfg[0]
     block_n = block_n or cfg[1]
@@ -1889,6 +1950,7 @@ def paged_attn_triton_prefill(
     return out
 
 
+@_smem_fallback
 def fn_triton_attn_nocache(args: AttnArgs) -> torch.Tensor | None:
     """Non-cached attention through the prefill kernel's direct-kv source (NEW_KV=2)."""
     if (
@@ -1917,6 +1979,7 @@ def fn_triton_attn_nocache(args: AttnArgs) -> torch.Tensor | None:
     )
 
 
+@_smem_fallback
 def fn_triton_paged_attn_prefill(args: AttnArgs) -> torch.Tensor | None:
     if (
         not has_triton or
@@ -2141,6 +2204,7 @@ def varlen_attn_triton(
     return out.unsqueeze(0) if squeeze else out
 
 
+@_smem_fallback
 def fn_triton_varlen_attn(args: AttnArgs) -> torch.Tensor | None:
     if (
         not has_triton or
@@ -2167,6 +2231,7 @@ def fn_triton_varlen_attn(args: AttnArgs) -> torch.Tensor | None:
     )
 
 
+@_smem_fallback
 def fn_triton_paged_attn_decode_qc(args: AttnArgs) -> torch.Tensor | None:
     if (
         args.q_cache is None or
@@ -2195,6 +2260,7 @@ def fn_triton_paged_attn_decode_qc(args: AttnArgs) -> torch.Tensor | None:
     )
 
 
+@_smem_fallback
 def fn_triton_paged_attn_prefill_qc(args: AttnArgs) -> torch.Tensor | None:
     if (
         args.q_cache is None or

--- a/exllamav3/modules/dsv4.py
+++ b/exllamav3/modules/dsv4.py
@@ -1345,6 +1345,7 @@ class DSV4Attention(Module):
         is device-driven (per-job state from `arr`, slot/block-table indirection
         in-kernel)."""
         from .attention_fn.dsa_triton import dsa_attn, _dsa_indexer_fewq_kernel
+        from .attention_fn.triton_paged import _dev_small_smem
         import triton
         device = x.device
         a_pos, a_floor, a_beg, a_ec, a_slots, a_klen = arr.unbind(0)
@@ -1380,16 +1381,21 @@ class DSV4Attention(Module):
                     int(RopeStyle.GPTJ), 1.0, None, None, 1e-6, 0.0, 0.0, 0, 1, 0)
                 wts = g_tensor_cache.get(device, (R, Hi), torch.half, "dsv4_b_wts")
                 self.idx_weights.inner.bc.run(x.view(R, -1), wts)
-                s_max = -(-kl.capacity // 128) * 128
+                # BLOCK_N 128 stages ~96 KB, which a 64 KB device (Turing) cannot hold;
+                # Triton raises OutOfResources at launch rather than recompiling smaller.
+                # s_max is both the score-buffer stride and the tile alignment, so it has to
+                # track BLOCK_N - hence one variable for both rather than a literal 128.
+                idx_bn = 64 if _dev_small_smem(device) else 128
+                s_max = -(-kl.capacity // idx_bn) * idx_bn
                 scores = g_tensor_cache.get(device, (R, s_max), torch.half, "dsv4_b_scores")
                 with torch.cuda.device(device):
-                    _dsa_indexer_fewq_kernel[(R, triton.cdiv(s_max, 128))](
+                    _dsa_indexer_fewq_kernel[(R, triton.cdiv(s_max, idx_bn))](
                         qi.view(R, Hi, Di), wts.view(R, Hi), kl.pool_idx.view(-1, Di),
                         scores, a_ec, R, a_pos, a_ec, bt_st,
                         bt_st.stride(0),
                         H_i = Hi, H_pad = max(triton.next_power_of_2(Hi), 16), D_i = Di,
                         S_stride = s_max, compress_rate = m,
-                        scale = Di ** -0.5 * Hi ** -0.5, BLOCK_N = 128,
+                        scale = Di ** -0.5 * Hi ** -0.5, BLOCK_N = idx_bn,
                         SEQ = S, MULTIROW = 1, EPP = kl.epp,
                         DEBUG_BOUNDS = 1 if dsa_debug_bounds else 0,
                         DEBUG_PAGES = kl.num_pages if dsa_debug_bounds else 0,

--- a/exllamav3/modules/dsv4.py
+++ b/exllamav3/modules/dsv4.py
@@ -1306,7 +1306,11 @@ class DSV4Attention(Module):
                 bcd = build_bc_dsa_batch(self, rsl, kl)
                 self._bc_dsa_batch[id(rsl)] = bcd if bcd is not None else False
             if bcd:
-                return bcd.run(x, B, S, pos_l, floor_l, beg_l, ec_l, slot_l, bt)
+                y = bcd.run(x, B, S, pos_l, floor_l, beg_l, ec_l, slot_l, bt)
+                # None means the BC path declined (e.g. its fixed tiles do not fit this
+                # device's shared memory); fall through to the eager batched body below
+                if y is not None:
+                    return y
 
         # Eager batched body (capture reference / fallback): per-job state in a device
         # array, same kernels as the graphs

--- a/tests/sm75_dsv4.py
+++ b/tests/sm75_dsv4.py
@@ -1,0 +1,90 @@
+"""
+DeepSeek-V4-Flash 2.77bpw on Turing, with MoE experts offloaded to system RAM.
+
+This is the case the port was built for: 93 GiB of weights against 4x15 GiB of T4. The routed
+experts of the leading MoE layers run on the CPU (--moe_cpu_offload), which also exercises the
+CPU handoff path and DeepSeek's DSA sparse attention - neither of which the smaller models
+touch.
+
+The offload path spawns worker processes, so this must run under a __main__ guard.
+
+    python tests/sm75_dsv4.py <model_dir> [cpu_layers]
+"""
+
+import sys
+import time
+
+import torch
+
+from exllamav3 import Cache, Config, Generator, Job, Model, Tokenizer
+from exllamav3.generator.sampler import GreedySampler
+
+
+def main():
+    model_dir = sys.argv[1]
+    cpu_layers = int(sys.argv[2]) if len(sys.argv) > 2 else 40
+
+    props = torch.cuda.get_device_properties(0)
+    print(f"device: {props.name} sm_{props.major}{props.minor} "
+          f"x{torch.cuda.device_count()}  smem_optin={props.shared_memory_per_block_optin}",
+          flush=True)
+
+    config = Config.from_directory(model_dir)
+    config.infer_params.moe_cpu_offload = cpu_layers
+    print(f"moe_cpu_offload: {cpu_layers} layers", flush=True)
+
+    model = Model.from_config(config)
+    # 4096 rather than a token-count minimum: DeepSeek-V4's load-time autosplit probe runs a
+    # full chunk through attention and asserts the cache can hold it.
+    cache = Cache(model, max_num_tokens=4096)
+
+    t0 = time.time()
+    model.load(progressbar=True)
+    print(f"load: {time.time() - t0:.0f}s", flush=True)
+
+    tokenizer = Tokenizer.from_config(config)
+    generator = Generator(model=model, cache=cache, tokenizer=tokenizer)
+
+    prompt = (
+        "<|begin_of_sentence|><|User|>Name three primary colors."
+        "<|Assistant|></think>"
+    )
+    job = Job(
+        input_ids=tokenizer.encode(prompt, add_bos=False),
+        max_new_tokens=32,
+        sampler=GreedySampler(),
+    )
+    generator.enqueue(job)
+
+    out = ""
+    first = None
+    n = 0
+    while generator.num_remaining_jobs():
+        for r in generator.iterate():
+            if r.get("stage") == "streaming":
+                if first is None:
+                    first = time.time()
+                n += 1
+            out += r.get("text", "")
+
+    if first and n > 1:
+        print(f"generate: {(n - 1) / (time.time() - first):.2f} tok/s over {n} tokens")
+
+    text = out.strip()
+    print("-" * 60)
+    print(text[:400])
+    print("-" * 60)
+
+    if len(text) < 10:
+        print(f"FAIL: output too short ({len(text)} chars)")
+        return 1
+    printable = sum(c.isascii() and (c.isprintable() or c.isspace()) for c in text) / len(text)
+    if printable < 0.95:
+        print(f"FAIL: {(1 - printable) * 100:.0f}% non-ASCII, likely garbage")
+        return 1
+    print(f"PASS: {len(text.split())} words, {printable * 100:.0f}% ASCII")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/sm75_dsv4.py
+++ b/tests/sm75_dsv4.py
@@ -25,8 +25,9 @@ def main():
     cpu_layers = int(sys.argv[2]) if len(sys.argv) > 2 else 40
 
     props = torch.cuda.get_device_properties(0)
+    from exllamav3.ext import exllamav3_ext as ext
     print(f"device: {props.name} sm_{props.major}{props.minor} "
-          f"x{torch.cuda.device_count()}  smem_optin={props.shared_memory_per_block_optin}",
+          f"x{torch.cuda.device_count()}  smem_optin={ext.g_get_smem_max(0)}",
           flush=True)
 
     config = Config.from_directory(model_dir)

--- a/tests/sm75_e2e.py
+++ b/tests/sm75_e2e.py
@@ -1,0 +1,80 @@
+"""
+End-to-end smoke test for the sm_75 port: load a real EXL3 model and generate greedily.
+
+The unit tests cover the GEMM in isolation. This exercises the paths they cannot: attention
+(which on Turing has no flash-attn and must fall through to the Triton/SDPA backends), the
+cache, the sampler, and the full stack of fused kernels a real forward pass touches. Greedy
+decoding makes the output reproducible, so a garbled result is a real failure rather than
+sampling noise.
+
+    python tests/sm75_e2e.py <model_dir>
+"""
+
+import sys
+import time
+
+import torch
+
+from exllamav3 import Cache, Config, Generator, Job, Model, Tokenizer
+from exllamav3.generator.sampler import GreedySampler
+
+
+def main(model_dir):
+    props = torch.cuda.get_device_properties(0)
+    print(f"device: {props.name}  sm_{props.major}{props.minor}  "
+          f"smem_optin={props.shared_memory_per_block_optin}")
+
+    config = Config.from_directory(model_dir)
+    model = Model.from_config(config)
+    cache = Cache(model, max_num_tokens=4096)
+
+    t0 = time.time()
+    model.load()
+    print(f"load: {time.time() - t0:.1f}s")
+
+    tokenizer = Tokenizer.from_config(config)
+    generator = Generator(model=model, cache=cache, tokenizer=tokenizer)
+
+    prompt = (
+        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+        "Name three primary colors, comma separated, nothing else."
+        "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+
+    job = Job(
+        input_ids=tokenizer.encode(prompt, add_bos=False),
+        max_new_tokens=48,
+        sampler=GreedySampler(),
+    )
+    generator.enqueue(job)
+
+    out = ""
+    first = None
+    n = 0
+    while generator.num_remaining_jobs():
+        for r in generator.iterate():
+            if r.get("stage") == "streaming":
+                if first is None:
+                    first = time.time()
+                n += 1
+            out += r.get("text", "")
+
+    if first and n > 1:
+        print(f"generate: {(n - 1) / (time.time() - first):.1f} tok/s over {n} tokens")
+
+    print("-" * 60)
+    print(out.strip())
+    print("-" * 60)
+
+    # A working stack answers this; a broken matmul yields repetition or non-ASCII garbage.
+    lowered = out.lower()
+    hits = sum(c in lowered for c in ("red", "blue", "yellow", "green"))
+    if hits < 2:
+        print(f"FAIL: expected colour names, got {hits} matches")
+        return 1
+    print(f"PASS: {hits} colour names present")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/tests/sm75_e2e.py
+++ b/tests/sm75_e2e.py
@@ -66,13 +66,25 @@ def main(model_dir):
     print(out.strip())
     print("-" * 60)
 
-    # A working stack answers this; a broken matmul yields repetition or non-ASCII garbage.
-    lowered = out.lower()
-    hits = sum(c in lowered for c in ("red", "blue", "yellow", "green"))
-    if hits < 2:
-        print(f"FAIL: expected colour names, got {hits} matches")
+    # Judge coherence, not task completion: reasoning models spend the 48-token budget
+    # thinking and never reach the answer, which says nothing about kernel correctness.
+    # A broken matmul produces repetition or non-ASCII garbage, and both are caught here.
+    text = out.strip()
+    if len(text) < 20:
+        print(f"FAIL: output too short ({len(text)} chars)")
         return 1
-    print(f"PASS: {hits} colour names present")
+
+    printable = sum(c.isascii() and (c.isprintable() or c.isspace()) for c in text) / len(text)
+    if printable < 0.95:
+        print(f"FAIL: {(1 - printable) * 100:.0f}% non-ASCII, likely garbage")
+        return 1
+
+    words = text.lower().split()
+    if len(words) >= 12 and len(set(words)) < len(words) * 0.35:
+        print(f"FAIL: degenerate repetition ({len(set(words))}/{len(words)} unique)")
+        return 1
+
+    print(f"PASS: {len(words)} words, {len(set(words))} unique, {printable * 100:.0f}% ASCII")
     return 0
 
 

--- a/tests/sm75_e2e.py
+++ b/tests/sm75_e2e.py
@@ -21,8 +21,9 @@ from exllamav3.generator.sampler import GreedySampler
 
 def main(model_dir):
     props = torch.cuda.get_device_properties(0)
+    from exllamav3.ext import exllamav3_ext as ext
     print(f"device: {props.name}  sm_{props.major}{props.minor}  "
-          f"smem_optin={props.shared_memory_per_block_optin}")
+          f"smem_optin={ext.g_get_smem_max(0)}")
 
     config = Config.from_directory(model_dir)
     model = Model.from_config(config)

--- a/tests/sm75_ppttg.py
+++ b/tests/sm75_ppttg.py
@@ -1,0 +1,103 @@
+"""
+Prompt-processing (pp) and token-generation (tg) throughput on the sm_75 port.
+
+Reports the two numbers separately because they are bound by different things on Turing:
+prefill is compute/shared-memory bound in the GEMM and attention kernels, decode is bound by
+weight bandwidth (and, with MoE experts offloaded, by the PCIe/CPU handoff). A single
+"tok/s" figure hides which one the port actually costs.
+
+pp is measured from the generator's own prefill timing over a synthetic prompt of the
+requested length, tg from the streaming phase only, so neither includes load or tokenization.
+Greedy sampling throughout, so runs are comparable.
+
+    python tests/sm75_ppttg.py <model_dir> [--pp 512,2048] [--tg 64] [--moe-cpu N]
+"""
+
+import argparse
+import sys
+import time
+
+import torch
+
+from exllamav3 import Cache, Config, Generator, Job, Model, Tokenizer
+from exllamav3.generator.sampler import GreedySampler
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("model_dir")
+    p.add_argument("--pp", default="512,2048", help="prompt lengths to measure, comma separated")
+    p.add_argument("--tg", type=int, default=64, help="tokens to generate per run")
+    p.add_argument("--moe-cpu", type=int, default=0, help="MoE layers to offload to system RAM")
+    p.add_argument("--cache", type=int, default=8192, help="cache size in tokens")
+    p.add_argument("--warmup", action="store_true", default=True)
+    args = p.parse_args()
+
+    pp_lens = [int(x) for x in args.pp.split(",") if x]
+
+    props = torch.cuda.get_device_properties(0)
+    from exllamav3.ext import exllamav3_ext as ext
+    print(f"device: {props.name} sm_{props.major}{props.minor} x{torch.cuda.device_count()}  "
+          f"smem_optin={ext.g_get_smem_max(0)}", flush=True)
+
+    config = Config.from_directory(args.model_dir)
+    if args.moe_cpu:
+        config.infer_params.moe_cpu_offload = args.moe_cpu
+        print(f"moe_cpu_offload: {args.moe_cpu} layers", flush=True)
+
+    model = Model.from_config(config)
+    cache = Cache(model, max_num_tokens=args.cache)
+
+    t0 = time.time()
+    model.load(progressbar=False)
+    print(f"load: {time.time() - t0:.0f}s", flush=True)
+
+    tokenizer = Tokenizer.from_config(config)
+    generator = Generator(model=model, cache=cache, tokenizer=tokenizer)
+
+    def run(prompt_len, new_tokens):
+        # Distinct token ids so nothing dedupes or hits the prefix cache across runs
+        ids = torch.randint(
+            1000, 20000, (1, prompt_len), dtype=torch.long
+        )
+        job = Job(input_ids=ids, max_new_tokens=new_tokens, sampler=GreedySampler())
+        generator.enqueue(job)
+        res = None
+        n_stream = 0
+        t_first = None
+        while generator.num_remaining_jobs():
+            for r in generator.iterate():
+                if r.get("stage") == "streaming":
+                    if t_first is None:
+                        t_first = time.time()
+                    n_stream += 1
+                if r.get("eos"):
+                    res = r
+        return res, n_stream, t_first
+
+    if args.warmup:
+        # First call pays kernel autotuning and Triton JIT; excluded from every figure below
+        run(128, 8)
+
+    print(f"\n{'prompt':>8}  {'pp tok/s':>10}  {'tg tok/s':>10}")
+    print("-" * 32)
+    for n in pp_lens:
+        if n + args.tg > args.cache:
+            print(f"{n:>8}  {'skipped (cache too small)':>22}")
+            continue
+        res, n_stream, t_first = run(n, args.tg)
+        if res is None:
+            print(f"{n:>8}  {'no result':>10}")
+            continue
+        # The generator reports prefill separately from generation, and discounts whatever
+        # the page table already had cached
+        new_ctx = res["prompt_tokens"] - res["cached_tokens"]
+        pp = new_ctx / res["time_prefill"] if res["time_prefill"] > 0 else float("nan")
+        tg = res["new_tokens"] / res["time_generate"] if res["time_generate"] > 0 else float("nan")
+        print(f"{n:>8}  {pp:>10.1f}  {tg:>10.2f}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sm75_gemm.py
+++ b/tests/test_sm75_gemm.py
@@ -1,0 +1,121 @@
+"""
+Numerical validation for the sm_75 (Turing) port.
+
+The Turing path substitutes two mma.m16n8k8 for each mma.m16n8k16 and replaces cp.async with
+synchronous shared-memory stores. Both are meant to be exact, not approximate, so these tests
+compare the quantized GEMM against a dequantize-then-matmul reference computed by the same
+extension. A correct k-split reproduces the reference to fp16 rounding; a wrong fragment
+mapping (the realistic failure mode - half the k dimension dropped or double-counted) shows up
+as a large relative error, not a small one.
+
+Run on any device; on sm_80+ this is a regression test that the refactor changed nothing.
+
+    python -m pytest tests/test_sm75_gemm.py -v
+"""
+
+import pytest
+import torch
+
+from exllamav3.ext import exllamav3_ext as ext
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+DEV = "cuda:0"
+
+
+def _make_trellis(k, n, K, seed):
+    """Random EXL3 trellis plus the scale/flip vectors the kernel expects."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    trellis = torch.randint(
+        0, 65536, (k // 16, n // 16, 16 * K), generator=g, dtype=torch.int32
+    ).to(torch.int16).to(DEV)
+    suh = (torch.randn(k, generator=g) * 0.1).to(torch.float16).to(DEV)
+    svh = (torch.randn(n, generator=g) * 0.1).to(torch.float16).to(DEV)
+    return trellis, suh, svh
+
+
+def _reference(A, trellis, suh, svh, K, mcg, mul1):
+    """Dequantize B to fp16 (same codebook path, no mma) and matmul, as ground truth.
+
+    reconstruct_had_slice applies the same input/output Hadamard and scale/flip vectors the
+    fused kernel folds in, so this isolates exactly the tensor-core matmul under test.
+    """
+    k = trellis.shape[0] * 16
+    n = trellis.shape[1] * 16
+    B = torch.empty((k, n), dtype=torch.float16, device=DEV)
+    ext.reconstruct_had_slice(B, trellis, suh, svh, K, mcg, mul1, 0)
+    return (A.float() @ B.float()).to(torch.float16)
+
+
+@pytest.mark.parametrize("K", [2, 3, 4])
+@pytest.mark.parametrize("m", [1, 8, 16, 32])
+def test_gemm_matches_reconstruct(K, m):
+    """exl3_gemm must agree with reconstruct-then-matmul across the m regimes.
+
+    m sweeps the kernel's dispatch tiers deliberately: m=1 takes the GEMV path, m<=8 the
+    small-m reduction, m>16 the multi-pass loop. Each tier drives the mma differently, so a
+    broken k=8 split would not necessarily fail all of them.
+    """
+    k, n = 512, 512
+    trellis, suh, svh = _make_trellis(k, n, K, seed=K * 100 + m)
+    A = (torch.randn((m, k), device=DEV) * 0.5).to(torch.float16)
+
+    C = torch.empty((m, n), dtype=torch.float16, device=DEV)
+    A_had = torch.empty_like(A)
+    ext.exl3_gemm(A, trellis, C, suh, A_had, svh, 0, False, False, 0)
+
+    ref = _reference(A, trellis, suh, svh, K, False, False)
+
+    # fp16 accumulation over k=512 with values ~O(1); compare on relative RMS rather than
+    # elementwise tolerance, which fp16 rounding alone would breach on the tail.
+    err = (C.float() - ref.float()).square().mean().sqrt()
+    scale = ref.float().square().mean().sqrt()
+    rel = (err / scale).item()
+    assert rel < 0.02, f"K={K} m={m}: relative RMS error {rel:.4f}"
+
+
+@pytest.mark.parametrize("K", [2, 4])
+def test_gemm_deterministic(K):
+    """Repeat launches must be bit-identical.
+
+    The Turing cp.async fallback relies on the pipeline's existing __syncthreads() for
+    ordering. If that assumption were wrong, the result would be a race and would show up
+    here as run-to-run variation rather than as a wrong-but-stable answer.
+    """
+    k, n, m = 512, 512, 16
+    trellis, suh, svh = _make_trellis(k, n, K, seed=7)
+    A = (torch.randn((m, k), device=DEV) * 0.5).to(torch.float16)
+
+    outs = []
+    for _ in range(8):
+        C = torch.empty((m, n), dtype=torch.float16, device=DEV)
+        A_had = torch.empty_like(A)
+        ext.exl3_gemm(A, trellis, C, suh, A_had, svh, 0, False, False, 0)
+        torch.cuda.synchronize()
+        outs.append(C.clone())
+
+    for i, o in enumerate(outs[1:], 1):
+        assert torch.equal(outs[0], o), f"K={K}: launch {i} differs from launch 0"
+
+
+def test_smem_budget_respected():
+    """Selected shapes must fit the device's dynamic shared memory limit.
+
+    Turing caps dynamic smem at 64 KB while the kernels are written against 90 KB, so shape 4
+    at 8 bpw (66 KB) has to be filtered out rather than attempted. This asserts the filter is
+    actually consulted: every shape the kernel selector accepts must be launchable.
+    """
+    props = torch.cuda.get_device_properties(0)
+    limit = props.shared_memory_per_block_optin
+
+    k, n = 2048, 2048
+    for K in range(1, 9):
+        trellis, suh, svh = _make_trellis(k, n, K, seed=K)
+        A = (torch.randn((16, k), device=DEV) * 0.5).to(torch.float16)
+        C = torch.empty((16, n), dtype=torch.float16, device=DEV)
+        A_had = torch.empty_like(A)
+        # A shape that exceeds the limit would fail the launch here rather than being skipped
+        ext.exl3_gemm(A, trellis, C, suh, A_had, svh, 0, False, False, 0)
+        torch.cuda.synchronize()
+        assert torch.isfinite(C.float()).all(), f"K={K}: non-finite output (limit {limit})"

--- a/tests/test_sm75_gemm.py
+++ b/tests/test_sm75_gemm.py
@@ -106,8 +106,7 @@ def test_smem_budget_respected():
     at 8 bpw (66 KB) has to be filtered out rather than attempted. This asserts the filter is
     actually consulted: every shape the kernel selector accepts must be launchable.
     """
-    props = torch.cuda.get_device_properties(0)
-    limit = props.shared_memory_per_block_optin
+    limit = ext.g_get_smem_max(0)
 
     k, n = 2048, 2048
     for K in range(1, 9):


### PR DESCRIPTION
Adds Turing (sm_75) support, per #162 and #81. On a T4 today the build dies at PTX assembly:

```
ptxas error : Feature 'cp.async' requires .target sm_80 or higher
ptxas error : Feature '.m16n8k16' requires .target sm_80 or higher
```

The ask in #162 was explicitly "we'll take slower, what we can't take is not supported", and that is what this is. It is not competitive with Ampere and does not try to be.

**Result: DeepSeek-V4-Flash-0731-exl3 2.77bpw runs on 4x Tesla T4.**

Based on `dev` @ 843725c. ~185 lines of functional change; the rest is docs and three tests.

## Re: the three blockers in #162

Your assessment was that the GEMM kernel would need a complete redesign. Two of the three points turned out narrower than that, and I'd appreciate scrutiny on whether I'm wrong about them.

### 1. `mma.m16n8k16` → two `mma.m16n8k8`

You wrote that "the lane mappings for m16n8k8 are different so you can't just run two of those mmas instead."

For the `.row.col` layout EXL3 uses, I believe they do line up. In m16n8k16 the A fragment is `{a0,a1,a2,a3}` where `{a0,a1}` covers k=0..7 and `{a2,a3}` covers k=8..15, with the same lane-to-element mapping m16n8k8 uses for its two registers; B splits into `b0`/`b1` and C is identical in both. Chaining two k=8 mmas through one accumulator computes the same products over the same operands.

Not bit-identical, and I'd overstated this in an earlier revision of the branch: PTX doesn't specify the internal accumulation order of a k=16 step, and splitting forces one extra rounding of the partial sum at the k=8 boundary. That's far below the quantization error already present at 2-4 bpw, and the tests bound it against a dequantize-then-matmul reference rather than asserting equality.

Sites: `ptx.cuh` (both accumulate variants) and `exl3_gemv_kernel.cuh` (`mma_ab_h` carries its own inline asm).

### 2. `cp.async` → synchronous 16 B copies

`cp_async()` degrades to a load/store pair through registers; `cp_async_fence()`/`cp_async_wait()` become no-ops.

This holds because the pipeline never relied on `cp.async.wait_group` alone for ordering: `wait_stage()` in `exl3_gemm_inner.cuh` issues a `__syncthreads()` after every wait, and a synchronous store has retired by then. The cost is the lost global→shared overlap. `test_gemm_deterministic` guards the assumption — a race would surface as run-to-run variation rather than a wrong-but-stable answer.

### 3. Shared memory

`SMEM_MAX` still bounds the compile-time `static_assert`, but what gets *requested* is now per-device via `DevCtx::get_smem_request()`. Shapes that don't fit are filtered out of kernel selection instead of failing at launch. On Turing only GEMM shape 4 at 8 bpw (66 KB) is excluded; every MoE instantiation fits in 44 KB.

The footprint is derived rather than tabulated: `exl3_gemm_smem_bytes()` takes the `EXL3_GEMM_SHAPE_n` expansion (where `SH_STAGES` is already declared) and reproduces the layout `exl3_gemm_kernel_inner` builds — and that kernel `static_assert`s per instantiation that the two agree, so drift between the filter and reality is a compile error, not an out-of-bounds read past the `extern __shared__` block. (An earlier revision hand-maintained a `{0,6,4,4,4}` table; verified the derived values are identical across all 32 shape/bitrate combinations.)

## Two more that only showed up on hardware

**Paths that abort rather than degrade.** The int8 GEMV sizes its shared memory against a fixed ~80 KB budget that the *device* code also depends on (the kernel recomputes `rows_per` from the same constants), so the host can't request less without desyncing the two — and `cudaFuncSetAttribute` failing there hits a `cuda_check` that kills the process. The quant-direct KV cache path writes K/V into the packed cache *before* dispatching over a Triton-only candidate list, so a backend miss is fatal rather than recoverable. Both are declined on small-smem devices. Quantized caches still work; they just materialize fp16 temporaries.

**Three attention paths with baked-in tiles.** `triton_paged.py` and `dsa_triton.py` now size tiles per device — at DeepSeek's `D_c = 512` the KV tiles dominate, so `block_n` has to come down too, or the one-shot DSA kernel asks for 140 KB. The batch-compiled AOT kernels (`bc_attn.py`/`bc_dsa.py`/`bc_mla.py`) have `constexpr` tile shapes that can't be resized, and their failure mode is an opaque `RuntimeError: CUDA driver error` out of `CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`; `_compile_kernel` now checks the compiled requirement and raises `BCKernelTooLarge`, which the builders catch to decline to the eager path.

Since Triton raises `OutOfResources` rather than recompiling smaller, the dispatcher entry points also treat that one error as a dispatch miss and fall through to SDPA/xformers.

## Verified on hardware

Tesla T4 (sm_75, `smem_optin=65536`), CUDA 13.0, torch 2.9.1+cu130, this branch:

| | Result |
|---|---|
| `tests/test_sm75_gemm.py` | 15 passed |
| Llama-3.2-1B-Instruct-exl3 4.0bpw (dense) | 134 tok/s, coherent |
| Qwen3-30B-A3B-exl3 3.0bpw (MoE) | 42.5 tok/s, coherent |
| DeepSeek-V4-Flash-0731-exl3 2.77bpw | 5.3 tok/s, coherent |

DeepSeek-V4 is 93 GiB of weights on 4x15 GiB with 40 MoE layers offloaded to system RAM, exercising MLA, DSA sparse attention and the CPU expert handoff:

```
The three primary colors are red, blue, and yellow. In additive color
models (like RGB), the primary colors are red, green, and blue.
```

`m` is swept 1/8/16/32 in the unit tests deliberately: m=1 takes the GEMV path, m≤8 the small-m reduction, m>16 the multi-pass loop, and each drives the mma differently, so a wrong fragment mapping wouldn't necessarily fail all of them.

### No Ampere regression

Also built and run on an RTX 3090 (sm_86, CUDA 12.4, torch 2.6), at the same final commit:

| Check | Result |
|---|---|
| `tests/test_sm75_gemm.py` | 15 passed |
| `g_get_cc` | 2 (`CC_AMPERE`, not `CC_OLD`) |
| `g_get_smem_max` | 101376 — raw driver value, unchanged |
| `_dev_small_smem` | False — tiles unshrunk, quant-direct cache and int8 GEMV both still active |

Every PTX substitution is behind `#if EXL3_SM75` (`__CUDA_ARCH__ < 800`), so an sm_80+ cubin is byte-identical to what it is today.

Worth flagging that an earlier revision of this branch *did* regress Ampere: `get_smem_max()` clamped the driver value to `SMEM_MAX`, which made sm_86 report 92160, fall under a 96 KB threshold, and take the Turing paths. Fixed by splitting the two meanings (`get_smem_max` = capability, `get_smem_request` = what a kernel may ask for) and keying the Python gates on compute capability `< 8` instead — Volta reports exactly 96 KB, so no byte threshold separates it from Ampere's 99 KB robustly.

## Cost on Turing

- No `cp.async`, so global→shared traffic no longer overlaps with compute
- Two mma instructions per tile instead of one
- 64 KB of shared memory caps tile sizes and occupancy
- No flash-attn; attention runs Triton or SDPA
- int8 GEMV and the batch-compiled (CUDA-graph) attention paths are declined

## Building

`TORCH_CUDA_ARCH_LIST` must include 7.5 — the release wheels contain no sm_75 cubin, and I have not touched the wheel matrix in this PR.

```bash
TORCH_CUDA_ARCH_LIST=7.5 MAX_JOBS=24 pip install --no-build-isolation -e .
```

## Points I'm least sure of

1. The m16n8k16 → 2x m16n8k8 fragment mapping, especially `mma_ab_h` which passes A as two `FragB` halves. If the lane mapping argument is wrong, this is the thing that's wrong.
2. Whether the synchronous `cp.async` fallback is genuinely race-free in every path, including `exl3_gemv_int8_kernel.cuh`'s staged unit. The claim rests entirely on existing `__syncthreads()` placement.
3. `exl3_gemm_shape_compat()` is now device-dependent but takes no device argument — it reads the current CUDA device. Every in-tree caller runs under a device guard, but it's a sharp edge on a mixed-arch host, and I'd rather thread a device through if you prefer.
4. Whether declining the int8 GEMV wholesale on small-smem devices is the right call versus making `gemv_int8_sq_rows_max()` device-aware. The latter is better but needs the kernel and host to agree on a runtime value, which is a larger change than I wanted to make unreviewed.

Happy to split this into separate PRs (PTX fallbacks / shared-memory sizing / attention tile sizing) if that's easier to review.
