### PR TITLE
Add Lfm2ForCausalLM architecture support for LiquidAI LFM2.5

### DIFF
--- a/exllamav3/architecture/architectures.py
+++ b/exllamav3/architecture/architectures.py
@@ -27,6 +27,7 @@ from .hy_v3 import HyV3Model
 from .hyperclovax import HyperClovaxModel
 from .iquestcoder import IQuestCoderModel
 from .laguna import LagunaModel
+from .lfm2 import Lfm2Model
 from .lfm2_moe import Lfm2MoeModel
 from .llama import LlamaModel
 from .mimo import MiMoModel
@@ -93,6 +94,7 @@ ARCHITECTURES = {
         HyperClovaxModel,
         IQuestCoderModel,
         LagunaModel,
+        Lfm2Model,
         Lfm2MoeModel,
         LlamaModel,
         MiMoModel,

--- a/exllamav3/architecture/lfm2.py
+++ b/exllamav3/architecture/lfm2.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+from typing_extensions import override
+import torch
+
+from ..model.config import Config, no_default
+from ..model.model import Model
+from ..util.rope import RopeStyle, RoPE
+from ..modules import (
+    RMSNorm,
+    Embedding,
+    TransformerBlock,
+    Attention,
+    Linear,
+    GatedMLP,
+    ShortConv,
+    ShortConvState,
+)
+from ..modules.attn import prepare_for_attn
+from ..cache.recurrent_util import prepare_for_recurrence
+
+
+def read_lfm2_layer_types(config: Config, num_layers: int) -> list[str]:
+    layer_types = config.read_cfg(list, "layer_types", None)
+    if layer_types is not None:
+        assert len(layer_types) == num_layers, \
+            "Length of layer_types key doesn't match number of hidden layers"
+        for t in layer_types:
+            if t not in ["full_attention", "conv"]:
+                raise ValueError(f"Unknown layer type in layer_types: {t}")
+        return layer_types
+
+    return [
+        "full_attention" if (idx + 1) % 4 == 0 else "conv"
+        for idx in range(num_layers)
+    ]
+
+
+class Lfm2Config(Config):
+    arch_string = "Lfm2ForCausalLM"
+
+    def __init__(
+        self,
+        directory: str,
+        **kwargs,
+    ):
+        super().__init__(
+            directory,
+            {"text": Lfm2Model},
+            **kwargs,
+        )
+
+        # Attention params
+        self.head_dim = self.read_cfg(int, "head_dim", None)
+        self.hidden_size = self.read_cfg(int, "hidden_size", no_default)
+        self.num_q_heads = self.read_cfg(int, "num_attention_heads", no_default)
+        self.num_kv_heads = self.read_cfg(int, "num_key_value_heads", self.num_q_heads)
+
+        if not self.head_dim:
+            self.head_dim = self.hidden_size // self.num_q_heads
+
+        # Short-conv params
+        self.conv_kernel_size = self.read_cfg(int, "conv_L_cache", 3)
+
+        # MLP params
+        self.assert_cfg(str, "hidden_act", "silu", True)
+        self.intermediate_size = self.read_cfg(int, "intermediate_size", no_default)
+
+        # Norms
+        self.rms_norm_eps = self.read_cfg(float, "norm_eps", no_default)
+
+        # Layers
+        self.num_hidden_layers = self.read_cfg(int, "num_hidden_layers", no_default)
+        self.tie_word_embeddings = self.read_cfg(bool, "tie_word_embeddings", False)
+        self.layer_types = read_lfm2_layer_types(self, self.num_hidden_layers)
+
+        # RoPE
+        self.rope_settings = self.read_rope_settings_default(
+            RopeStyle.NEOX,
+            default_rope_theta = self.read_cfg(float, "rope_theta", 1000000.0),
+        )
+
+        # Vision placeholders
+        self.vision = None
+
+
+class Lfm2Model(Model):
+    config_class = Lfm2Config
+
+    def __init__(
+        self,
+        config: Lfm2Config,
+        **kwargs,
+    ):
+        super().__init__(config, **kwargs)
+
+        key_prefix = "model"
+
+        self.modules += [
+            Embedding(
+                config = config,
+                key = f"{key_prefix}.embed_tokens",
+                vocab_size = config.vocab_size,
+                hidden_size = config.hidden_size,
+            )
+        ]
+
+        self.first_block_idx = len(self.modules)
+
+        for idx in range(config.num_hidden_layers):
+            self.modules += [
+                TransformerBlock(
+                    config = config,
+                    key = f"{key_prefix}.layers.{idx}",
+                    layer_idx = idx,
+                    attn_norm = RMSNorm(
+                        config = config,
+                        key = f"{key_prefix}.layers.{idx}.operator_norm",
+                        rms_norm_eps = config.rms_norm_eps,
+                    ),
+                    attn = (
+                        ShortConv(
+                            config = config,
+                            key = f"{key_prefix}.layers.{idx}.conv",
+                            layer_idx = idx,
+                            hidden_size = config.hidden_size,
+                            conv_kernel_size = config.conv_kernel_size,
+                            key_in = "in_proj",
+                            key_conv = "conv",
+                            key_out = "out_proj",
+                            qmap = "block.attn",
+                            out_dtype = torch.float,
+                            select_hq_bits = 2,
+                        )
+                        if config.layer_types[idx] == "conv" else
+                        Attention(
+                            config = config,
+                            key = f"{key_prefix}.layers.{idx}.self_attn",
+                            layer_idx = idx,
+                            hidden_size = config.hidden_size,
+                            head_dim = config.head_dim,
+                            num_q_heads = config.num_q_heads,
+                            num_kv_heads = config.num_kv_heads,
+                            rope_settings = config.rope_settings,
+                            sm_scale = None,
+                            key_q = "q_proj",
+                            key_k = "k_proj",
+                            key_v = "v_proj",
+                            key_o = "out_proj",
+                            qmap = "block.attn",
+                            q_norm = RMSNorm(
+                                config = config,
+                                key = f"{key_prefix}.layers.{idx}.self_attn.q_layernorm",
+                                rms_norm_eps = config.rms_norm_eps,
+                            ),
+                            k_norm = RMSNorm(
+                                config = config,
+                                key = f"{key_prefix}.layers.{idx}.self_attn.k_layernorm",
+                                rms_norm_eps = config.rms_norm_eps,
+                            ),
+                            out_dtype = torch.float,
+                            select_hq_bits = 2,
+                        )
+                    ),
+                    mlp_norm = RMSNorm(
+                        config = config,
+                        key = f"{key_prefix}.layers.{idx}.ffn_norm",
+                        rms_norm_eps = config.rms_norm_eps,
+                    ),
+                    mlp = GatedMLP(
+                        config = config,
+                        key = f"{key_prefix}.layers.{idx}.feed_forward",
+                        hidden_size = config.hidden_size,
+                        intermediate_size = config.intermediate_size,
+                        key_up = "w3",
+                        key_gate = "w1",
+                        key_down = "w2",
+                        qmap = "block.mlp",
+                        interm_dtype = torch.half,
+                        out_dtype = torch.float,
+                        select_hq_bits = 1,
+                    ),
+                )
+            ]
+
+        self.last_kv_module_idx = len(self.modules) - 1
+
+        head_alt_key = None
+        if config.tie_word_embeddings and not self.config.stc.has_tensor("lm_head"):
+            head_alt_key = f"{key_prefix}.embed_tokens"
+
+        self.modules += [
+            RMSNorm(
+                config = config,
+                key = f"{key_prefix}.embedding_norm",
+                rms_norm_eps = config.rms_norm_eps,
+                out_dtype = torch.half,
+            ),
+            Linear(
+                config = config,
+                key = "lm_head",
+                qbits_key = "head_bits",
+                alt_key = head_alt_key,
+                in_features = config.hidden_size,
+                out_features = config.vocab_size,
+                qmap = "block",
+                caps = {"logits_output": True},
+            )
+        ]
+
+        self.logit_layer_idx = len(self.modules) - 1
+
+        self.caps.update({
+            "supports_tp": False,
+            "recurrent_states": True,
+            "default_recurrent_checkpoint_interval": 2048,
+            "linear_attn": True,
+        })
+        self.recurrent_state_cls = ShortConvState
+        self.g_rope = RoPE("cpu", config.rope_settings)
+
+
+    @override
+    def prepare_inputs(self, input_ids: torch.Tensor, params: dict) -> torch.Tensor:
+        input_ids = prepare_for_attn(input_ids, params)
+        prepare_for_recurrence(input_ids, params, self)
+        return input_ids
+
+
+    @override
+    def default_chat_prompt(self, prompt: str, system_prompt: str = None) -> str:
+        p = ""
+        if system_prompt:
+            p += f"<|im_start|>system\n"
+            p += f"{system_prompt}<|im_end|>\n"
+        p += f"<|im_start|>user\n"
+        p += f"{prompt}<|im_end|>\n"
+        p += f"<|im_start|>assistant\n"
+        return p


### PR DESCRIPTION
Adds support for the dense LFM2 architecture (LiquidAI LFM2 family), enabling loading and inference of Lfm2ForCausalLM models in exllamav3. The hybrid (short-conv + full-attention) layer layout, post-embedding RMSNorm, QK-LayerNorm in attention, and SwiGLU FFN are all modelled. Mirrors the structure of the existing lfm2_moe module with MoE-specific fields removed.

## Changes

- New: exllamav3/architecture/lfm2.py - Lfm2Config and Lfm2Model (207 lines). Reads layer_types (mix of conv / full_attention), conv_L_cache for ShortConv kernel size, rope_parameters->rope_theta (HF transformers v5 nested format), and tie_word_embeddings. Wires ShortConv with recurrent_states (ShortConvState), Attention with per-head QK RMSNorm, SwiGLU GatedMLP, and embedding_norm placed before lm_head.
- Modified: exllamav3/architecture/architectures.py - registers Lfm2Model under Lfm2ForCausalLM (import + ARCHITECTURES entry).

Pattern follows the Lfm2Moe reference; the dense variant simply drops the routed-expert FFN. Per-tensor keys in the safetensors index (model.layers.<i>.{conv.{in,out}_proj, conv.conv, self_attn.{q,k,v,out}_proj, self_attn.{q,k}_layernorm, feed_forward.{w1,w2,w3}, operator_norm, ffn_norm} and model.{embed_tokens, embedding_norm}) all match the module layout produced here.

## Tested against LiquidAI/LFM2.5-2.6B

End-to-end verification on
https://huggingface.co/LiquidAI/LFM2.5-2.6B
(model type: lfm2, 30 hidden layers, hidden_size=2048, 32 q-heads / 8 kv-heads, head_dim=64, vocab=128000, max_position_embeddings=131072, tie_word_embeddings=true, layer_types = 22 conv + 8 full_attention, rope_theta=10_000_000, conv_L_cache=3):

1. Config.from_directory parses correctly. All assertions on hidden_size, num_q_heads, num_kv_heads, head_dim, num_hidden_layers, conv_kernel_size, intermediate_size, vocab_size, tie_word_embeddings, rope_theta, and layer-type counts pass.
2. Model.from_config builds 33 modules (1 embed + 30 blocks + 1 embedding_norm + 1 lm_head). Module-key layout matches model.safetensors.index.json.
3. model.load(progressbar=True) succeeds. All 33 modules report loaded.
4. model.forward(input_ids, params) with "Hello, world!" (4 tokens) returns logits of shape (1, 4, 128000), dtype float16, with sane values.
5. exllamav3.conversion.convert_model quantises to EXL3 (-b 4.0 -hb 6 -d 0): 30 hidden layers, embedding at 16 bpw, lm_head at 6 bpw, mean decoder bitrate 4.00. Per-layer SQNR 26.1-34.8 dB on conv layers, 26.7-29.1 dB on attention layers, 39.6 dB on lm_head. Output model: 1.85 GB vs 5.16 GB bf16 source (2.76x compression).
6. eval/perf.py on the EXL3 model with cache_size=8192: prefill peaks at 90 131 tokens/s (2 048 context), generation 248-274 tokens/s (batch 1, 0-1792 context) on a single RTX 4090.
7. eval/sc_measure.py (iid noise, 4 rows x 512 tokens) and eval/sc_optimize.py produce a valid per-tensor recipe at target 4.0 bpw with predicted KLD 0.123 (vs 0.196 ends-first baseline, 1.6x improvement).
8. F:\tabbyAPI\main.py with the new architecture loads the EXL3 model on http://0.0.0.0:15404, serves /v1/completions and /v1/chat/completions, accepts max_seq_len: 131072 and cache_size: 131072 (128K context), and returns coherent text for the prompt "The capital of France is".

Also smoke-tested against https://huggingface.co/LiquidAI/LFM2.5-230M (14 layers, 16/8 heads, vocab=65536, 128K context) with the same flow: config parse, weight load, forward, EXL3 quantisation (recipe with per-tensor 3-6 bpw targeting predicted KLD 0.123), and TabbyAPI on port 14404 with 32K context.

## Notes

- exllamav3 upstream does not yet ship LFM2 support, so installing exllamav3 from PyPI on a host that needs to load LFM2 weights will fail with "Unknown architecture Lfm2ForCausalLM". Until this lands upstream, downstream consumers (e.g. TabbyAPI) should either install this fork or copy architecture/lfm2.py and the corresponding architectures.py entry into their installed package.
- Test artifacts (smoke-test scripts, sc_measure JSON, recipe YAML, EXL3 outputs) live outside this repo under F:\HF\ and are not part of this commit.