### PR TITLE
CPU MoE: AVX-512BW kernel tier, plus three kernel/scheduling improvements

### DIFF
--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -268,13 +268,17 @@ only a small amount of shared-memory overprovisioning, not runtime.
 
 ### `EXL3_MOE_CPU_MAX_ISA` (default: unset, auto-detect)
 
-Caps the CPU kernel's runtime ISA detection at `scalar`, `avx2`, `vnni`/`avx512`, or `vbmi`,
-for testing a lower-tier kernel path on hardware that supports better. The `vbmi` tier
+Caps the CPU kernel's runtime ISA detection at `scalar`, `avx2`, `bw`/`avx512bw`,
+`vnni`/`avx512`, or `vbmi`, for testing a lower-tier kernel path on hardware that supports
+better. The `bw` tier covers AVX-512F/BW/VL hardware without VNNI (Skylake-SP/X: 1st-gen Xeon
+Scalable, Core-X), which previously fell through to `avx2`: the `vnni` dword kernel with the
+AVX2 tier's vpmaddubsw/vpmaddwd accumulate, ~1.5x the `avx2` tier's cold-expert decode
+throughput on a Xeon Gold 6148. The `vbmi` tier
 (AVX512-VBMI byte-gather state extraction, Zen 4+ / Ice Lake+; Cascade/Cooper Lake have VNNI
 without VBMI and stay on the `vnni` tier) is 15-70% faster than the dword scheme depending on
 bitrate. Never upgrades past what the CPU actually supports; unrecognized values are ignored.
 Read once per process (parent and worker independently), so it must be set before either is
-started. Note that capping below `vbmi` also disables the swizzled weight layout (see
+started. Note that capping below `bw` also disables the swizzled weight layout (see
 `EXL3_MOE_CPU_SWIZZLE`).
 
 ### `EXL3_MOE_CPU_SWIZZLE` (default: `1`)
@@ -282,11 +286,12 @@ started. Note that capping below `vbmi` also disables the swizzled weight layout
 Repack the CPU worker's expert trellis copies into a band-contiguous ("swizzled") layout at
 load, so each GEMV band streams sequentially from DRAM instead of in short strided runs
 (+45-75% cold decode GEMV throughput measured on a 7960X, reaching the sequential-read
-roofline). Only takes effect when the `vbmi` kernel tier is active, whose byte-gather
-extraction leaves the register headroom for the wide bands the swizzled layout wants at
-m > 1; K8 tensors always stay in the native layout (they route to the dword kernel). The
-GPU-streaming prefill path un-swizzles during staging, so staged bytes reaching the GPU
-dequant are unaffected. Set to `0` to keep the native layout.
+roofline). Takes effect on the `vbmi` kernel tier, whose byte-gather extraction leaves the
+register headroom for the wide bands the swizzled layout wants at m > 1, and on the `bw` tier
+(+2-29% on Skylake-SP, where the sequential per-band k-stream beats 96-128 B strided reads);
+the `vnni` tier keeps the native layout. K8 tensors always stay in the native layout (they
+route to the dword kernel). The GPU-streaming prefill path un-swizzles during staging, so
+staged bytes reaching the GPU dequant are unaffected. Set to `0` to keep the native layout.
 
 ### `EXL3_MOE_MEMOPS` (default: `1`)
 

--- a/exllamav3/exllamav3_ext/bindings.cpp
+++ b/exllamav3/exllamav3_ext/bindings.cpp
@@ -164,6 +164,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("exl3_moe_cpu_pool_stress", &exl3_moe_cpu_pool_stress, "exl3_moe_cpu_pool_stress");
     m.def("exl3_moe_cpu_worker_run", &exl3_moe_cpu_worker_run, "exl3_moe_cpu_worker_run",
           py::call_guard<py::gil_scoped_release>());
+    m.def("exl3_moe_cpu_has_avx512_bw", &exl3_moe_cpu_has_avx512_bw, "exl3_moe_cpu_has_avx512_bw");
     m.def("exl3_moe_cpu_has_avx512_vnni", &exl3_moe_cpu_has_avx512_vnni, "exl3_moe_cpu_has_avx512_vnni");
     m.def("exl3_moe_cpu_has_avx512_vbmi", &exl3_moe_cpu_has_avx512_vbmi, "exl3_moe_cpu_has_avx512_vbmi");
     m.def("exl3_mgemm", &exl3_mgemm, "exl3_mgemm");

--- a/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
+++ b/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
@@ -1911,48 +1911,30 @@ void transform_out(const MoeCpuMatrix& mat, float* tout, int m)
 }
 
 
-// Assign workers to GEMVs: with more GEMVs than workers, each worker strides over whole GEMVs;
-// otherwise GEMV j gets the contiguous worker group [j*nw/total, (j+1)*nw/total). Returns false
-// when this worker has no assignment. Missing either regime silently drops GEMVs.
-inline bool gemv_assignment(int worker, int num_workers, int total, int& j0, int& j_step, int& sub, int& per)
-{
-    if (total <= 0) return false;
-    if (total >= num_workers)
-    {
-        j0 = worker; j_step = num_workers; sub = 0; per = 1;
-        return j0 < total;
-    }
+// Assign this worker its share of a phase's `total` GEMVs (all of one width, tiles_n tiles),
+// calling gemv(j, t0, t1) per tile range. Few GEMVs (decode, small batches; each expert read
+// once): the GEMVs' tiles form one flat range, split evenly across workers in 8-tile groups so
+// no piece crosses a group of its GEMV (the swizzled band kernels' invariant; n % 128 == 0
+// makes every tiles_n a multiple of 8). Whole-GEMV assignment left a 2:1 imbalance whenever
+// 2 * cold experts fell between multiples of the worker count (16 gate/up GEMVs on 20 workers:
+// twelve single-worker GEMVs set the phase time while eight workers idled half of it). Many
+// GEMVs (prefill): whole GEMVs strided across workers, so all workers stream the same expert's
+// chunks together and L3 serves the repeats; the imbalance there is at most one GEMV in four.
+constexpr int FLAT_MAX_GEMVS_PER_WORKER = 4;
 
-    for (int j = 0; j < total; ++j)
-    {
-        const int w0 = j * num_workers / total;
-        const int w1 = (j + 1) * num_workers / total;
-        if (worker >= w0 && worker < w1) {
-            j0 = j; j_step = total; sub = worker - w0; per = w1 - w0;
-            return true;
-        }
-    }
-    return false;
-}
-
-// Contiguous tile range for split sub/per of one GEMV. Swizzled matrices hand out whole
-// 8-tile groups per worker: the band kernels' swizzled addressing assumes n0's group is not
-// split mid-band (band tables only produce divisors of 8, which stay inside a group only
-// when the range starts group-aligned).
-inline void tile_split(const MoeCpuMatrix& mat, int sub, int per, int& t0, int& t1)
+template <typename Gemv>
+inline void assign_gemvs(int worker, int num_workers, int total, int tiles_n, Gemv gemv)
 {
-    const int tiles_n = mat.n / 16;
-    if (mat.swz)
+    if (total > FLAT_MAX_GEMVS_PER_WORKER * num_workers)
     {
-        const int groups = tiles_n / 8;
-        t0 = groups * sub / per * 8;
-        t1 = groups * (sub + 1) / per * 8;
+        for (int j = worker; j < total; j += num_workers) gemv(j, 0, tiles_n);
+        return;
     }
-    else
-    {
-        t0 = tiles_n * sub / per;
-        t1 = tiles_n * (sub + 1) / per;
-    }
+    const int64_t groups = static_cast<int64_t>(total) * (tiles_n / 8);
+    const int f0 = static_cast<int>(groups * worker / num_workers) * 8;
+    const int f1 = static_cast<int>(groups * (worker + 1) / num_workers) * 8;
+    for (int j = f0 / tiles_n; j * tiles_n < f1; ++j)
+        gemv(j, std::max(f0 - j * tiles_n, 0), std::min(f1 - j * tiles_n, tiles_n));
 }
 
 void forward_phase(void* vctx, int worker, int num_workers)
