### PR TITLE
Quantizer: CPU fallback when CUDA Cholesky or inverse fail with 'Invalid argument'

### DIFF
--- a/exllamav3/modules/quant/exl3_lib/quantize.py
+++ b/exllamav3/modules/quant/exl3_lib/quantize.py
@@ -424,7 +424,7 @@ def block_ldl(H: torch.Tensor, b: int, quant_args: dict, verbose: bool, debug_in
     # Cholesky factorization: H = L @ L.T
     # Try on GPU first
     num_cholesky_retries = 0
-    retry_cpu = False
+    cpu_fallback = None
     while True:
         try:
             L = torch.linalg.cholesky(H)
@@ -449,16 +449,21 @@ def block_ldl(H: torch.Tensor, b: int, quant_args: dict, verbose: bool, debug_in
             H.diagonal().add_(2.0 * quant_args.get("sigma_reg", 0.025) * H.diagonal().mean())
             continue
 
-        # Fall back on CPU factorization
+        # Fall back on CPU factorization if the GPU is out of memory, or if the CUDA solver rejects the call
+        # outright: cuSOLVER returns "Invalid argument" for every Cholesky on some torch/CUDA builds (seen with
+        # torch 2.10+cu128), including well-conditioned SPD matrices
         except Exception as e:
             if e.__class__.__name__ == "OutOfMemoryError" or "CUDA out of memory" in str(e) or "HIP out of memory" in str(e):
-                retry_cpu = True
+                cpu_fallback = "out of memory"
+                break
+            elif "Invalid argument" in str(e):
+                cpu_fallback = "invalid argument"
                 break
             else:
                 raise e
 
-    if retry_cpu:
-        print(f" !! Out of memory on {str(H.device)}, trying CPU fallback")
+    if cpu_fallback:
+        print(f" !! Cholesky decomp. failed on {str(H.device)} ({cpu_fallback}), trying CPU fallback")
         free_mem()
         H_cpu = H.cpu()
         L_cpu = torch.linalg.cholesky(H_cpu)
@@ -474,8 +479,14 @@ def block_ldl(H: torch.Tensor, b: int, quant_args: dict, verbose: bool, debug_in
     # Compute D as D[i] = DL[i] @ DL[i].T for each diagonal block i (don't actually end up needing this)
     # D = DL @ DL.transpose(1, 2)
 
-    # Invert each diagonal block
-    DL = torch.linalg.inv(DL)
+    # Invert each diagonal block, with the same CPU fallback if the CUDA solver rejects the call
+    try:
+        DL = torch.linalg.inv(DL)
+    except RuntimeError as e:
+        if "Invalid argument" not in str(e):
+            raise e
+        print(f" !! Block inverse failed on {str(DL.device)} (invalid argument), trying CPU fallback")
+        DL = torch.linalg.inv(DL.cpu()).to(DL.device)
 
     # Multiply each block's column with its inverse
     L = L.view(n, m, b)


### PR DESCRIPTION
## Motivation

With torch 2.10.0+cu128 (the build the 1.4.7 cu128 wheel targets), `torch.linalg.cholesky` on a CUDA tensor
raises `RuntimeError: Invalid argument` for fp32 inputs larger than 4096 x 4096 (5120 x 5120 and 17408 x 17408 in this
conversion; sizes up to 4096 work, and torch 2.11.0+cu128, 2.13.0+cu130 and 2.14.0+cu130 do not fail at all — see the comment below), so it is
not a conditioning problem and the `_LinAlgError` damping retries never see it; selecting MAGMA through
`torch.backends.cuda.preferred_linalg_library("magma")` segfaults; `torch.linalg.inv` works. `block_ldl`
only falls back to the CPU on out-of-memory, so every conversion aborted at the first Hessian with
"Quantization worker failed". With the fallback, a full conversion of a 27B model completed (64 layers,
~3.1 h on an 80 W RTX 4080 Laptop, 148-262 s per layer), and two later conversions ran on the same box,
where the converter cannot complete without it. CPU factorization costs 0.1 s for 5120^2 and 2.2 s for
17408^2 on 24 threads, under 2% of a layer.
(Evidence: the author's lab notes, see the footer.)

## Change

- In `block_ldl`'s generic `except`, a `RuntimeError` whose message contains "Invalid argument" is handled
  like the out-of-memory case: break out to the existing CPU factorization path. The existing one-line
  message now names the reason: `!! Cholesky decomp. failed on cuda:0 (invalid argument), trying CPU fallback`.
- The batched diagonal-block inverse (`torch.linalg.inv(DL)`) gets the same fallback (CPU inverse, result
  moved back to the GPU) with a one-line message. Any other `RuntimeError` still propagates.
- Same logic as the lab patch; comments rewritten for upstream; `retry_cpu` renamed `cpu_fallback` (holds
  the reason string).

## Testing

On the author's machine: the equivalent lab patch ran the conversions above (the Cholesky branch fires on every Hessian on
this machine). This cleaned version was checked without a GPU: the patch applies to the pristine file;
`py_compile`; a CPU unit test extracts `block_ldl` from the patched and pristine files and monkeypatches
`torch.linalg.cholesky` / `torch.linalg.inv` to raise `RuntimeError("Invalid argument")` on the first call.
The patched function returns the same L as the pristine one does on a working solver, prints the fallback
line, and re-raises other RuntimeErrors; the pristine function aborts. Owner re-test: one conversion (or
the layer-limited dry run) on the cu128 wheel with this file; confirm the message appears once per tensor
and the output matches the lab-patched copy.

## Risks and compatibility

- Matching on the error text ("Invalid argument", as observed, case-sensitive) is the style upstream
  already uses for "CUDA out of memory". A sticky CUDA error state would fail on the next kernel anyway.
- On a healthy solver nothing changes. Where the solver is broken the fallback is quiet apart from one
  line per Hessian, which may hide the problem from users who would rather fix their torch build.
- The inverse fallback was not exercised by the lab conversions (the notes record `torch.linalg.inv` as
  working on this build); it is covered by the CPU unit test only.
- The root cause is in the torch/cuSOLVER build, not exllamav3; worth a PyTorch issue with the 5120^2
  reproducer.

---
Measurements and the pre-registered experiment log are in the author's lab notes (private for now; the relevant tables are reproduced above, and the full write-up is available on request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWY9bG6iQAswvYgYFch6ex
