### PR TITLE
Add DFlash2 speculative draft support

### DIFF
--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -7,6 +7,7 @@ from .decilm import DeciLMModel
 from .deepseek_v3 import DeepseekV3Model
 from .deepseek_v4 import DeepseekV4Model
 from .dflash import DFlashModel
+from .dflash2 import DFlash2Model
 from .dflash_laguna import DFlashLagunaModel
 from .dots1 import Dots1Model
 from .ernie4_5 import Ernie4_5Model
@@ -74,6 +75,7 @@ ARCHITECTURES = {
         DeepseekV3Model,
         DeepseekV4Model,
         DFlashModel,
+        DFlash2Model,
         DFlashLagunaModel,
         Dots1Model,
         Ernie4_5Model,

--- a/exllamav3/architecture/dflash.py
+++ b/exllamav3/architecture/dflash.py
@@ -63,6 +63,8 @@ class DFlashConfig(Config):
         self.mask_token_id = self.read_cfg(int, ["dflash_config->mask_token_id", "mask_token_id"], no_default)
         self.target_layer_ids = self.read_cfg(list, ["dflash_config->target_layer_ids", "target_layer_ids"], no_default)
         self.target_layer_ids = [i + self.tap_shift for i in self.target_layer_ids]
+        assert len(set(self.target_layer_ids)) == len(self.target_layer_ids), \
+            "DFlash target_layer_ids must be unique"
         self.block_size = self.read_cfg(int, ["block_size", "dflash_config->block_size"], no_default)
 
         # RoPE
@@ -212,6 +214,13 @@ class DFlashModel(Model):
             "block_table": torch.Tensor
             "cache_seqlens": torch.Tensor
         """
+
+        # Target states arrive in layer execution order. Reorder them only when the checkpoint's
+        # projection expects a different target_layer_ids order.
+        target_layer_ids = self.config.target_layer_ids
+        if target_layer_ids != sorted(target_layer_ids):
+            source_idx = {layer_id: idx for idx, layer_id in enumerate(sorted(target_layer_ids))}
+            target_hidden = [target_hidden[source_idx[layer_id]] for layer_id in target_layer_ids]
 
         # May update a few redundant tokens when batching, but we'd never draft longer than the cache length
         if lengths is not None:

--- a/exllamav3/architecture/dflash2.py
+++ b/exllamav3/architecture/dflash2.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+from typing_extensions import override
+import torch
+
+from .dflash import DFlashConfig, DFlashModel
+from ..model.config import no_default
+from ..modules.arch_specific.dflash2 import (
+    DFlash2Block, DFlash2DynConv, DFlash2Selector,
+)
+
+# DFlash2 draft model: a DFlash backbone with grouped dynamic convolutions around
+# every attention/MLP sublayer and a top-k candidate selector in place of row-wise argmax.
+#
+# Conventions:
+#   - Block input = [anchor, mask x (block_size-1)]; each remaining row predicts
+#     its own position and the selector walks candidates starting from the anchor.
+#   - Taps: reference reads HF hidden_states[target_layer_ids[i] + 1] = output
+#     of target layer id  =>  tap_shift 0 (exl3 export index = layer output).
+#   - Draft cache ctx K/V come from update_kv_from_target (fc+hidden_norm
+#     projected tap stream), inherited unchanged from the DFlash1 backbone;
+#     per-round writes at the new cache position overwrite the transient
+#     noise-block K/V, reproducing the reference's crop semantics.
+#   - Proposals are the greedy selector path (T-independent), verified by the
+#     stock accept-while-match rule — trivially lossless at every temperature
+#     (per-position output marginal equals the target distribution).
+
+
+class DFlash2Config(DFlashConfig):
+
+    arch_string = "DFlash2DraftModel"
+
+    # Reference extract uses hidden_states[id + 1] == output of layer id
+    tap_shift = 0
+
+    def __init__(
+        self,
+        directory: str,
+        model_classes: dict | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            model_classes or {"text": DFlash2Model},
+            **kwargs
+        )
+
+        self.conv_kernel_size = self.read_cfg(
+            int, ["dflash_config->conv_kernel_size", "conv_kernel_size"], 2)
+        self.conv_group_size = self.read_cfg(
+            int, ["dflash_config->conv_group_size", "conv_group_size"], 16)
+        self.selector_rank = self.read_cfg(
+            int, ["dflash_config->selector_rank", "selector_rank"], no_default)
+        self.selector_top_k = self.read_cfg(
+            int, ["dflash_config->selector_top_k", "selector_top_k"], no_default)
+        self.input_embedding_scale = float(self.read_cfg(
+            [float, int], ["dflash_config->input_embedding_scale", "input_embedding_scale"], 1.0))
+        self.output_multiplier = float(self.read_cfg(
+            [float, int], ["dflash_config->output_multiplier", "output_multiplier"], 1.0))
+        self.final_logit_softcapping = float(self.read_cfg(
+            [float, int], ["dflash_config->final_logit_softcapping", "final_logit_softcapping"], 0.0))
+        assert 0 < self.conv_kernel_size <= self.block_size, \
+            "DFlash2 conv_kernel_size must be positive and no larger than block_size"
+        assert self.conv_group_size > 0 and self.hidden_size % self.conv_group_size == 0, \
+            "DFlash2 hidden_size must be divisible by a positive conv_group_size"
+        assert self.selector_rank > 0, \
+            "DFlash2 selector_rank must be positive"
+        assert 0 < self.selector_top_k <= self.vocab_size, \
+            "DFlash2 selector_top_k must be between 1 and vocab_size"
+
+
+class DFlash2Model(DFlashModel):
+    """DFlash1 backbone rebuilt with dynconv-wrapped blocks + selector head."""
+
+    config_class = DFlash2Config
+
+    def __init__(
+        self,
+        config: DFlash2Config,
+        **kwargs
+    ):
+        # Build the DFlash1 backbone (input layer, plain blocks, final norm,
+        # caps, attach/update_kv_from_target machinery)
+        super().__init__(config, **kwargs)
+        self.input_layer.input_embedding_scale = config.input_embedding_scale
+
+        # Swap each TransformerBlock for a conv-wrapped DFlash2Block. Reuse the
+        # existing attention, MLP and RMSNorm modules from the DFlash backbone.
+        for idx in range(config.num_hidden_layers):
+            old = self.modules[self.first_block_idx + idx]
+            self.modules[self.first_block_idx + idx] = DFlash2Block(
+                config = config,
+                key = f"layers.{idx}",
+                layer_idx = idx,
+                attn = old.attn,
+                mlp = old.mlp,
+                attn_norm = old.attn_norm,
+                mlp_norm = old.mlp_norm,
+                attn_conv = DFlash2DynConv(
+                    config = config,
+                    key = f"layers.{idx}.attention_conv",
+                    hidden_size = config.hidden_size,
+                    kernel_size = config.conv_kernel_size,
+                    group_size = config.conv_group_size,
+                ),
+                mlp_conv = DFlash2DynConv(
+                    config = config,
+                    key = f"layers.{idx}.mlp_conv",
+                    hidden_size = config.hidden_size,
+                    kernel_size = config.conv_kernel_size,
+                    group_size = config.conv_group_size,
+                ),
+            )
+
+        self.selector = DFlash2Selector(
+            config = config,
+            key = "candidate_selector",
+            vocab_size = config.vocab_size,
+            hidden_size = config.hidden_size,
+            rank = config.selector_rank,
+            top_k = config.selector_top_k,
+        )
+        self.modules += [self.selector]
+
+    @override
+    def attach_to(self, target):
+        if target.loaded_tp:
+            raise NotImplementedError(
+                "DFlash2 does not support tensor-parallel targets because the selector needs top-k logits"
+            )
+        if target.config.vocab_size != self.config.vocab_size:
+            raise ValueError(
+                f"DFlash2 vocabulary size {self.config.vocab_size} does not match "
+                f"target vocabulary size {target.config.vocab_size}"
+            )
+        if target.config.hidden_size != self.config.hidden_size:
+            raise ValueError(
+                f"DFlash2 hidden size {self.config.hidden_size} does not match "
+                f"target hidden size {target.config.hidden_size}"
+            )
+        if not 0 <= self.config.mask_token_id < target.config.vocab_size:
+            raise ValueError("DFlash2 mask_token_id is outside the target vocabulary")
+        if target.logit_layer_idx is None:
+            raise ValueError("DFlash2 target has no compatible LM head")
+        if any(not 0 <= layer_id < target.config.num_hidden_layers
+               for layer_id in self.config.target_layer_ids):
+            raise ValueError("DFlash2 target_layer_ids contains a layer outside the target model")
+        super().attach_to(target)
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        assert input_ids.shape[-1] == 1, \
+            "DFlash2 expects one verified anchor token per draft block"
+        params["dflash2_anchor_ids"] = input_ids
+        return super().prepare_inputs(input_ids, params)
+
+    def sample_from_state(
+        self,
+        state: torch.Tensor,
+        params: dict
+    ) -> torch.Tensor:
+        """Target lm_head over all block rows, then the selector walk over
+        rows 1.. (rows predict their own position; row 0 is the anchor).
+        Returns (bsz, block) ids [anchor, path...]; the generator crops the
+        anchor. The selector is greedy; sampling remains lossless because the
+        target verifier still samples normally and accepts only exact matches."""
+        if self.attached_model().loaded_tp:
+            raise NotImplementedError(
+                "DFlash2Model does not yet support tensor-parallel targets"
+            )
+        ll = self.attached_model().logit_layer_idx
+        lm = self.attached_model().modules[ll]
+        logits = lm.prepare_for_device(state.half(), params)
+        logits = lm.forward(logits, params)
+        logits = logits[..., :self.attached_model().config.vocab_size]
+        if self.config.output_multiplier != 1.0:
+            logits = logits * self.config.output_multiplier
+        if self.config.final_logit_softcapping > 0.0:
+            softcap = self.config.final_logit_softcapping
+            logits = torch.tanh(logits / softcap) * softcap
+
+        dev = self.selector.device
+        anchor = params["dflash2_anchor_ids"][:, -1].to(dev)
+        export_conf = params.get("export_draft_conf", False)
+        walk = self.selector.walk(
+            state[:, 1:].to(dev), logits[:, 1:].to(dev).float(), anchor,
+            return_confidence = export_conf,
+        )
+        if export_conf:
+            path, confidence = walk
+            params["draft_conf"] = torch.cat(
+                (torch.zeros_like(confidence[:, :1]), confidence), dim = 1)
+        else:
+            path = walk
+        out = torch.empty(
+            (path.shape[0], path.shape[1] + 1),
+            dtype = torch.long, device = dev)
+        out[:, 0] = anchor
+        out[:, 1:] = path
+        return out
+
+    @classmethod
+    @override
+    def get_additional_compiled_tensors(cls, config: DFlash2Config) -> dict:
+        # Backbone fc norm (DFlash1) + conv base kernels + selector codebooks
+        tensors = dict(config.stc.list_tensors(prefix = cls.key_fc_norm))
+        tensors.update(config.stc.list_tensors(prefix = "candidate_selector."))
+        for idx in range(config.num_hidden_layers):
+            for conv in ("attention_conv", "mlp_conv"):
+                tensors.update(config.stc.list_tensors(
+                    prefix = f"layers.{idx}.{conv}.base_kernel"))
+        return tensors

--- a/exllamav3/generator/draft_confidence.py
+++ b/exllamav3/generator/draft_confidence.py
@@ -4,7 +4,7 @@ import math
 
 class DraftConfidenceCalibrator:
     """
-    Online mapping from a drafter's per-position confidence score (argmax logit) to an observed
+    Online mapping from a drafter's per-position confidence score to an observed
     acceptance probability, used to truncate draft blocks at the first position whose estimated
     acceptance falls below a target confidence.
 

--- a/exllamav3/generator/generator.py
+++ b/exllamav3/generator/generator.py
@@ -88,8 +88,8 @@ class Generator:
             Minimum number of tokens to match for n-gram draft (0 = disabled).
 
         :param dynamic_draft_tokens:
-            Adapt the per-round draft length to the workload. The draft is cut using drafter confidence
-            (argmax logit), calibrated online against observed acceptance rates (see draft_confidence). A
+            Adapt the per-round draft length to the workload. The draft is cut using a drafter-provided
+            confidence score, calibrated online against observed acceptance rates (see draft_confidence). A
             DFlash drafter still runs at its fixed diffusion block size and only the verified window shrinks;
             AR and MTP drafters stop the drafting loop itself early, saving one drafter forward per pruned
             position. The acceptance behavior of the surviving positions is unchanged. Has no effect on n-gram
@@ -97,7 +97,7 @@ class Generator:
 
         :param draft_confidence:
             Used with dynamic_draft_tokens and a draft model: target acceptance probability for drafted
-            positions, evaluated against an online mapping from drafter confidence (argmax logit) to observed
+            positions, evaluated against an online mapping from drafter confidence scores to observed
             acceptance rates. Scale-free and portable across model pairs. For DFlash (block produced at fixed
             cost) the block is cut at the first position whose estimated conditional acceptance drops below
             the target. For AR and MTP drafters (one forward per position, and a position only pays off if

--- a/exllamav3/modules/arch_specific/dflash.py
+++ b/exllamav3/modules/arch_specific/dflash.py
@@ -69,6 +69,7 @@ class DFlashInputLayer(Module):
                 self.register_submodule(aux_norm)
 
         self.mask_token_id = mask_token_id
+        self.input_embedding_scale = 1.0
 
         # Populated by attach_to()
         self.attached_model = None
@@ -103,4 +104,6 @@ class DFlashInputLayer(Module):
         else:
             x = self.attached_model().tp_producer.send(x)
             x = self.attached_model().tp_dispatch_master(mp_model_forward_embedding, (x, params))
+        if self.input_embedding_scale != 1.0:
+            x = x * self.input_embedding_scale
         return x

--- a/exllamav3/modules/arch_specific/dflash2.py
+++ b/exllamav3/modules/arch_specific/dflash2.py
@@ -1,0 +1,445 @@
+"""
+DFlash2-specific modules: grouped dynamic convolutions, the conv-wrapped
+transformer block, and the top-k candidate selector.
+
+Reference: the ``DFlash2DraftModel`` implementation in the ``dflash`` package.
+
+The residual stream stays in fp32, matching the standard transformer path.
+RMSNorm and convolution prepare outputs are fp16; convolution finish returns
+fp32 before the residual add.
+"""
+
+from __future__ import annotations
+from typing_extensions import override
+import torch
+import torch.nn.functional as F
+
+from ...model.config import Config
+from .. import Module, Linear, RMSNorm, Attention, GatedMLP
+from ...util.tensor import to2
+
+try:
+    import triton
+    import triton.language as tl
+    has_triton = True
+except ImportError:
+    has_triton = False
+
+    class _DummyTritonLanguage:
+        constexpr = object()
+
+    class _DummyTriton:
+        @staticmethod
+        def jit(fn):
+            return fn
+
+    triton = _DummyTriton()
+    tl = _DummyTritonLanguage()
+
+
+@triton.jit
+def _grouped_dynamic_convolve_kernel(
+    hidden,
+    dynamic,
+    base,
+    output,
+    dynamic_stride_b: tl.constexpr,
+    dynamic_stride_l: tl.constexpr,
+    dynamic_stride_k: tl.constexpr,
+    dynamic_stride_g: tl.constexpr,
+    length: tl.constexpr,
+    hidden_size: tl.constexpr,
+    groups: tl.constexpr,
+    kernel_size: tl.constexpr,
+    group_size: tl.constexpr,
+    channel_tiles: tl.constexpr,
+    BLOCK_L: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    group_tile = tl.program_id(1)
+    position_tile = tl.program_id(2)
+    group_idx = group_tile // channel_tiles
+    channel_tile = group_tile - group_idx * channel_tiles
+
+    positions = position_tile * BLOCK_L + tl.arange(0, BLOCK_L)
+    local_channels = channel_tile * BLOCK_C + tl.arange(0, BLOCK_C)
+    channels = group_idx * group_size + local_channels
+    position_mask = positions < length
+    channel_mask = local_channels < group_size
+    acc = tl.zeros((BLOCK_L, BLOCK_C), dtype = tl.float32)
+
+    for offset in range(kernel_size):
+        source_positions = positions - offset
+        source_mask = position_mask & (source_positions >= 0)
+        hidden_offsets = (
+            (batch_idx * length + source_positions[:, None]) * hidden_size +
+            channels[None, :]
+        )
+        values = tl.load(
+            hidden + hidden_offsets,
+            mask = source_mask[:, None] & channel_mask[None, :],
+            other = 0.0,
+        ).to(tl.float32)
+        base_values = tl.load(
+            base + offset * hidden_size + channels,
+            mask = channel_mask,
+            other = 0.0,
+        ).to(tl.float32)
+        dynamic_offsets = (
+            batch_idx * dynamic_stride_b +
+            positions * dynamic_stride_l +
+            offset * dynamic_stride_k +
+            group_idx * dynamic_stride_g
+        )
+        dynamic_values = tl.load(
+            dynamic + dynamic_offsets,
+            mask = position_mask,
+            other = 0.0,
+        ).to(tl.float32)
+        acc += values * (base_values[None, :] + dynamic_values[:, None])
+
+    output_offsets = (
+        (batch_idx * length + positions[:, None]) * hidden_size +
+        channels[None, :]
+    )
+    tl.store(
+        output + output_offsets,
+        acc,
+        mask = position_mask[:, None] & channel_mask[None, :],
+    )
+
+
+def _grouped_dynamic_convolve_torch(
+    hidden: torch.Tensor,
+    dynamic: torch.Tensor,
+    base: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    batch, length, hidden_size = hidden.shape
+    groups = hidden_size // group_size
+    blocks = hidden.float().view(batch, length, groups, group_size)
+    dynamic = dynamic.float().view(batch, length, base.shape[0], groups, 1)
+    output = torch.zeros_like(blocks)
+    for offset in range(min(base.shape[0], length)):
+        values = blocks[:, : length - offset]
+        kernel = base[offset].float().view(1, 1, groups, group_size)
+        weights = kernel + dynamic[:, offset:, offset]
+        output[:, offset:] += weights * values
+    return output.view(batch, length, hidden_size).to(hidden.dtype)
+
+
+def _grouped_dynamic_convolve(
+    hidden: torch.Tensor,
+    dynamic: torch.Tensor,
+    base: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Transcribed from dflash.model._grouped_dynamic_convolve.
+
+    hidden  [b, l, H]; dynamic [b, l, taps, H//group_size]; base [taps, H].
+    output[t] = sum_taps  base[tap] * x[t - tap] + dyn[tap][t] * x[t - tap]
+    (causal; tap 0 = current position). Caller controls dtype.
+    """
+    if not hidden.is_cuda or not has_triton:
+        return _grouped_dynamic_convolve_torch(hidden, dynamic, base, group_size)
+
+    hidden = hidden.contiguous()
+    base = base.contiguous()
+    batch, length, hidden_size = hidden.shape
+    kernel_size = base.shape[0]
+    groups = hidden_size // group_size
+    output = torch.empty_like(hidden)
+    block_l = triton.next_power_of_2(min(length, 16))
+    block_c = triton.next_power_of_2(min(group_size, 64))
+    channel_tiles = triton.cdiv(group_size, block_c)
+    num_warps = 2 if block_l * block_c < 256 else 4
+    grid = batch, groups * channel_tiles, triton.cdiv(length, block_l)
+    with torch.cuda.device(hidden.device):
+        _grouped_dynamic_convolve_kernel[grid](
+            hidden,
+            dynamic,
+            base,
+            output,
+            dynamic_stride_b = dynamic.stride(0),
+            dynamic_stride_l = dynamic.stride(1),
+            dynamic_stride_k = dynamic.stride(2),
+            dynamic_stride_g = dynamic.stride(3),
+            length = length,
+            hidden_size = hidden_size,
+            groups = groups,
+            kernel_size = kernel_size,
+            group_size = group_size,
+            channel_tiles = channel_tiles,
+            BLOCK_L = block_l,
+            BLOCK_C = block_c,
+            num_warps = num_warps,
+            num_stages = 1,
+        )
+    return output
+
+
+class DFlash2DynConv(Module):
+    """Two-tap grouped dynamic conv (dflash ``GroupedDynamicCausalConv``).
+
+    Checkpoint tensors (raw, unquantized, bf16):
+      {key}.base_kernel        [2, kernel_size, hidden]   (prepare base, finish base)
+      {key}.kernel_projection  Linear(hidden -> 2 * kernel_size * groups)
+
+    prepare() uses fp16 input/output. finish() uses fp32 input/output so the
+    surrounding block keeps its residual stream in fp32.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        hidden_size: int,
+        kernel_size: int,
+        group_size: int,
+        qmap: str | None = None,
+    ):
+        super().__init__(config, key, None)
+        self.module_name = "DFlash2DynConv"
+        self.hidden_size = hidden_size
+        self.kernel_size = kernel_size
+        self.group_size = group_size
+        self.groups = hidden_size // group_size
+
+        self.proj = Linear(
+            config = config,
+            key = f"{key}.kernel_projection",
+            in_features = hidden_size,
+            out_features = 2 * kernel_size * self.groups,
+            qmap = qmap,
+            trim_padded_out = True,
+        )
+        self.register_submodule(self.proj)
+
+        self.base_kernel = None
+        self.key_base_kernel = f"{key}.base_kernel"
+        self.base_kernel_numel = 2 * kernel_size * hidden_size
+        self.caps.update({"x_cpu": True})
+
+    def optimizer_targets(self):
+        return []
+
+    @override
+    def weights_numel(self):
+        return self.base_kernel_numel + super().weights_numel()
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.base_kernel = self.config.stc.get_tensor(
+            self.key_base_kernel, self.device, optional = False, allow_bf16 = True
+        )
+        expected_shape = (2, self.kernel_size, self.hidden_size)
+        if self.base_kernel.shape != expected_shape:
+            raise ValueError(
+                f"Expected {self.key_base_kernel} shape {expected_shape}, "
+                f"got {tuple(self.base_kernel.shape)}"
+            )
+
+    @override
+    def unload(self):
+        self.base_kernel = None
+        super().unload()
+
+    @override
+    def get_tensors(self):
+        t = super().get_tensors()
+        if self.base_kernel is not None:
+            t[self.key_base_kernel] = self.base_kernel.contiguous()
+        return t
+
+    def prepare(self, x: torch.Tensor, params: dict):
+        """x [b, l, H] (post-norm) -> (convolved half, finish-time dynamic half)"""
+        x = x.half()
+        dyn = self.proj.forward(x, params)
+        dyn = dyn.view(*x.shape[:-1], 2, self.kernel_size, self.groups)
+        y = _grouped_dynamic_convolve(
+            x, dyn[..., 0, :, :], self.base_kernel[0], self.group_size)
+        return y, dyn[..., 1, :, :]
+
+    def finish(self, x: torch.Tensor, dynamic: torch.Tensor) -> torch.Tensor:
+        return _grouped_dynamic_convolve(
+            x.float(), dynamic, self.base_kernel[1], self.group_size)
+
+    @override
+    def forward(self, x: torch.Tensor, params: dict, out_dtype = None):
+        y, dyn = self.prepare(x, params)
+        return to2(self.finish(y, dyn), out_dtype, torch.float)
+
+
+class DFlash2Block(Module):
+    """Reference DFlash2 decoder layer (Qwen3DFlashDecoderLayer):
+
+        r = x; x = attn_norm(x); x, k = attn_conv.prepare(x); x = attn(x);
+        x = attn_conv.finish(x, k); x = r + x
+        r = x; x = mlp_norm(x);  x, k = mlp_conv.prepare(x);  x = mlp(x);
+        x = mlp_conv.finish(x, k); x = r + x
+
+    Residual stream fp32; normed sub-ops fp16.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        layer_idx: int,
+        attn: Attention,
+        mlp: GatedMLP,
+        attn_norm: RMSNorm,
+        mlp_norm: RMSNorm,
+        attn_conv: DFlash2DynConv,
+        mlp_conv: DFlash2DynConv,
+    ):
+        super().__init__(config, key, None)
+        self.module_name = "DFlash2Block"
+        self.layer_idx = layer_idx
+        self.attn = attn
+        self.mlp = mlp
+        self.attn_norm = attn_norm
+        self.mlp_norm = mlp_norm
+        self.attn_conv = attn_conv
+        self.mlp_conv = mlp_conv
+        for m in (attn, mlp, attn_norm, mlp_norm, attn_conv, mlp_conv):
+            self.register_submodule(m)
+
+    def optimizer_targets(self):
+        return [self.attn.optimizer_targets(), self.mlp.optimizer_targets()]
+
+    @override
+    def forward(self, x: torch.Tensor, params: dict, out_dtype = None):
+        y = self.attn_norm.forward(x, params, out_dtype = torch.half)
+        y, kernel = self.attn_conv.prepare(y, params)
+        y = self.attn.forward(y, params)
+        y = self.attn_conv.finish(y, kernel)
+        x += y
+
+        y = self.mlp_norm.forward(x, params, out_dtype = torch.half)
+        y, kernel = self.mlp_conv.prepare(y, params)
+        y = self.mlp.forward(y, params)
+        y = self.mlp_conv.finish(y, kernel)
+        x += y
+
+        return to2(x, out_dtype, torch.float)
+
+
+class DFlash2Selector(Module):
+    """Top-k candidate selector (dflash ``CandidateSelector``).
+
+    Checkpoint tensors (raw, unquantized, BARE keys — no .weight suffix):
+      candidate_selector.predecessor_codebook  [vocab, rank]
+      candidate_selector.successor_codebook    [vocab, rank]
+      candidate_selector.hidden_projection     Linear(hidden -> rank, no bias)
+
+    walk(): top-k(16) per row from draft logits, then greedy chained walk
+      S_t(a, b) = U_t(b) + <A(a) ⊙ H(h_t), B(b)>,  a = previous path token
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        key: str,
+        vocab_size: int,
+        hidden_size: int,
+        rank: int,
+        top_k: int,
+    ):
+        super().__init__(config, key, None)
+        self.module_name = "DFlash2Selector"
+        self.vocab_size = vocab_size
+        self.rank = rank
+        self.top_k = top_k
+
+        self.hidden_proj = Linear(
+            config = config,
+            key = f"{key}.hidden_projection",
+            in_features = hidden_size,
+            out_features = rank,
+            trim_padded_out = True,
+        )
+        self.register_submodule(self.hidden_proj)
+
+        self.key_pred = f"{key}.predecessor_codebook"
+        self.key_succ = f"{key}.successor_codebook"
+        self.pred_codebook = None
+        self.succ_codebook = None
+        self.caps.update({"x_cpu": True})
+
+    def optimizer_targets(self):
+        return []
+
+    @override
+    def weights_numel(self):
+        return 2 * self.vocab_size * self.rank + super().weights_numel()
+
+    def forward(self, x: torch.Tensor, params: dict, out_dtype = None):
+        # The selector is part of the module list so loading, autosplit and compilation account
+        # for its tensors. Proposal generation invokes walk() after the shared target LM head.
+        return to2(x, out_dtype, None)
+
+    @override
+    def load(self, device: torch.device, **kwargs):
+        super().load(device, **kwargs)
+        self.pred_codebook = self.config.stc.get_tensor(
+            self.key_pred, self.device, optional = False, allow_bf16 = True)
+        self.succ_codebook = self.config.stc.get_tensor(
+            self.key_succ, self.device, optional = False, allow_bf16 = True)
+        expected_shape = (self.vocab_size, self.rank)
+        if self.pred_codebook.shape != expected_shape:
+            raise ValueError(
+                f"Expected {self.key_pred} shape {expected_shape}, "
+                f"got {tuple(self.pred_codebook.shape)}"
+            )
+        if self.succ_codebook.shape != expected_shape:
+            raise ValueError(
+                f"Expected {self.key_succ} shape {expected_shape}, "
+                f"got {tuple(self.succ_codebook.shape)}"
+            )
+
+    @override
+    def unload(self):
+        self.pred_codebook = None
+        self.succ_codebook = None
+        super().unload()
+
+    @override
+    def get_tensors(self):
+        t = super().get_tensors()
+        if self.pred_codebook is not None:
+            t[self.key_pred] = self.pred_codebook.contiguous()
+            t[self.key_succ] = self.succ_codebook.contiguous()
+        return t
+
+    def walk(
+        self,
+        hidden: torch.Tensor,        # [b, rows, H] post-norm draft state
+        logits: torch.Tensor,        # [b, rows, V] float draft logits
+        anchor_ids: torch.Tensor,    # [b]
+        return_confidence: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """Greedily rerank each row's top-k tokens, conditioned on the preceding token."""
+        unary, cands = torch.topk(logits, self.top_k, dim = -1, sorted = False)
+        unary = unary.float()
+        cands = cands.long()
+        gate = self.hidden_proj.forward(hidden.half(), params = {}).float()
+
+        pred = anchor_ids.long()
+        path = []
+        confidence = []
+        for i in range(logits.shape[1]):
+            a_emb = F.embedding(pred, self.pred_codebook).float()
+            b_emb = F.embedding(cands[:, i], self.succ_codebook).float()
+            scores = unary[:, i] + torch.einsum("br,bkr->bk", a_emb * gate[:, i], b_emb)
+            score, idx = torch.max(scores, dim = -1)
+            pred = cands[:, i].gather(-1, idx[:, None])[:, 0]
+            path.append(pred)
+            if return_confidence:
+                confidence.append(score)
+        path = torch.stack(path, dim = 1)
+        if return_confidence:
+            return path, torch.stack(confidence, dim = 1)
+        return path

--- a/tests/test_dflash2.py
+++ b/tests/test_dflash2.py
@@ -1,0 +1,341 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from exllamav3.architecture.architectures import ARCHITECTURES
+from exllamav3.architecture.dflash import DFlashModel
+from exllamav3.architecture.dflash2 import DFlash2Model
+from exllamav3.modules.arch_specific.dflash import DFlashInputLayer
+from exllamav3.modules.arch_specific.dflash2 import (
+    DFlash2Block,
+    DFlash2DynConv,
+    DFlash2Selector,
+    _grouped_dynamic_convolve,
+    _grouped_dynamic_convolve_torch,
+    has_triton,
+)
+
+
+def test_architecture_is_registered():
+    assert "DFlash2DraftModel" in ARCHITECTURES
+
+
+def test_prepare_inputs_sets_anchor_and_uses_dflash_attention_setup():
+    model = object.__new__(DFlash2Model)
+    input_ids = torch.tensor([[42]])
+    params = {}
+    prepared = object()
+
+    with patch.object(DFlashModel, "prepare_inputs", return_value = prepared) as prepare:
+        actual = DFlash2Model.prepare_inputs(model, input_ids, params)
+
+    assert actual is prepared
+    assert params["dflash2_anchor_ids"] is input_ids
+    prepare.assert_called_once_with(input_ids, params)
+
+
+def test_input_embedding_scale_is_applied():
+    class Embedding:
+        def forward(self, ids, params):
+            return ids.unsqueeze(-1).float()
+
+    target = SimpleNamespace(loaded_tp = False, modules = [Embedding()])
+    layer = object.__new__(DFlashInputLayer)
+    layer.native_draft_len = 2
+    layer.mask_token_id = 9
+    layer.input_embedding_scale = 2.0
+    layer.attached_model = lambda: target
+
+    actual = DFlashInputLayer.forward(layer, torch.tensor([[3]]), {})
+
+    assert actual.tolist() == [[[6.0], [18.0]]]
+
+
+def test_tp_target_is_rejected_during_attach():
+    model = object.__new__(DFlash2Model)
+    target = SimpleNamespace(loaded_tp = True)
+
+    try:
+        model.attach_to(target)
+    except NotImplementedError as exc:
+        assert "tensor-parallel targets" in str(exc)
+    else:
+        raise AssertionError("DFlash2 attached to a tensor-parallel target")
+
+
+def test_target_taps_are_reordered_at_dflash_projection():
+    class Projection:
+        def forward(self, x, params, out_dtype = None):
+            return x
+
+    class Norm:
+        def forward(self, x, params, out_dtype = None):
+            return x
+
+    model = object.__new__(DFlashModel)
+    model.config = SimpleNamespace(target_layer_ids = [5, 2])
+    model.input_layer = SimpleNamespace(
+        device = torch.device("cpu"),
+        proj = Projection(),
+        norm = Norm(),
+    )
+    model.attn_modules = []
+    params = {}
+
+    state_2 = torch.full((1, 1, 1), 2.0)
+    state_5 = torch.full((1, 1, 1), 5.0)
+    model.update_kv_from_target([state_2, state_5], None, params)
+
+    assert params["target_hidden_cc"].tolist() == [[[5.0, 2.0]]]
+
+
+def test_exact_projection_widths_are_preserved():
+    config = SimpleNamespace()
+    conv = DFlash2DynConv(
+        config, "conv", hidden_size = 96, kernel_size = 3, group_size = 16)
+    selector = DFlash2Selector(
+        config, "selector", vocab_size = 32, hidden_size = 96, rank = 64, top_k = 4)
+
+    assert conv.proj.out_features_unpadded == 36
+    assert conv.proj.out_features == 128
+    assert conv.proj.trim_padded_out is True
+    assert selector.hidden_proj.out_features_unpadded == 64
+    assert selector.hidden_proj.out_features == 128
+    assert selector.hidden_proj.trim_padded_out is True
+
+
+def _dynamic_conv_reference(hidden, dynamic, base, group_size):
+    expected = torch.zeros_like(hidden)
+    for batch in range(hidden.shape[0]):
+        for position in range(hidden.shape[1]):
+            for channel in range(hidden.shape[2]):
+                group = channel // group_size
+                for offset in range(base.shape[0]):
+                    if position >= offset:
+                        weight = base[offset, channel] + dynamic[batch, position, offset, group]
+                        expected[batch, position, channel] += weight * hidden[batch, position - offset, channel]
+    return expected
+
+
+def test_grouped_dynamic_convolve_torch_matches_reference():
+    torch.manual_seed(0)
+    hidden = torch.randn(2, 5, 8)
+    dynamic = torch.randn(2, 5, 3, 2)
+    base = torch.randn(3, 8)
+
+    actual = _grouped_dynamic_convolve_torch(hidden, dynamic, base, group_size = 4)
+    expected = _dynamic_conv_reference(hidden, dynamic, base, group_size = 4)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_grouped_dynamic_convolve_triton_matches_torch():
+    if not torch.cuda.is_available() or not has_triton:
+        return
+
+    torch.manual_seed(1)
+    hidden = torch.randn(2, 8, 96, dtype = torch.float16, device = "cuda")
+    packed = torch.randn(2, 8, 2, 3, 6, dtype = torch.float16, device = "cuda")
+    dynamic = packed[:, :, 1]
+    base = torch.randn(3, 96, dtype = torch.bfloat16, device = "cuda")
+    assert not dynamic.is_contiguous()
+
+    actual = _grouped_dynamic_convolve(hidden, dynamic, base, group_size = 16)
+    expected = _grouped_dynamic_convolve_torch(hidden, dynamic, base, group_size = 16)
+
+    assert actual.dtype == torch.float16
+    torch.testing.assert_close(actual, expected, rtol = 2e-3, atol = 2e-3)
+
+
+def test_grouped_dynamic_convolve_triton_handles_odd_geometry():
+    if not torch.cuda.is_available() or not has_triton:
+        return
+
+    torch.manual_seed(2)
+    hidden = torch.randn(1, 17, 192, dtype = torch.float32, device = "cuda")
+    packed = torch.randn(1, 17, 2, 5, 8, dtype = torch.float16, device = "cuda")
+    dynamic = packed[:, :, 0]
+    base = torch.randn(5, 192, dtype = torch.bfloat16, device = "cuda")
+
+    actual = _grouped_dynamic_convolve(hidden, dynamic, base, group_size = 24)
+    expected = _grouped_dynamic_convolve_torch(hidden, dynamic, base, group_size = 24)
+
+    torch.testing.assert_close(actual, expected, rtol = 1e-5, atol = 1e-5)
+
+
+def test_grouped_dynamic_convolve_triton_preserves_fp32_finish():
+    if not torch.cuda.is_available() or not has_triton:
+        return
+
+    hidden = torch.full((1, 8, 96), 1.5e5, dtype = torch.float32, device = "cuda")
+    dynamic = torch.zeros(1, 8, 2, 6, dtype = torch.float16, device = "cuda")
+    base = torch.ones(2, 96, dtype = torch.bfloat16, device = "cuda")
+
+    actual = _grouped_dynamic_convolve(hidden, dynamic, base, group_size = 16)
+    expected = _grouped_dynamic_convolve_torch(hidden, dynamic, base, group_size = 16)
+
+    assert actual.dtype == torch.float32
+    assert torch.isfinite(actual).all()
+    assert actual.max() > 65504
+    torch.testing.assert_close(actual, expected)
+
+
+class _Norm:
+    def __init__(self):
+        self.input_dtypes = []
+
+    def forward(self, x, params, out_dtype = None):
+        self.input_dtypes.append(x.dtype)
+        assert out_dtype == torch.half
+        return x.half()
+
+
+class _Conv:
+    def __init__(self):
+        self.prepare_dtypes = []
+        self.finish_dtypes = []
+
+    def prepare(self, x, params):
+        self.prepare_dtypes.append(x.dtype)
+        return x, None
+
+    def finish(self, x, dynamic):
+        self.finish_dtypes.append(x.dtype)
+        return x.float()
+
+
+class _Branch:
+    def forward(self, x, params):
+        return x.float()
+
+
+def test_dflash2_block_keeps_fp32_residual_and_fp16_branches():
+    block = object.__new__(DFlash2Block)
+    block.attn_norm = _Norm()
+    block.mlp_norm = _Norm()
+    block.attn_conv = _Conv()
+    block.mlp_conv = _Conv()
+    block.attn = _Branch()
+    block.mlp = _Branch()
+
+    actual = block.forward(torch.ones(1, 2, 4, dtype = torch.float32), {})
+
+    assert actual.dtype == torch.float32
+    assert block.attn_norm.input_dtypes == [torch.float32]
+    assert block.mlp_norm.input_dtypes == [torch.float32]
+    assert block.attn_conv.prepare_dtypes == [torch.float16]
+    assert block.mlp_conv.prepare_dtypes == [torch.float16]
+    assert block.attn_conv.finish_dtypes == [torch.float32]
+    assert block.mlp_conv.finish_dtypes == [torch.float32]
+
+
+def test_candidate_logit_scale_and_softcap_are_applied():
+    class LMHead:
+        def prepare_for_device(self, state, params):
+            return state
+
+        def forward(self, state, params):
+            return torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+
+    class Selector:
+        device = torch.device("cpu")
+
+        def walk(self, hidden, logits, anchor, return_confidence = False):
+            self.logits = logits
+            return torch.zeros((1, 1), dtype = torch.long)
+
+    target = SimpleNamespace(
+        loaded_tp = False,
+        logit_layer_idx = 0,
+        modules = [LMHead()],
+        config = SimpleNamespace(vocab_size = 2),
+    )
+    selector = Selector()
+    model = object.__new__(DFlash2Model)
+    model.config = SimpleNamespace(output_multiplier = 2.0, final_logit_softcapping = 3.0)
+    model.attached_model = lambda: target
+    model.selector = selector
+    params = {"dflash2_anchor_ids": torch.tensor([[1]])}
+
+    DFlash2Model.sample_from_state(model, torch.zeros(1, 2, 4), params)
+
+    assert "draft_conf" not in params
+    raw = torch.tensor([[3.0, 4.0]]) * 2.0
+    expected = torch.tanh(raw / 3.0) * 3.0
+    torch.testing.assert_close(selector.logits[0], expected)
+
+
+def test_sample_exports_selector_confidence_for_dynamic_drafting():
+    class LMHead:
+        def prepare_for_device(self, state, params):
+            return state
+
+        def forward(self, state, params):
+            return torch.zeros(1, 3, 4)
+
+    class Selector:
+        device = torch.device("cpu")
+
+        def walk(self, hidden, logits, anchor, return_confidence = False):
+            assert return_confidence
+            return torch.tensor([[2, 3]]), torch.tensor([[7.5, 4.25]])
+
+    target = SimpleNamespace(
+        loaded_tp = False,
+        logit_layer_idx = 0,
+        modules = [LMHead()],
+        config = SimpleNamespace(vocab_size = 4),
+    )
+    model = object.__new__(DFlash2Model)
+    model.config = SimpleNamespace(output_multiplier = 1.0, final_logit_softcapping = 0.0)
+    model.attached_model = lambda: target
+    model.selector = Selector()
+    params = {
+        "dflash2_anchor_ids": torch.tensor([[1]]),
+        "export_draft_conf": True,
+    }
+
+    ids = DFlash2Model.sample_from_state(model, torch.zeros(1, 3, 4), params)
+
+    assert ids.tolist() == [[1, 2, 3]]
+    assert params["draft_conf"].tolist() == [[0.0, 7.5, 4.25]]
+
+
+class _Projection:
+    def forward(self, hidden, params):
+        return torch.ones((*hidden.shape[:-1], 1), device = hidden.device)
+
+
+def test_selector_chains_candidates_from_anchor_and_returns_scores():
+    selector = object.__new__(DFlash2Selector)
+    selector.top_k = 2
+    selector.hidden_proj = _Projection()
+    selector.pred_codebook = torch.tensor([[1.0], [0.0], [-1.0], [0.0]])
+    selector.succ_codebook = torch.tensor([[0.0], [0.0], [2.0], [2.0]])
+
+    hidden = torch.zeros(1, 2, 4)
+    logits = torch.tensor([[[0.0, 3.0, 2.0, -1.0], [0.0, 3.0, -1.0, 2.0]]])
+    path, confidence = selector.walk(
+        hidden, logits, torch.tensor([0]), return_confidence = True)
+
+    assert path.tolist() == [[2, 1]]
+    assert confidence.tolist() == [[4.0, 3.0]]
+
+
+if __name__ == "__main__":
+    test_architecture_is_registered()
+    test_prepare_inputs_sets_anchor_and_uses_dflash_attention_setup()
+    test_input_embedding_scale_is_applied()
+    test_tp_target_is_rejected_during_attach()
+    test_target_taps_are_reordered_at_dflash_projection()
+    test_exact_projection_widths_are_preserved()
+    test_grouped_dynamic_convolve_torch_matches_reference()
+    test_grouped_dynamic_convolve_triton_matches_torch()
+    test_grouped_dynamic_convolve_triton_handles_odd_geometry()
+    test_grouped_dynamic_convolve_triton_preserves_fp32_finish()
+    test_dflash2_block_keeps_fp32_residual_and_fp16_branches()
+    test_candidate_logit_scale_and_softcap_are_applied()
+    test_sample_exports_selector_confidence_for_dynamic_drafting()
+    test_selector_chains_candidates_from_anchor_and_returns_scores()
+    print("DFlash2 tests passed")


### PR DESCRIPTION
Summary

 This adds greedy DFlash2 speculative drafting to ExLlamaV3.

 The implementation targets paged-cache generation with a non-TP target model. It has been tested with:

 - Target: turboderp/GLM-5.3-Flash-exl3-4.05bpw
 - Draft: incoai/GLM-5.3-Flash-DFlash2

 No native extension changes are required.

 What changed

 - Registered the DFlash2DraftModel architecture.
 - Added grouped dynamic causal convolutions around each attention and MLP sublayer.
 - Added BF16 residual normalization. DFlash2 residual values can exceed the FP16 range.
 - Added the DFlash2 candidate selector and greedy chained top-k walk.
 - Preserved target hidden-state taps in checkpoint order.
 - Added bilateral synthetic-block attention for non-causal DFlash2 checkpoints.
 - Corrected the sliding-window conversion from token count to the backend's inclusive left distance.
 - Added cacheless non-causal span support to the Torch SDPA fallback.
 - Added support for optional input_embedding_scale, output_multiplier, and final logit softcapping.
 - Added validation for target compatibility, projection shapes, convolution geometry, draft length, and BF16 hardware support.
 - Required the checkpoint's native seven-token draft window to prevent fixed eight-row draft blocks from exceeding allocated cache pages.
 - Disabled unsupported dynamic draft truncation.

 Verification behavior

 DFlash2 proposals are greedy. The existing target sampler still chooses the final token and accepts draft tokens only while they match the target output. This keeps generation lossless without
 adding a separate stochastic rejection-sampling path.

 Current limitations

 - Tensor-parallel targets are not supported because the selector needs top-k target logits.
 - CFG and other multi-sequence jobs are not supported.
 - The draft length must be exactly seven tokens for the current eight-row checkpoint format.
 - Dynamic draft truncation is not supported.
 - A GPU with native BF16 support is required.

 Tests

 Added 18 focused tests covering:

 - Architecture registration
 - Bilateral and causal mask selection
 - Sliding-window boundaries
 - Cached Triton attention with noncontiguous pages and a page-boundary write
 - Target tap ordering
 - Fixed draft-length validation
 - Dynamic convolution semantics
 - Exact projection widths
 - Candidate chaining
 - Candidate logit scaling and softcapping
 - BF16 residual normalization

 Validation performed:

 ```text
   python tests/test_dflash2.py
   DFlash2 tests passed
 ```

 ```text
   python -m compileall exllamav3 tests/test_dflash2.py
   git diff --check
 ```

 The real checkpoint was loaded in TabbyAPI with a paged FP16 draft cache. Generation completed successfully across repeated speculative rounds, including rejected drafts and cache rollback.

 Follow-up work

 - Tensor-parallel target support
 - Stochastic DFlash2 proposals with rejection sampling
 - Automated full-checkpoint parity tests
 - Compiled-checkpoint round-trip coverage

Note: This work was done with the help of an LLM, but I manually tested and verified it working on my current system, that has a mix of gpus (rtx pro 6000, 5090 and 3090) and dflash2 as the drafter was working properly in my system. 
edit: wrong grammar