@@ -1982,22 +1964,17 @@ void forward_phase(void* vctx, int worker, int num_workers)
 
         case 1:
         {
-            // Gate + up GEMVs: workers spread over the GEMVs, contiguous tile ranges within each
+            // Gate + up GEMVs (see assign_gemvs)
             const int gu = L.gates.empty() ? 1 : 2;
-            const int total = nc * gu;
-            int j0, j_step, sub, per;
-            if (gemv_assignment(worker, num_workers, total, j0, j_step, sub, per))
-                for (int j = j0; j < total; j += j_step)
-                {
-                    const Chunk& ch = c.chunks[j / gu];
-                    const bool up = gu == 1 || (j % gu);
-                    const MoeCpuMatrix& mat = up ? L.ups[ch.expert] : L.gates[ch.expert];
-                    const PreparedIn& p = (up ? c.prep_u : c.prep_g)[j / gu];
-                    float* tout = (up ? c.tout_u : c.tout_g) + static_cast<size_t>(j / gu) * MAX_M * I;
-                    int t0, t1;
-                    tile_split(mat, sub, per, t0, t1);
-                    run_tiles(mat, p, tout, ch.m, t0, t1);
-                }
+            assign_gemvs(worker, num_workers, nc * gu, I / 16, [&](int j, int t0, int t1)
+            {
+                const Chunk& ch = c.chunks[j / gu];
+                const bool up = gu == 1 || (j % gu);
+                const MoeCpuMatrix& mat = up ? L.ups[ch.expert] : L.gates[ch.expert];
+                const PreparedIn& p = (up ? c.prep_u : c.prep_g)[j / gu];
+                float* tout = (up ? c.tout_u : c.tout_g) + static_cast<size_t>(j / gu) * MAX_M * I;
+                run_tiles(mat, p, tout, ch.m, t0, t1);
+            });
             break;
         }
 
@@ -2064,16 +2041,12 @@ void forward_phase(void* vctx, int worker, int num_workers)
         case 3:
         {
             // Down GEMVs
-            int j0, j_step, sub, per;
-            if (gemv_assignment(worker, num_workers, nc, j0, j_step, sub, per))
-                for (int j = j0; j < nc; j += j_step) {
-                    const Chunk& ch = c.chunks[j];
-                    const MoeCpuMatrix& mat = L.downs[ch.expert];
-                    float* tout = c.tout_d + static_cast<size_t>(j) * MAX_M * H;
-                    int t0, t1;
-                    tile_split(mat, sub, per, t0, t1);
-                    run_tiles(mat, c.prep_d[j], tout, ch.m, t0, t1);
-                }
+            assign_gemvs(worker, num_workers, nc, H / 16, [&](int j, int t0, int t1)
+            {
+                const Chunk& ch = c.chunks[j];
+                float* tout = c.tout_d + static_cast<size_t>(j) * MAX_M * H;
+                run_tiles(L.downs[ch.expert], c.prep_d[j], tout, ch.m, t0, t1);
+            });
             break;
         }
 

--- a/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
+++ b/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
@@ -457,9 +457,21 @@ inline void dword_gather(__m512i p0, __m512i p1, __m512i p2, __m512i p3, __m512i
     }
 }
 
+// Per-lane shift counts for the funnel merge: cols 0-7 use s0, cols 8-15 use s1
+template <int s0, int s1>
+constexpr std::array<int32_t, 16> make_lane_shifts()
+{
+    std::array<int32_t, 16> v{};
+    for (int i = 0; i < 16; ++i) v[i] = i < 8 ? s0 : s1;
+    return v;
+}
+
 // Shift-merge codes for `row` out of its gathered word vectors; delta = bits extracts row+1
 // from row's own gather (valid when word_pair_ok). Vector shifts by >= 32 are well-defined
-// zero, so the s' == 0 case needs no special path.
+// zero, so the s' == 0 case needs no special path. The two half-rows generally need different
+// shifts: one per-lane variable funnel shift (vpsrlvd/vpsllvd against compile-time count
+// vectors) merges both in 4 uops (GCC fuses the or+and into vpternlogd), where two immediate
+// funnel shifts plus a lane blend took 8.
 template <int bits, int row, int delta>
 M1_TARGET_BW
 inline __m512i dword_codes(__m512i a, __m512i b)
@@ -467,9 +479,19 @@ inline __m512i dword_codes(__m512i a, __m512i b)
     constexpr int s0 = row_shift<bits, row>(0) - delta;
     constexpr int s1 = row_shift<bits, row>(8) - delta;
     static_assert(s0 >= 0 && s1 >= 0, "pairing delta exceeds shift headroom");
-    const __m512i c0 = _mm512_or_si512(_mm512_srli_epi32(b, s0), _mm512_slli_epi32(a, 32 - s0));
-    const __m512i c1 = _mm512_or_si512(_mm512_srli_epi32(b, s1), _mm512_slli_epi32(a, 32 - s1));
-    return _mm512_and_si512(_mm512_mask_blend_epi32(0xff00, c0, c1), _mm512_set1_epi32(0xffff));
+    if constexpr (s0 == s1)
+    {
+        const __m512i c = _mm512_or_si512(_mm512_srli_epi32(b, s0), _mm512_slli_epi32(a, 32 - s0));
+        return _mm512_and_si512(c, _mm512_set1_epi32(0xffff));
+    }
+    else
+    {
+        alignas(64) static constexpr auto sh = make_lane_shifts<s0, s1>();
+        alignas(64) static constexpr auto shc = make_lane_shifts<32 - s0, 32 - s1>();
+        const __m512i c = _mm512_or_si512(_mm512_srlv_epi32(b, _mm512_load_si512(sh.data())),
+                                          _mm512_sllv_epi32(a, _mm512_load_si512(shc.data())));
+        return _mm512_and_si512(c, _mm512_set1_epi32(0xffff));
+    }
 }
 
 template <int bits, int row>

