### PR TITLE
RoPE: pick up mrope_section / mrope_interleaved in YaRN branch

### DIFF
--- a/exllamav3/util/rope.py
+++ b/exllamav3/util/rope.py
@@ -249,6 +249,13 @@ class RoPE:
 
     def _rope_params_yarn(self):
         rs = self.rope_settings
+        # PATCH: also pick up mrope_section / mrope_interleaved for multimodal
+        # models (Qwen3.5/3.8 VL). Without this, vision rendering crashes in
+        # get_mrope_freqs() with "TypeError: 'NoneType' object is not subscriptable".
+        if rs.rope_scaling:
+            if rs.rope_scaling.get("mrope_section") is not None:
+                self.mrope_section = rs.rope_scaling.get("mrope_section")
+                self.mrope_interleaved = rs.rope_scaling.get("mrope_interleaved")
         max_position_embeddings = rs.override_max_position_embeddings or rs.max_position_embeddings
         assert max_position_embeddings is not None, \
             "YaRN scaling requires explicit max_position_embeddings"


### PR DESCRIPTION
Multimodal models that combine YaRN context extension with mrope (e.g. Qwen3.5-VL / Qwen3.8-VL family, where the Qwen3.5/3.8 base ships `text_config.rope_parameters = {rope_type: "yarn", factor, ..., mrope_section, mrope_interleaved}`) hit a TypeError on the first vision request.

`_rope_params_yarn` only configured YaRN scaling and never read the `mrope_section` / `mrope_interleaved` keys. The complementary `_rope_params_default` path already did — but `match t` in `__init__` routes `rope_type == "yarn"` exclusively to yarn, so default is never called.

Result at inference time:

  File ".../exllamav3/util/rope.py", line 461, in get_mrope_freqs
    length = self.mrope_section[dim] * 3
TypeError: 'NoneType' object is not subscriptable

Workaround before this patch: copy `rope_parameters` into a separate `rope_scaling` block in the model config with `rope_type` rewritten to `"mrope"`. That re-routes to `_rope_params_default`, which does read mrope_section, but at the cost of losing yarn context extension and fights any other tool that consumes the same config (transformers, LM Studio, etc.).

Fix: in `_rope_params_yarn`, after `rs = self.rope_settings`, copy `mrope_section` / `mrope_interleaved` from `rs.rope_scaling` onto `self`, guarded so the patch is a no-op when those keys are absent. This keeps the YaRN scaling path intact and the model config untouched.

Validated end-to-end against Qwen3.5-27B-ABLITERATED EXL3 3.75bpw on RTX 4090 (TabbyAPI 1.4.6 + this patch):
  - vision module loads (30/30)
  - image + text request succeeds (200 OK, normal <|im_end|> stop)
  - model correctly enumerates shapes/colors and reads on-image text