### PR TITLE
Read max_position_embeddings from text_config for Qwen3.5 VL

### DIFF
--- a/exllamav3/architecture/qwen3_5.py
+++ b/exllamav3/architecture/qwen3_5.py
@@ -104,6 +104,10 @@ class Qwen3_5VLBaseConfig(Config):
             default_rope_theta = 10000000,
             config_dict = self.read_cfg(dict, text_cfg, no_default) if text_cfg else None
         )
+        # VL configs keep the text limit under text_config, while Config reads only the
+        # top-level key and otherwise falls back to 8192. Keep public metadata aligned with
+        # the RoPE settings actually used by attention.
+        self.max_position_embeddings = self.rope_settings.max_position_embeddings
 
         # Vision model settings
         if vision_model:
@@ -230,6 +234,7 @@ class Qwen3_5VLMoeBaseConfig(Config):
             default_rope_theta = 10000000,
             config_dict = self.read_cfg(dict, text_cfg, no_default) if text_cfg else None
         )
+        self.max_position_embeddings = self.rope_settings.max_position_embeddings
 
         # Vision model settings
         if vision_model:


### PR DESCRIPTION
Qwen3.5 VL keeps the text model settings under `text_config`. `Config` reads only the top-level `max_position_embeddings`, does not find it, and falls back to the generic 8192. So `config.max_position_embeddings` reports 8K for a model whose real limit is 262144.

Attention was already constructing RoPE from the nested value, so the runtime geometry was correct and only the public metadata was wrong. That still matters, because anything reading `config.max_position_embeddings` to size a cache or choose a context length gets the wrong number.

This sets `max_position_embeddings` from the rope settings that are already parsed, in both `Qwen3_5VLBaseConfig` and `Qwen3_5VLMoeBaseConfig`, so the reported value matches what attention uses.

I hit this loading Qwen3.8-27B, which reported 8192 instead of 262144.

Five lines, no change to attention behaviour.