--- a/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
+++ b/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
@@ -73,11 +73,13 @@ constexpr int MAX_M = 4;
 #define M1_TARGET_BW __attribute__((target("avx512f,avx512bw,avx512vl,fma,f16c")))
 #define M1_TARGET_VNNI __attribute__((target("avx512f,avx512bw,avx512vl,avx512vnni,fma,f16c")))
 #define M1_TARGET_VBMI __attribute__((target("avx512f,avx512bw,avx512vl,avx512vnni,avx512vbmi,fma,f16c")))
+#define M1_ALWAYS_INLINE __attribute__((always_inline)) inline
 #else
 #define M1_TARGET_AVX2
 #define M1_TARGET_BW
 #define M1_TARGET_VNNI
 #define M1_TARGET_VBMI
+#define M1_ALWAYS_INLINE __forceinline
 #endif
 
 inline void cpu_pause()
@@ -716,9 +718,12 @@ void vnni_tiles(const MoeCpuMatrix& mat, const PreparedIn& in, float* tout, int 
 //   contracting vpmaddwd+vpaddd into vpdpwssd.
 // -------------------------------------------------------------------------------------------
 
+// Force-inlined: GCC otherwise outlines the 16-row chain behind a call on every tile step, and
+// with every zmm register caller-saved the band loop then reloads all of its live constants
+// (index tables, multiplier, shift vectors) after each call (+8-9% inlined, Skylake-SP)
 template <int bits, int rows, int band, int R>
 M1_TARGET_BW
-inline void bw_band_rows
+M1_ALWAYS_INLINE void bw_band_rows
 (
     __m512i p0, __m512i p1, __m512i p2, __m512i p3, int b, const int32_t* splat_dup, int k,
     __m512i (&acc)[band][MAX_M]

--- a/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
+++ b/exllamav3/exllamav3_ext/cpu/moe_mul1.cpp
@@ -41,7 +41,7 @@
 // below 2^15, which makes the operand order load-bearing). Accuracy matches the GPU int8-GEMV
 // mode-2 class (~0.9% per-call output RMS). i32 accumulators are safe for k up to ~8192.
 //
-// On the AVX2 tier (no VNNI) the byte-sum must be emulated with vpmaddubsw, whose i16 pair sums
+// On the AVX2 and AVX-512BW tiers (no VNNI) the byte-sum is emulated with vpmaddubsw, whose i16 pair sums
 // saturate once an activation is inside the pair. The accumulate therefore keeps the pair x-free:
 // sum the product bytes once per k-row into i16 pair-sums <= 510, then multiply by x with one
 // vpmaddwd per token row. +-127 activations, bit-exact vs the masked accumulate it replaces,
@@ -70,10 +70,12 @@ constexpr int MAX_M = 4;
 
 #if defined(__GNUC__) && defined(__linux__)
 #define M1_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define M1_TARGET_BW __attribute__((target("avx512f,avx512bw,avx512vl,fma,f16c")))
 #define M1_TARGET_VNNI __attribute__((target("avx512f,avx512bw,avx512vl,avx512vnni,fma,f16c")))
 #define M1_TARGET_VBMI __attribute__((target("avx512f,avx512bw,avx512vl,avx512vnni,avx512vbmi,fma,f16c")))
 #else
 #define M1_TARGET_AVX2
+#define M1_TARGET_BW
 #define M1_TARGET_VNNI
 #define M1_TARGET_VBMI
 #endif
@@ -190,8 +192,9 @@ inline float decode_mul1_scalar(uint16_t state)
 // -------------------------------------------------------------------------------------------
 
 // Declared early: the transforms below select on it. Vbmi = Vnni + AVX512-VBMI (Zen4+, Ice
-// Lake+); kept as a separate tier because Cascade/Cooper Lake have VNNI without VBMI.
-enum class Isa { Scalar, Avx2, Vnni, Vbmi };
+// Lake+); kept as a separate tier because Cascade/Cooper Lake have VNNI without VBMI. Bw =
+// AVX-512F/BW/VL without VNNI (Skylake-SP/X): the dword kernel with the AVX2-style accumulate.
+enum class Isa { Scalar, Avx2, Bw, Vnni, Vbmi };
 extern const Isa g_isa;
 
 // -------------------------------------------------------------------------------------------
@@ -395,8 +398,8 @@ void prepare_rows
 
         // int8 quantization, one scale per row
         int32_t* splat = p.splat32 + static_cast<size_t>(r) * k;
-        // dup is only read by the AVX2 maddubs kernels; skip the stores on the VNNI/VBMI tiers
-        int32_t* splat_dup = (p.splat_dup && g_isa == Isa::Avx2)
+        // dup is only read by the AVX2/BW maddubs kernels; skip the stores on the VNNI/VBMI tiers
+        int32_t* splat_dup = (p.splat_dup && (g_isa == Isa::Avx2 || g_isa == Isa::Bw))
             ? p.splat_dup + static_cast<size_t>(r) * k : nullptr;
         float q;
         int32_t s;
@@ -431,7 +434,7 @@ void prepare_rows
 // Gather the two 32-bit word vectors covering row `row`'s 16-bit states (the permute stage of
 // the extraction, split out so a row pair can share it -- see vnni_band_rows)
 template <int bits, int row>
-M1_TARGET_VNNI
+M1_TARGET_BW
 inline void dword_gather(__m512i p0, __m512i p1, __m512i p2, __m512i p3, __m512i& a, __m512i& b)
 {
     alignas(64) static constexpr auto i0d = make_row_indices<bits, row, false>();
@@ -458,7 +461,7 @@ inline void dword_gather(__m512i p0, __m512i p1, __m512i p2, __m512i p3, __m512i
 // from row's own gather (valid when word_pair_ok). Vector shifts by >= 32 are well-defined
 // zero, so the s' == 0 case needs no special path.
 template <int bits, int row, int delta>
-M1_TARGET_VNNI
+M1_TARGET_BW
 inline __m512i dword_codes(__m512i a, __m512i b)
 {
     constexpr int s0 = row_shift<bits, row>(0) - delta;
@@ -470,7 +473,7 @@ inline __m512i dword_codes(__m512i a, __m512i b)
 }
 
 template <int bits, int row>
-M1_TARGET_VNNI
+M1_TARGET_BW
 inline __m512i extract_row(__m512i p0, __m512i p1, __m512i p2, __m512i p3)
 {
     __m512i a, b;
@@ -673,6 +676,165 @@ void vnni_tiles(const MoeCpuMatrix& mat, const PreparedIn& in, float* tout, int 
                     }
                 }
                 break;
+        }
+        n0 += band;
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+//   AVX-512 BW banded kernel
+//
+//   AVX-512F/BW/VL without VNNI (Skylake-SP/X), which otherwise fell through to the AVX2 tier.
+//   The VNNI kernel's dword extraction and k-major band structure (pure AVX-512F) with the AVX2
+//   tier's accumulate in place of vpdpbusd: vpmaddubsw of the product bytes against 0x01 pairs
+//   gives (b0+b1), (b2+b3) as i16 lanes (<= 510, cannot saturate), then one vpmaddwd per token
+//   row against splat_dup (x8 in both 16-bit slots). Bit-exact with the AVX2 and VNNI tiers.
+//   Separate functions rather than a template flag on the VNNI kernel: a function carries one
+//   target attribute, and compiling this accumulate under the VNNI target would permit
+//   contracting vpmaddwd+vpaddd into vpdpwssd.
+// -------------------------------------------------------------------------------------------
+
+template <int bits, int rows, int band, int R>
+M1_TARGET_BW
+inline void bw_band_rows
+(
+    __m512i p0, __m512i p1, __m512i p2, __m512i p3, int b, const int32_t* splat_dup, int k,
+    __m512i (&acc)[band][MAX_M]
+)
+{
+    if constexpr (dword_pair_wins<bits>())
+    {
+        if constexpr (R < 16) {
+            const __m512i mult = _mm512_set1_epi32(static_cast<int32_t>(MUL1_MULT));
+            const __m512i ones = _mm512_set1_epi32(0x01010101);
+            __m512i a, wb;
+            dword_gather<bits, R>(p0, p1, p2, p3, a, wb);
+            const __m512i code0 = dword_codes<bits, R, 0>(a, wb);
+            __m512i code1;
+            if constexpr (word_pair_ok<bits, R>())
+            {
+                code1 = dword_codes<bits, R, bits>(a, wb);
+            }
+            else
+            {
+                dword_gather<bits, R + 1>(p0, p1, p2, p3, a, wb);
+                code1 = dword_codes<bits, R + 1, 0>(a, wb);
+            }
+            const __m512i ps0 = _mm512_maddubs_epi16(_mm512_mullo_epi32(code0, mult), ones);
+            const __m512i ps1 = _mm512_maddubs_epi16(_mm512_mullo_epi32(code1, mult), ones);
+            for (int i = 0; i < rows; ++i)
+            {
+                const __m512i x0 = _mm512_set1_epi32(splat_dup[static_cast<size_t>(i) * k + R]);
+                const __m512i x1 = _mm512_set1_epi32(splat_dup[static_cast<size_t>(i) * k + R + 1]);
+                acc[b][i] = _mm512_add_epi32(acc[b][i], _mm512_madd_epi16(ps0, x0));
+                acc[b][i] = _mm512_add_epi32(acc[b][i], _mm512_madd_epi16(ps1, x1));
+            }
+            bw_band_rows<bits, rows, band, R + 2>(p0, p1, p2, p3, b, splat_dup, k, acc);
+        }
+    }
+    else
+    {
+        if constexpr (R < 16) {
+            const __m512i mult = _mm512_set1_epi32(static_cast<int32_t>(MUL1_MULT));
+            const __m512i ones = _mm512_set1_epi32(0x01010101);
+            const __m512i code = extract_row<bits, R>(p0, p1, p2, p3);
+            const __m512i ps = _mm512_maddubs_epi16(_mm512_mullo_epi32(code, mult), ones);
+            for (int i = 0; i < rows; ++i)
+                acc[b][i] = _mm512_add_epi32(acc[b][i], _mm512_madd_epi16(ps,
+                    _mm512_set1_epi32(splat_dup[static_cast<size_t>(i) * k + R])));
+            bw_band_rows<bits, rows, band, R + 1>(p0, p1, p2, p3, b, splat_dup, k, acc);
+        }
+    }
+}
+
+template <int bits, int rows, int band>
+M1_TARGET_BW
+void bw_band(const MoeCpuMatrix& mat, const PreparedIn& in, float* tout, int n0)
+{
+    const int tiles_k = mat.k / 16;
+    const int tiles_n = mat.n / 16;
+    constexpr int packed_size = 16 * bits;
+    constexpr int words32 = bits * 256 / 32;
+    constexpr auto ld_mask = [](int n) -> __mmask16
+    {
+        return n >= 16 ? 0xffffu : (n <= 0 ? 0x0000u : static_cast<__mmask16>((1u << n) - 1u));
+    };
+    constexpr __mmask16 mask0 = ld_mask(words32 - 0);
+    constexpr __mmask16 mask1 = ld_mask(words32 - 16);
+    constexpr __mmask16 mask2 = ld_mask(words32 - 32);
+    constexpr __mmask16 mask3 = ld_mask(words32 - 48);
+
+    __m512i acc[band][MAX_M];
+    for (int b = 0; b < band; ++b)
+        for (int i = 0; i < rows; ++i)
+            acc[b][i] = _mm512_setzero_si512();
+
+    // Layout and prefetch handling as in vnni_band (see the comments there); the host hands
+    // this tier the swizzled layout too (moe_cpu_host gates it on has_avx512_bw)
+    const size_t row_stride = static_cast<size_t>(tiles_n) * packed_size;
+    const size_t pf_step = mat.swz ? static_cast<size_t>(8) * packed_size : row_stride;
+    const uint16_t* packed_row = mat.trellis + static_cast<size_t>(n0) * packed_size;
+    for (int tile_k = 0; tile_k < tiles_k; ++tile_k, packed_row += row_stride)
+    {
+        const int32_t* splat_dup = in.splat_dup + tile_k * 16;
+        for (int b = 0; b < band; ++b)
+        {
+            const uint16_t* packed = mat.swz
+                ? mat.trellis + (static_cast<size_t>(n0 / 8) * tiles_k * 8
+                                 + static_cast<size_t>(tile_k) * 8 + (n0 % 8) + b) * packed_size
+                : packed_row + b * packed_size;
+            if (mat.swz && band == 8)
+            {
+                _mm_prefetch(reinterpret_cast<const char*>(packed + pf_step), _MM_HINT_T1);
+            }
+            else
+            {
+                constexpr int pf_lines = (packed_size * 2 + 63) / 64;
+                constexpr int pf_dist = (bits == 6) ? 2 : 4;
+                const char* pf = reinterpret_cast<const char*>(packed + pf_step * pf_dist);
+                for (int l = 0; l < pf_lines; ++l)
+                    _mm_prefetch(pf + l * 64, _MM_HINT_T0);
+            }
+            const uint32_t* pw = reinterpret_cast<const uint32_t*>(packed);
+            const __m512i p0 = _mm512_maskz_loadu_epi32(mask0, pw);
+            const __m512i p1 = _mm512_maskz_loadu_epi32(mask1, pw + 16);
+            const __m512i p2 = mask2 ? _mm512_maskz_loadu_epi32(mask2, pw + 32) : _mm512_setzero_si512();
+            const __m512i p3 = mask3 ? _mm512_maskz_loadu_epi32(mask3, pw + 48) : _mm512_setzero_si512();
+            bw_band_rows<bits, rows, band, 0>(p0, p1, p2, p3, b, splat_dup, mat.k, acc);
+        }
+    }
+    for (int b = 0; b < band; ++b)
+        for (int i = 0; i < rows; ++i)
+        {
+            const float scale = mul1_k_inv() * in.q[i];
+            const __m512 corr = _mm512_set1_ps(-510.0f * static_cast<float>(in.sum_x8[i]) * scale);
+            const __m512 out = _mm512_fmadd_ps(_mm512_cvtepi32_ps(acc[b][i]), _mm512_set1_ps(scale), corr);
+            _mm512_storeu_ps(tout + static_cast<size_t>(i) * mat.n + (n0 + b) * 16, out);
+        }
+}
+
+template <int bits, int rows>
+M1_TARGET_BW
+void bw_tiles(const MoeCpuMatrix& mat, const PreparedIn& in, float* tout, int tn0, int tn1)
+{
+    // Same band widths as vnni_tiles (one more live temporary per band step, same budget)
+    constexpr int band_cap = 8;
+    const int max_band = mat.swz ? (rows == 1 ? 8 : rows <= 3 ? 4 : 2)
+                                 : (rows == 1 ? band_cap : (12 / rows < 8 ? 12 / rows : 8));
+    int n0 = tn0;
+    while (n0 < tn1)
+    {
+        const int band = std::min(tn1 - n0, max_band);
+        switch (band)
+        {
+            case 1: bw_band<bits, rows, 1>(mat, in, tout, n0); break;
+            case 2: bw_band<bits, rows, 2>(mat, in, tout, n0); break;
+            case 3: bw_band<bits, rows, 3>(mat, in, tout, n0); break;
+            case 4: bw_band<bits, rows, 4>(mat, in, tout, n0); break;
+            case 5: bw_band<bits, rows, 5>(mat, in, tout, n0); break;
+            case 6: bw_band<bits, rows, 6>(mat, in, tout, n0); break;
+            case 7: bw_band<bits, rows, 7>(mat, in, tout, n0); break;
+            default: bw_band<bits, rows, 8>(mat, in, tout, n0); break;
         }
         n0 += band;
     }
@@ -1207,8 +1369,13 @@ Isa detect_isa()
     Isa hw;
 #if defined(__GNUC__) && defined(__linux__)
     if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512bw") &&
-        __builtin_cpu_supports("avx512vl") && __builtin_cpu_supports("avx512vnni"))
-        hw = __builtin_cpu_supports("avx512vbmi") ? Isa::Vbmi : Isa::Vnni;
+        __builtin_cpu_supports("avx512vl") && __builtin_cpu_supports("fma"))
+    {
+        if (__builtin_cpu_supports("avx512vnni"))
+            hw = __builtin_cpu_supports("avx512vbmi") ? Isa::Vbmi : Isa::Vnni;
+        else
+            hw = Isa::Bw;
+    }
     else if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("fma"))
         hw = Isa::Avx2;
     else
@@ -1239,13 +1406,13 @@ Isa detect_isa()
         const bool vnni = (info[2] & (1u << 11)) != 0;
         const bool vbmi = (info[2] & (1u << 1)) != 0;
         const bool avx2 = (info[1] & (1u << 5)) != 0;
-        hw = (avx512 && vnni && zmm_os) ? (vbmi ? Isa::Vbmi : Isa::Vnni)
+        hw = (avx512 && fma && zmm_os) ? (vnni ? (vbmi ? Isa::Vbmi : Isa::Vnni) : Isa::Bw)
            : (avx2 && fma && ymm_os)    ? Isa::Avx2
            :                              Isa::Scalar;
     }
 #endif
 
