### PR TITLE
chat.py: add -gcs to set the generator's max_chunk_size

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -94,6 +94,7 @@ def main(args):
         cpu_cache_size = int(args.cpu_cache_size * 1024 ** 3),
         recurrent_cache_size = int(args.recurrent_cache_size * 1024 ** 3),
         show_visualizer = args.visualize_cache,
+        max_chunk_size = args.generator_chunk_size,
     )
     stop_conditions = [sc for sc in prompt_format.stop_conditions(tokenizer) if sc]
     if config.eos_token_id_list and all(config.eos_token_id_list):
@@ -649,5 +650,6 @@ if __name__ == "__main__":
     parser.add_argument("-lw", "--loop_window", type = int, help = "Loop detection window in tokens, default = 300", default = 300)
     parser.add_argument("-lmr", "--loop_min_reps", type = int, help = "Min. reps to detect, default = 3", default = 3)
     parser.add_argument("-vis", "--visualize_cache", action = "store_true", help = "Show cache visualizer (slow)")
+    parser.add_argument("-gcs", "--generator_chunk_size", type = int, default = 2048, help = "Maximum prompt-prefill chunk size, default = 2048")
     _args = parser.parse_args()
     main(_args)


### PR DESCRIPTION
`Generator` already accepts `max_chunk_size`, but `chat.py` never passes it, so the example is stuck at the 2048 default with no way to change it short of editing the file.

I hit this while testing long context on a 24 GB card, where prefill chunk size is worth tuning and I wanted to try a few values without keeping a local edit around.

The default here is 2048, matching the `Generator` default, so behavior is unchanged unless you pass the flag.
