### PR TITLE
Hoist hot-path scratch allocations in hyperconnection mix and routing

### DIFF
--- a/exllamav3/modules/block_sparse_mlp.py
+++ b/exllamav3/modules/block_sparse_mlp.py
@@ -89,9 +89,22 @@ def routing_std(bsz, cfg, y, params):
                 routing_weights *= cfg.per_expert_scale.unsqueeze(0)
             return selected_experts, routing_weights
         else:
-            router_logits = torch.empty((bsz, cfg.num_experts), dtype = torch.half, device = y.device)
-            routing_weights = torch.empty((bsz, cfg.num_experts_per_tok), dtype = torch.half, device = y.device)
-            selected_experts = torch.empty((bsz, cfg.num_experts_per_tok), dtype = torch.long, device = y.device)
+            # Hoisted per-(bsz, device) buffers, mirroring the bsz-1 fast path above: the
+            # MTP verify batch hits this branch on every pass, and fresh empties per MoE
+            # layer cost hundreds of allocator round trips per pass. Outputs are consumed
+            # by run_bszN in the same forward step; slot reuse is stream-ordered.
+            bufs = getattr(cfg, "_routing_bufs_n", None)
+            if bufs is None:
+                bufs = cfg._routing_bufs_n = {}
+            key = (bsz, y.device)
+            bufs_ = bufs.get(key)
+            if bufs_ is None:
+                bufs[key] = bufs_ = (
+                    torch.empty((bsz, cfg.num_experts), dtype = torch.half, device = y.device),
+                    torch.empty((bsz, cfg.num_experts_per_tok), dtype = torch.half, device = y.device),
+                    torch.empty((bsz, cfg.num_experts_per_tok), dtype = torch.long, device = y.device),
+                )
+            router_logits, routing_weights, selected_experts = bufs_
             ext.routing_std(
                 y,
                 cfg.gate_tensor,

--- a/exllamav3/modules/hyperconnections.py
+++ b/exllamav3/modules/hyperconnections.py
@@ -260,6 +260,10 @@ class GatedResidual(Module):
         self.proj_h = None          # cat(down, inject) half, unfolded (GEMM path)
         self.fn_h = None            # cat(down, inject) * w half, folded (fused path)
         self.rank = 0
+        # Output/scratch buffers for the fused _mix path, keyed by (rows, fn_h rows).
+        # Allocations are hoisted out of the per-site hot path: every decoder layer calls
+        # _mix twice, so fresh empties cost hundreds of allocator round trips per pass.
+        self._mix_bufs = {}
 
     @override
     def load(self, device: torch.device, **kwargs):
@@ -351,14 +355,28 @@ class GatedResidual(Module):
         if not s3.is_contiguous():
             s3 = s3.contiguous()
         dev = s3.device
-        post = torch.empty((R, H), dtype = torch.float, device = dev) \
-            if self.use_combine else None
 
         if R <= self.FUSED_MAX_R:
-            dots = torch.empty((R, self.fn_h.shape[0] + 1, H), dtype = torch.float, device = dev)
-            mixed = torch.empty((R, Dh), dtype = torch.half, device = dev)
+            # Hoisted buffers, keyed by (rows, fn_h rows) so a rebuilt fn_h with a different
+            # rank can never hit a stale shape. SAFETY INVARIANT: at most one outstanding
+            # _mix result per instance per key — true today because nothing calls _mix on a
+            # site instance between its mix() and its apply_(); a refactor that does breaks
+            # this silently. Consumers (gr_mix write -> apply_/lm_head) are stream-ordered
+            # before the next same-slot write.
+            key = (R, self.fn_h.shape[0])
+            bufs = self._mix_bufs.get(key)
+            if bufs is None:
+                bufs = self._mix_bufs[key] = (
+                    torch.empty((R, self.fn_h.shape[0] + 1, H), dtype = torch.float, device = dev),
+                    torch.empty((R, H), dtype = torch.float, device = dev),
+                    torch.empty((R, Dh), dtype = torch.half, device = dev),
+                )
+            dots, post_b, mixed = bufs
+            post = post_b if self.use_combine else None
             ext.gr_mix(s3, self.fn_h, self.upx_h, self.w_h, self.rms_eps, dots, post, mixed)
         else:
+            post = torch.empty((R, H), dtype = torch.float, device = dev) \
+                if self.use_combine else None
             normed = torch.empty((R * H, Dh), dtype = torch.half, device = dev)
             ext.rms_norm(s3.view(R * H, Dh), self.w_h, normed,
                          self.rms_eps, 0.0, 1.0, False, False, H)


### PR DESCRIPTION
## Problem

Two hot decode paths allocate fresh scratch tensors on every call:

- `HyperConnection._mix` allocates its `dots` / `post` / `mixed` buffers per invocation (2× per block per pass);
- the multi-row router path (`routing_std`) allocates per call.

At decode shapes these are small, frequent allocations that ride the caching allocator's slow path once shapes vary (speculative verify windows change row counts constantly).

## Change

Hoist the scratch into per-instance cached buffers keyed by shape, with a safety note: at most one outstanding result per buffer key, which holds because nothing calls `_mix` on a site instance between its `mix()` and `apply_()` — consumers are stream-ordered before the next same-slot write. No behavior change; the comments mark the invariant for anyone who refactors the site.

## Measurement

+3–6% decode end-to-end on a 4× RTX 3090 layer-split rig (Qwen3.8-Flash-Next EXL3, MTP speculative decoding, measured across repeated matched batteries). Measured before/after on the same prompts with warm-up runs discarded.