-    // EXL3_MOE_CPU_MAX_ISA=scalar|avx2|vnni|vbmi: cap detection at a lower tier for testing
+    // EXL3_MOE_CPU_MAX_ISA=scalar|avx2|bw|vnni|vbmi: cap detection at a lower tier for testing
     // (e.g. exercising the AVX2 path on AVX512-VNNI hardware, or the dword scheme on VBMI
     // hardware). Never upgrades past what the CPU actually supports; an unrecognized value is
     // ignored.
@@ -1256,6 +1423,7 @@ Isa detect_isa()
         Isa cap;
         if (s == "scalar") cap = Isa::Scalar;
         else if (s == "avx2") cap = Isa::Avx2;
+        else if (s == "bw" || s == "avx512bw") cap = Isa::Bw;
         else if (s == "vnni" || s == "avx512") cap = Isa::Vnni;
         else if (s == "vbmi") cap = Isa::Vbmi;
         else return hw;
@@ -1347,6 +1515,45 @@ void run_tiles(const MoeCpuMatrix& mat, const PreparedIn& in, float* tout, int m
                 case 8 * 4 + 1: vnni_tiles<8, 2>(mat, in, tout, tn0, tn1); return;
                 case 8 * 4 + 2: vnni_tiles<8, 3>(mat, in, tout, tn0, tn1); return;
                 case 8 * 4 + 3: vnni_tiles<8, 4>(mat, in, tout, tn0, tn1); return;
+            }
+            return;
+        }
+        case Isa::Bw:
+        {
+            switch (mat.bits * 4 + m - 1)
+            {
+                case 1 * 4 + 0: bw_tiles<1, 1>(mat, in, tout, tn0, tn1); return;
+                case 1 * 4 + 1: bw_tiles<1, 2>(mat, in, tout, tn0, tn1); return;
+                case 1 * 4 + 2: bw_tiles<1, 3>(mat, in, tout, tn0, tn1); return;
+                case 1 * 4 + 3: bw_tiles<1, 4>(mat, in, tout, tn0, tn1); return;
+                case 2 * 4 + 0: bw_tiles<2, 1>(mat, in, tout, tn0, tn1); return;
+                case 2 * 4 + 1: bw_tiles<2, 2>(mat, in, tout, tn0, tn1); return;
+                case 2 * 4 + 2: bw_tiles<2, 3>(mat, in, tout, tn0, tn1); return;
+                case 2 * 4 + 3: bw_tiles<2, 4>(mat, in, tout, tn0, tn1); return;
+                case 3 * 4 + 0: bw_tiles<3, 1>(mat, in, tout, tn0, tn1); return;
+                case 3 * 4 + 1: bw_tiles<3, 2>(mat, in, tout, tn0, tn1); return;
+                case 3 * 4 + 2: bw_tiles<3, 3>(mat, in, tout, tn0, tn1); return;
+                case 3 * 4 + 3: bw_tiles<3, 4>(mat, in, tout, tn0, tn1); return;
+                case 4 * 4 + 0: bw_tiles<4, 1>(mat, in, tout, tn0, tn1); return;
+                case 4 * 4 + 1: bw_tiles<4, 2>(mat, in, tout, tn0, tn1); return;
+                case 4 * 4 + 2: bw_tiles<4, 3>(mat, in, tout, tn0, tn1); return;
+                case 4 * 4 + 3: bw_tiles<4, 4>(mat, in, tout, tn0, tn1); return;
+                case 5 * 4 + 0: bw_tiles<5, 1>(mat, in, tout, tn0, tn1); return;
+                case 5 * 4 + 1: bw_tiles<5, 2>(mat, in, tout, tn0, tn1); return;
+                case 5 * 4 + 2: bw_tiles<5, 3>(mat, in, tout, tn0, tn1); return;
+                case 5 * 4 + 3: bw_tiles<5, 4>(mat, in, tout, tn0, tn1); return;
+                case 6 * 4 + 0: bw_tiles<6, 1>(mat, in, tout, tn0, tn1); return;
+                case 6 * 4 + 1: bw_tiles<6, 2>(mat, in, tout, tn0, tn1); return;
+                case 6 * 4 + 2: bw_tiles<6, 3>(mat, in, tout, tn0, tn1); return;
+                case 6 * 4 + 3: bw_tiles<6, 4>(mat, in, tout, tn0, tn1); return;
+                case 7 * 4 + 0: bw_tiles<7, 1>(mat, in, tout, tn0, tn1); return;
+                case 7 * 4 + 1: bw_tiles<7, 2>(mat, in, tout, tn0, tn1); return;
+                case 7 * 4 + 2: bw_tiles<7, 3>(mat, in, tout, tn0, tn1); return;
+                case 7 * 4 + 3: bw_tiles<7, 4>(mat, in, tout, tn0, tn1); return;
+                case 8 * 4 + 0: bw_tiles<8, 1>(mat, in, tout, tn0, tn1); return;
+                case 8 * 4 + 1: bw_tiles<8, 2>(mat, in, tout, tn0, tn1); return;
+                case 8 * 4 + 2: bw_tiles<8, 3>(mat, in, tout, tn0, tn1); return;
+                case 8 * 4 + 3: bw_tiles<8, 4>(mat, in, tout, tn0, tn1); return;
             }
             return;
         }
@@ -1983,6 +2190,7 @@ void exl3_moe_cpu_stage_experts
 }
 
 bool exl3_moe_cpu_has_avx2() { return g_isa != Isa::Scalar; }
+bool exl3_moe_cpu_has_avx512_bw() { return g_isa >= Isa::Bw; }
 bool exl3_moe_cpu_has_avx512_vnni() { return g_isa >= Isa::Vnni; }
 bool exl3_moe_cpu_has_avx512_vbmi() { return g_isa == Isa::Vbmi; }
 

--- a/exllamav3/exllamav3_ext/cpu/moe_mul1.h
+++ b/exllamav3/exllamav3_ext/cpu/moe_mul1.h
@@ -7,9 +7,9 @@
 // CPU-side MoE expert GEMM for mul1 (cb2) EXL3 tensors, standalone from the module code so it
 // can be benchmarked and driven directly. A layer is registered once (raw pointers into CPU
 // trellis/suh/svh tensors, which the caller must keep alive) and then invoked per forward with
-// the routing results. Kernels dispatch at runtime on scalar / AVX2 / AVX-512+VNNI; the mul1
-// codebook is affine in a byte-sum, so dequantization and the activation product fuse into
-// integer dot products (see exl3_moe_cpu_forward for the math).
+// the routing results. Kernels dispatch at runtime on scalar / AVX2 / AVX-512BW / AVX-512+VNNI;
+// the mul1 codebook is affine in a byte-sum, so dequantization and the activation product
+// fuse into integer dot products (see exl3_moe_cpu_forward for the math).
 //
 // Current limits: mul1 codebook only, K in [1, 8]. Gated experts with silu/gelu/swiglu_oai
 // (act_limit) or gateless with relu2; optional per-expert biases (uniform per projection).
@@ -115,8 +115,9 @@ void exl3_moe_cpu_set_prof(bool enabled);
 int64_t exl3_moe_cpu_pool_stress(int threads, int iters, int small, int spin);   // test hook
 
 // Kernel availability (dispatch happens internally; these are informational, post-env-cap).
-// has_avx512_vbmi additionally gates the swizzled weight layout in the child loader: the wide
-// swizzle bands need the byte-gather kernels' low temporary count.
+// has_avx512_vbmi and has_avx512_bw additionally gate the swizzled weight layout in the child
+// loader (the VBMI tier's wide swizzle bands need the byte-gather kernels' low temporary count).
 bool exl3_moe_cpu_has_avx2();
+bool exl3_moe_cpu_has_avx512_bw();
 bool exl3_moe_cpu_has_avx512_vnni();
 bool exl3_moe_cpu_has_avx512_vbmi();

--- a/exllamav3/model/moe_cpu_host.py
+++ b/exllamav3/model/moe_cpu_host.py
@@ -87,8 +87,8 @@ class MoeCpuTuning:
         # region once easily-compactable free memory runs low, which can stall loading badly
         self.arena_hugepage = os.environ.get("EXL3_MOE_ARENA_HUGEPAGE", "1") != "0"
         # Band-contiguous ("swizzled") expert trellis layout: repacked at arena rehome so each
-        # 8-tile output band streams sequentially from DRAM. Only applied when the VBMI kernel
-        # tier is active. EXL3_MOE_CPU_SWIZZLE=0 restores the native layout.
+        # 8-tile output band streams sequentially from DRAM. Applied when the VBMI or the
+        # AVX-512BW kernel tier is active. EXL3_MOE_CPU_SWIZZLE=0 restores the native layout.
         self.swizzle = os.environ.get("EXL3_MOE_CPU_SWIZZLE", "1") != "0"
 
         # --- GPU-streaming prefill ---
@@ -235,8 +235,8 @@ def _moe_cpu_child_main(conn, model_dir, threads, stage_threads):
                 out.append((trellis, suh, svh, bias))
             return out
 
-        # Swizzle the trellis copies band-contiguous when the VBMI kernel tier will consume them
-        swz = TUNING.swizzle and cext.exl3_moe_cpu_has_avx512_vbmi()
+        # Swizzle the trellis copies band-contiguous when the VBMI/BW kernel tiers will consume them
+        swz = TUNING.swizzle and (cext.exl3_moe_cpu_has_avx512_vbmi() or cext.exl3_moe_cpu_has_avx512_bw())
 
         def rehome_trellis(t):
             return arena.rehome(t, band_swizzle = swz and t.shape[2] // 16 != 8)
@@ -595,7 +595,8 @@ class MoeCpuHost:
         self._start_watchdog()
         kern = "avx512-vbmi" if ext.exl3_moe_cpu_has_avx512_vbmi() else \
                ("avx512-vnni" if ext.exl3_moe_cpu_has_avx512_vnni() else \
-               ("avx2" if ext.exl3_moe_cpu_has_avx2() else "scalar"))
+               ("avx512-bw" if ext.exl3_moe_cpu_has_avx512_bw() else \
+               ("avx2" if ext.exl3_moe_cpu_has_avx2() else "scalar")))
         print(f" -- CPU MoE worker started: {len(self.specs)} layers, {kern}, {self.threads} threads")
 
     def _start_watchdog(self):
@@ -875,7 +876,7 @@ class MoeCpuHost:
         # Experts arrive band-swizzled when the VBMI CPU tier owns them (same rule as the child's
         # arena rehome, K8 excepted per matrix); the GPU restores the native tile order into a
         # parallel ring after each DMA
-        swz = TUNING.swizzle and ext.exl3_moe_cpu_has_avx512_vbmi()
+        swz = TUNING.swizzle and (ext.exl3_moe_cpu_has_avx512_vbmi() or ext.exl3_moe_cpu_has_avx512_bw())
         st = dict(
             copy_stream = torch.cuda.Stream(device = device),
             vram_slots = [torch.empty(self.wslot_size // 2, dtype = torch.int16, device = device)

--- a/tests/test_moe_cpu_tiers_.py
+++ b/tests/test_moe_cpu_tiers_.py
@@ -1,0 +1,129 @@
+"""
+CPU MoE expert kernel (cpu/moe_mul1.cpp): every ISA tier the CPU can run must agree. The int8
+tiers (avx2, bw, vnni, vbmi) compute the same integer dot products from the same int8 activations,
+so they agree to float rounding of the epilogue; the scalar tier is an fp32 reference without the
+int8 activation quantization and agrees to ~1%. Any state-extraction or accumulate bug in a tier
+shows up as O(1) error, far outside both tolerances.
+
+The tier is fixed per process by EXL3_MOE_CPU_MAX_ISA (read once at static init), so each tier
+runs in a subprocess; on a VBMI machine that exercises vbmi, vnni, bw, avx2 and scalar in one run.
+Covers K1-8, gated and gateless experts, 1..5 tokens (m = 1..4 rows per expert chunk), the
+swizzled layout, and a 256-token case that takes the GEMV phases' many-GEMV (strided) regime.
+"""
+import os, sys, subprocess, tempfile
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+INT8_TOL = 5e-4     # rel. L2 between int8 tiers (observed <= 1e-4 under -Ofast; 0 with strict FP)
+SCALAR_TOL = 0.05   # rel. L2 int8 tiers vs the fp32 scalar reference (observed <= 0.02)
+
+
+def _worker(tier, out_path):
+    os.environ["EXL3_MOE_CPU_MAX_ISA"] = tier
+    import torch
+    from exllamav3.ext import exllamav3_ext as ext
+    g = torch.Generator().manual_seed(1234)
+    threads = max(2, min(16, (os.cpu_count() or 2) // 2))
+
+    def trellis(k, n, K):   # native [k/16, n/16, 16K] packed layout, random states
+        return torch.randint(-32768, 32767, (k // 16, n // 16, 16 * K), dtype = torch.int16, generator = g)
+
+    def suh(n):   # real EXL3 suh: random signs x ~0.015
+        s = torch.randint(0, 2, (n,), generator = g).float() * 2 - 1
+        return (s * (0.015 + 0.004 * torch.randn(n, generator = g))).half().contiguous()
+
+    def svh(n):   # real EXL3 svh: random signs x ~1.0
+        s = torch.randint(0, 2, (n,), generator = g).float() * 2 - 1
+        return (s * (1.0 + 0.1 * torch.randn(n, generator = g))).half().contiguous()
+
+    # The swizzled (band-contiguous) layout is only ever handed to the tiers that consume it (the
+    # host gates it on has_avx512_vbmi/has_avx512_bw); scalar and avx2 read the native layout only
+    swz_capable = tier in ("bw", "vnni", "vbmi", "avx512", "avx512bw")
+
+    def swizzled(t, K):
+        if K == 8: return t   # K8 tensors stay native (make_matrix exempts them too)
+        tk, tn, ps = t.shape
+        return t.view(tk, tn // 8, 8, ps).permute(1, 0, 2, 3).contiguous().view(tk, tn, ps)
+
+    results = {}
+    hid, inter, E, topk = 512, 640, 6, 3
+    for K in range(1, 9):
+        for gated in (True, False):
+            # one set of logical weights per (K, gated); the swizzled layer is a repack of the same
+            gt, gs, gv, ut, us, uv, dt, ds, dv = ([] for _ in range(9))
+            for _ in range(E):
+                if gated:
+                    gt.append(trellis(hid, inter, K)); gs.append(suh(hid)); gv.append(svh(inter))
+                ut.append(trellis(hid, inter, K)); us.append(suh(hid)); uv.append(svh(inter))
+                dt.append(trellis(inter, hid, K)); ds.append(suh(inter)); dv.append(svh(hid))
+            layers = [(False, ext.exl3_moe_cpu_make_layer(gt, gs, gv, ut, us, uv, dt, ds, dv, [], [], [],
+                                                          0 if gated else 2, 0.0, 0))]
+            if swz_capable:
+                sw = lambda ts: [swizzled(t, K) for t in ts]
+                layers.append((True, ext.exl3_moe_cpu_make_layer(sw(gt), gs, gv, sw(ut), us, uv, sw(dt), ds, dv,
+                                                                 [], [], [], 0 if gated else 2, 0.0, 1)))
+            cases = []
+            for tokens in (1, 2, 3, 4, 5, 256):
+                x = torch.randn(tokens, hid, generator = g).half()
+                # 1..5 tokens on the same experts -> chunks of m = 1..4 rows; 256 tokens spread over
+                # all experts -> many chunks per expert -> the strided GEMV assignment regime
+                if tokens <= 5:
+                    sel = torch.randperm(E, generator = g)[:topk].unsqueeze(0).repeat(tokens, 1)
+                else:
+                    sel = torch.stack([torch.randperm(E, generator = g)[:topk] for _ in range(tokens)])
+                w = torch.rand(tokens, topk, generator = g)
+                w = (w / w.sum(-1, keepdim = True)).half()
+                cases.append((tokens, x, sel.contiguous(), w.contiguous()))
+            for swz, h in layers:
+                for tokens, x, sel, w in cases:
+                    for th in ((1, threads) if tokens <= 5 else (threads,)):
+                        out = torch.zeros(tokens, hid, dtype = torch.float32)
+                        ext.exl3_moe_cpu_forward(h, x, sel, w, out, th)
+                        results[(K, gated, swz, tokens, th)] = out.clone()
+                ext.exl3_moe_cpu_free_layer(h)
+    torch.save(results, out_path)
+
+
+def _supported_tiers():
+    from exllamav3.ext import exllamav3_ext as ext
+    tiers = ["scalar"]
+    if ext.exl3_moe_cpu_has_avx2(): tiers.append("avx2")
+    if getattr(ext, "exl3_moe_cpu_has_avx512_bw", lambda: False)(): tiers.append("bw")
+    if ext.exl3_moe_cpu_has_avx512_vnni(): tiers.append("vnni")
+    if ext.exl3_moe_cpu_has_avx512_vbmi(): tiers.append("vbmi")
+    return tiers
+
+
+def test_cpu_moe_tiers_agree():
+    import torch
+    tiers = _supported_tiers()
+    assert "avx2" in tiers, "no vector tier available; nothing to compare"
+    with tempfile.TemporaryDirectory() as td:
+        outs = {}
+        for tier in tiers:
+            path = os.path.join(td, f"{tier}.pt")
+            env = dict(os.environ, EXL3_MOE_CPU_MAX_ISA = tier)
+            subprocess.run([sys.executable, os.path.abspath(__file__), "--worker", tier, path],
+                           env = env, check = True)
+            outs[tier] = torch.load(path)
+        ref = outs["avx2"]   # native layout only; swizzled results compare against the same weights natively
+        native = lambda key: (key[0], key[1], False, key[3], key[4])
+        for tier, res in outs.items():
+            assert all(native(k) in ref for k in res), f"{tier}: case set differs from avx2"
+            tol = SCALAR_TOL if tier == "scalar" else INT8_TOL
+            worst, exact = 0.0, 0
+            for key, out in res.items():
+                assert torch.isfinite(out).all(), f"{tier} {key}: non-finite output"
+                r = ref[native(key)]
+                rel = ((out - r).norm() / (r.norm() + 1e-12)).item()
+                worst = max(worst, rel)
+                exact += torch.equal(out, r)
+                assert rel <= tol, f"tier {tier} vs avx2 differs on (K, gated, swizzled, tokens, threads) = {key}: rel {rel:.3e} > {tol}"
+            nswz = sum(1 for k in res if k[2])
+            print(f" -- {tier:6}: {len(res)} cases ({nswz} swizzled), worst rel {worst:.2e} vs avx2, {exact} bit-exact")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--worker":
+        _worker(sys.argv[2], sys.argv[3])
+    else:
+        test_cpu_moe_tiers_agree(); print("PASS")


### PR DESCRIPTION
### Why

`cpu/moe_mul1.cpp` dispatches on `scalar / avx2 / avx512-vnni / avx512-vbmi`, and the 512-bit paths require VNNI. Skylake-SP/X class CPUs (1st-gen Xeon Scalable, Xeon W-21xx/31xx, Core-X) have AVX-512F/BW/VL but no VNNI, so they ran the 256-bit AVX2 tier. The only VNNI dependency in the 512-bit kernel is the accumulate (`vpdpbusd`); the extraction is pure AVX-512F, and the AVX2 tier already has the VNNI-free, bit-exact substitute.

### Commits

1. **`Isa::Bw` tier.** The VNNI kernel's dword extraction and band structure with the AVX2 tier's `vpmaddubsw`/`vpmaddwd` accumulate. Separate functions because a function carries one target attribute and compiling this accumulate under the VNNI target would permit contracting it into `vpdpwssd`. Exposes `exl3_moe_cpu_has_avx512_bw()`, accepts `EXL3_MOE_CPU_MAX_ISA=bw`, enables the swizzled layout for the tier, updates `doc/env_vars.md`.
2. **Even flat tile partition in the few-GEMV regime** (all tiers). Whole-GEMV assignment left a 2:1 worker imbalance whenever `2 × cold experts` wasn't a multiple of the worker count (16 GEMVs on 20 workers: twelve single-worker GEMVs set the phase time). For ≤ 4×workers GEMVs the phase's tiles are one flat range split evenly in 8-tile groups; above that the strided whole-GEMV scheme stays so L3 keeps serving repeated expert chunks during prefill. `gemv_assignment`/`tile_split` fold into `assign_gemvs`.
3. **Per-lane variable-shift funnel merge** in `dword_codes` (BW and VNNI tiers): 8 → 4 uops per k-row per tile, and GCC fuses the trailing or+and into `vpternlogd`. Bit-identical codes.
4. **Force-inline the BW row chain.** GCC outlined it behind a call per tile step, and with all zmm registers caller-saved that reloaded every live constant.
5. **`tests/test_moe_cpu_tiers_.py`.** Every tier the CPU supports, one subprocess each via `EXL3_MOE_CPU_MAX_ISA`, checked against the AVX2 tier (int8 tiers to float rounding, scalar fp32 reference to ~1%) over K1–8, gated/gateless, 1–4 rows per chunk, the strided regime, and the swizzled layout on the tiers that consume it. **On a VBMI machine this runs vbmi, vnni, bw, avx2 and scalar in one go**, which is how the BW tier can be validated without the hardware.

### Numbers

Xeon Gold 6148 (20C, AVX-512F/BW/DQ/VL, no VNNI), GCC 13, cold experts streamed from DRAM, 20 threads, median GB/s of trellis bytes, single-token decode, 8 cold experts per layer:

| shape | avx2 (before) | 1: bw | 2: +partition | 3: +varshift | 4: +inline |
|---|---|---|---|---|---|
| 4096×2048 K3 | 15.6 | 24.0 | 30.6 | 38.3 | 41.4 |
| 4096×2048 K4 | 21.1 | 35.4 | 39.2 | 51.8 | 57.0 |
| 2560×640 K4 | 17–25 | 37.6 | ≈ | 44.5 | 46.3 |

Partition by cold experts per layer (K3): 5 neutral, 6 +40%, 7 +33%, 8 +17%; 10 (already even) neutral. Batched rows (4 per expert): 11.6 → 20.0. 10 → 20 threads still scales 1.73×, so the kernel remains compute-bound here.

End to end (TabbyAPI): GLM-5.3-Flash 3.05bpw, 232/288 experts per layer on CPU: **4.3–4.9 → 11.7 T/s** (8k-token generation). Qwen3.8-Flash-Next 4.05bpw, 340/512 on CPU: **24.6 → 31.8 T/s** after commits.

### Correctness

Strict-FP builds (`-O3 -fno-fast-math -ffp-contract=off`): bw ≡ avx2 bit-for-bit over 640 cases (K1–8, 1–5 tokens, gated/gateless, 1 and 20 threads, partial bands, swizzled layout) plus 256 many-chunk cases for the strided regime; avx2 and scalar tiers unchanged bit-for-bit through all four commits. Under `-Ofast` tiers differ only by epilogue reassociation (≤ 1e-4 rel). Disassembly: no VNNI/VBMI instructions in `bw_*`.

### Caveats

- Not runtime-tested on VNNI/VBMI hardware. Commit 1's change there is attribute-only (helpers still inline, verified in the disassembly). Commit 3 changes VNNI-tier codegen (`vpsrlvd/vpsllvd` for immediate shifts + blend); expected neutral-to-positive (single-uop, latency-1 on Skylake-SP through Sapphire Rapids and Zen 4/5), a Cascade Lake A/B would settle it. The VBMI tier only meets this code on its K8 route.
- Swizzled layout for the BW tier rests on one machine's measurements (+2–29%); `EXL3_MOE_CPU_SWIZZLE=0` opts out.
- The Windows branch of `detect_isa()` and `M1_ALWAYS_INLINE` (`__forceinline`) are compile-untested here, like the file's existing Windows-specific code.

### Disclaimer

Implementation code fully written with AI-assistance but was manually tested and validated on my setup. The CPU-offloaded gains are instantly noticeable but remain untested on other CPU platforms. For now, I'll mark this PR as draft until maintainers chip in and deem this ready,

IF bits and pieces of this are to be taken with the decision to write a clean PR from scratch, that's understandable and you have my full approval. Feel free to!