### PR TITLE
Add the p2b cooperative fused-MoE kernel from vllm-exl3 (opt-in via EXL3_P2B_MOE)

### DIFF
--- a/exllamav3/exllamav3_ext/bindings.cpp
+++ b/exllamav3/exllamav3_ext/bindings.cpp
@@ -31,6 +31,8 @@
 #include "quant/exl3_devctx.cuh"
 #include "quant/exl3_moe.cuh"
 
+#include "quant/p2b_moe.cuh"
+
 #include "generator/strings.h"
 #include "generator/sampling_basic.cuh"
 #include "generator/sampling_extra.cuh"
@@ -144,6 +146,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("reconstruct_had_slice", &reconstruct_had_slice, "reconstruct_had_slice");
     m.def("reconstruct_slice", &reconstruct_slice, "reconstruct_slice");
     m.def("had_r_128", &had_r_128, "had_r_128");
+    m.def("p2b_fused_moe", &p2b_fused_moe_cuda, "p2b_fused_moe",
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p2b_map_slots", &p2b_map_slots, "p2b_map_slots",
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p2b_stage_debug", &p2b_stage_debug_cuda,
+          "p2b_stage_debug: run the p2b MoE kernel to phase N and return the staged "
+          "intermediates (diagnostic; not used at inference)",
+          py::call_guard<py::gil_scoped_release>());
     m.def("exl3_gemm", &exl3_gemm, "exl3_gemm");
     m.def("exl3_gemv", &exl3_gemv, "exl3_gemv");
     m.def("exl3_gemm_num_kernel_shapes", &exl3_gemm_num_kernel_shapes, "exl3_gemm_num_kernel_shapes");

--- a/exllamav3/exllamav3_ext/quant/p2b_moe.cu
+++ b/exllamav3/exllamav3_ext/quant/p2b_moe.cu
@@ -1,0 +1,576 @@
+// Port of vcruz305/vllm-exl3 csrc/p2b_moe.cu (MIT, Copyright Mia AI Lab / vcruz305, see
+// THIRD_PARTY notices in that repository) to the exllamav3 tree, extended from one input row
+// per launch to a full row-expert slot table so a whole verify window (bsz * top_k slots)
+// runs as ONE cooperative launch instead of one per row.
+//
+// Four grid-synchronized phases over all active expert slots: input Hadamard, batched
+// gate/up GEMV (exl3_gemv_kernel.cuh MMA path), SwiGLU + down-input Hadamard, batched down
+// GEMV, then output Hadamard and weighted atomic accumulation. Grid size is occupancy-derived;
+// every phase grid-strides over its work items.
+//
+// Dimensions are runtime parameters (the reference build hardcoded hidden 4096 / inter 2048);
+// hidden and inter must be multiples of 128 (Hadamard warp tiling). MCG codebook only, K in
+// {2, 3, 4} and uniform across gate/up/down, matching MultiLinear pointer tables.
+
+#include <cuda_fp16.h>
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cooperative_groups.h>
+
+#include "../util.h"
+#include "../util.cuh"
+#include "exl3_gemv_kernel.cuh"
+#include "hadamard_inner.cuh"
+
+#include "p2b_moe.cuh"
+
+namespace cg = cooperative_groups;
+
+template <int bits, int cb, int CFG>
+__device__ __forceinline__ void run_gemv_tile(
+    const uint32_t* __restrict__ B32,
+    const half2* __restrict__ A2,
+    half* __restrict__ C,
+    int kslices,
+    int size_k,
+    int group,
+    int ntiles,
+    int warp,
+    int lane,
+    float (*sh_red)[1][32])
+{
+    // Verbatim extraction of exllamav3's exl3_gemv_kernel group-loop body (MMODE = 0,
+    // SMEM_STAGE = false), the production-validated m=1 decode GEMV. The reference port's
+    // tile was textually close but numerically wrong against this tree's kernel.
+    constexpr int WK = CFG == 0 ? 16 : 8;
+    constexpr int WNT = CFG == 0 ? 2 : 4;
+    constexpr int PF = CFG == 0 ? 4 : 2;
+    constexpr int FOLD = CFG == 0 ? 4 : 2;
+    constexpr int THREADS = WK * 32;
+    constexpr int COLS = WNT * 16;
+    constexpr int TWORDS = 8 * bits;
+    constexpr int LOADS = bits == 2 ? WNT / 2 : WNT;
+    constexpr int LSTRIDE = bits == 3 ? 24 : 32;
+
+    const int chunk = CEIL_DIVIDE(kslices, WK);
+    const int ks0 = warp * chunk;
+    const int myn = max(0, min(chunk, kslices - ks0));
+    const size_t slice_stride = (size_t) ntiles * TWORDS;
+
+    const bool r0_ok = lane < 4;
+    const half2 hzero = __half2half2(__ushort_as_half(0));
+
+    int x_src_a = 0, x_src_b = 0, x_s2 = 0;
+    if constexpr (bits == 2) {
+        int i1 = lane >> 1;
+        x_src_b = i1;
+        x_src_a = (i1 + 15) & 15;
+    } else if constexpr (bits == 3) {
+        int t_offset = lane << 3;
+        int b1 = (t_offset + 257) * 3;
+        int b2 = b1 + 21;
+        int i0 = (b1 - 16) / 32;
+        int i2 = (b2 - 1) / 32;
+        x_s2 = (i2 + 1) * 32 - b2;
+        x_src_a = i0 % 24;
+        x_src_b = i2 % 24;
+    }
+
+    const uint32_t* bp = B32 + (size_t) ks0 * slice_stride + group * WNT * TWORDS + lane;
+
+    auto ld_b = [&] (int i, int l) -> uint32_t {
+        if constexpr (bits == 3)
+            return lane < 24 ? __ldcs(bp + (size_t) i * slice_stride + l * LSTRIDE) : 0;
+        else
+            return __ldcs(bp + (size_t) i * slice_stride + l * LSTRIDE);
+    };
+
+    uint32_t pf[PF][LOADS];
+    #pragma unroll
+    for (int d = 0; d < PF; ++d)
+        if (d < myn)
+            #pragma unroll
+            for (int l = 0; l < LOADS; ++l)
+                pf[d][l] = ld_b(d, l);
+
+    FragC_h ch[WNT][2] = {};
+    float2 acc0[WNT][2] = {};
+
+    for (int ib = 0; ib < myn; ib += PF) {
+        #pragma unroll
+        for (int d = 0; d < PF; ++d) {
+            const int i = ib + d;
+            if (i >= myn) break;
+
+            uint32_t bw[LOADS];
+            #pragma unroll
+            for (int l = 0; l < LOADS; ++l)
+                bw[l] = pf[d][l];
+
+            if (i + PF < myn) {
+                #pragma unroll
+                for (int l = 0; l < LOADS; ++l)
+                    pf[d][l] = ld_b(i + PF, l);
+            }
+
+            const size_t a_col = (size_t) (ks0 + i) * 8 + (lane & 3);
+            FragB a01, a23;
+            a01[0] = r0_ok ? A2[a_col] : hzero;
+            a23[0] = r0_ok ? A2[a_col + 4] : hzero;
+            a01[1] = hzero;
+            a23[1] = hzero;
+
+            #pragma unroll
+            for (int t = 0; t < WNT; ++t) {
+                FragB f0, f1;
+                if constexpr (bits == 4) {
+                    uint32_t aw = __shfl_sync(0xffffffffu, bw[t], (lane + 31) & 31);
+                    exl3_gemv_ns::dq8_regs_4bits<cb>(aw, bw[t], f0, f1);
+                } else if constexpr (bits == 2) {
+                    const uint32_t w = bw[t >> 1];
+                    const int base = (t & 1) << 4;
+                    uint32_t bwv = __shfl_sync(0xffffffffu, w, base + x_src_b);
+                    uint32_t awv = __shfl_sync(0xffffffffu, w, base + x_src_a);
+                    exl3_gemv_ns::dq8_regs_2bits<cb>(awv, bwv, lane << 3, f0, f1);
+                } else {
+                    uint32_t awv = __shfl_sync(0xffffffffu, bw[t], x_src_a);
+                    uint32_t bwv = __shfl_sync(0xffffffffu, bw[t], x_src_b);
+                    exl3_gemv_ns::dq8_regs_3bits<cb>(awv, bwv, x_s2, f0, f1);
+                }
+
+                exl3_gemv_ns::mma_ab_h(a01, a23, f0, ch[t][0]);
+                exl3_gemv_ns::mma_ab_h(a01, a23, f1, ch[t][1]);
+            }
+
+            if ((d + 1) % FOLD == 0 || i + 1 == myn) {
+                #pragma unroll
+                for (int t = 0; t < WNT; ++t)
+                    #pragma unroll
+                    for (int f = 0; f < 2; ++f) {
+                        acc0[t][f].x += __low2float(ch[t][f][0]);
+                        acc0[t][f].y += __high2float(ch[t][f][0]);
+                        ch[t][f][0] = hzero;
+                    }
+            }
+        }
+    }
+
+    // Cross-warp reduction over the k splits: lane l holds row l/4, cols
+    // tile*16 + frag*8 + 2*(l%4) (+1) -- exactly the production kernel's mapping
+    {
+        const int c0 = 2 * (lane & 3);
+        if (lane < 4)
+        {
+            #pragma unroll
+            for (int t = 0; t < WNT; ++t)
+                #pragma unroll
+                for (int f = 0; f < 2; ++f)
+                {
+                    const int col = t * 16 + f * 8 + c0;
+                    sh_red[warp][0][col + 0] = acc0[t][f].x;
+                    sh_red[warp][0][col + 1] = acc0[t][f].y;
+                }
+        }
+    }
+    __syncthreads();
+
+    for (int idx = threadIdx.x; idx < COLS; idx += THREADS) {
+        float sum = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < WK; ++j)
+            sum += sh_red[j][0][idx];
+        const int col = group * COLS + idx;
+        C[col] = __float2half_rn(sum);
+    }
+    __syncthreads();
+}
+
+template <int BITS, int CB>
+__global__ __launch_bounds__(512)
+void p2b_moe_batched_kernel(
+    const half* __restrict__ x,          // (m, hidden)
+    const int64_t* __restrict__ gt_ptrs, // per-expert pointer tables
+    const int64_t* __restrict__ gu_ptrs,
+    const int64_t* __restrict__ gv_ptrs,
+    const int64_t* __restrict__ ut_ptrs,
+    const int64_t* __restrict__ uu_ptrs,
+    const int64_t* __restrict__ uv_ptrs,
+    const int64_t* __restrict__ dt_ptrs,
+    const int64_t* __restrict__ du_ptrs,
+    const int64_t* __restrict__ dv_ptrs,
+    const int32_t* __restrict__ ids,     // (slots,) local expert id per slot
+    const int32_t* __restrict__ rows,    // (slots,) row index per slot
+    const half* __restrict__ rw,         // (slots,) routing weight per slot
+    half* __restrict__ gate,             // (slots, inter)
+    half* __restrict__ up,               // (slots, inter)
+    half* __restrict__ down,             // (slots, hidden)
+    float* __restrict__ out,             // (m, hidden), fp32: the accumulator is returned as is
+    half* __restrict__ had_gate,         // (slots, hidden)
+    half* __restrict__ had_up,           // (slots, hidden)
+    half* __restrict__ had_down,         // (slots, inter)
+    float* __restrict__ accum,           // (m, hidden)
+    int slots,
+    int m,
+    int hidden,
+    int inter,
+    // Diagnostic: run only the first N of the four grid-synchronised phases and return the
+    // intermediates, so a parity failure can be bisected to a phase instead of a tile. 4 (the
+    // default at every production call site) runs the whole kernel; reachable from Python only
+    // through p2b_stage_debug. Finding the codebook dispatch fault took this.
+    int stop_after)
+{
+    auto grid = cg::this_grid();
+    const int warp = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total_threads = gridDim.x * blockDim.x;
+
+    const int ntiles_gate = inter / 16;
+    const int kslices_gate = hidden / 16;
+    const int num_groups_gate = inter / 32;
+
+    const int ntiles_down = hidden / 16;
+    const int kslices_down = inter / 16;
+    const int num_groups_down = hidden / 32;
+
+    __shared__ float sh_red[16][1][32];
+
+    // Zero accum
+    for (int j = tid; j < m * hidden; j += total_threads)
+        accum[j] = 0.0f;
+
+    // Phase 1: Input Hadamard for Gate and Up across all slots
+    {
+        int warps_per_exp = hidden / 128;
+        int total_warps = slots * warps_per_exp;
+        int this_warp = warp + (blockDim.x / 32) * blockIdx.x;
+        int grid_warps = gridDim.x * (blockDim.x / 32);
+
+        for (; this_warp < total_warps; this_warp += grid_warps) {
+            int s = this_warp / warps_per_exp;
+            int w = this_warp % warps_per_exp;
+            if (__half2float(rw[s]) == 0.0f) continue;
+            int src = ids[s];
+            int row = rows[s];
+            const half* gu_e = reinterpret_cast<const half*>(gu_ptrs[src]);
+            const half* uu_e = reinterpret_cast<const half*>(uu_ptrs[src]);
+            half* hg_e = had_gate + (size_t) s * hidden;
+            half* hu_e = had_up + (size_t) s * hidden;
+
+            had_hf_r_128_inner<true, false>(x + (size_t) row * hidden + w * 128, hg_e + w * 128, gu_e + (w * 128) % hidden, 0.088388347648f);
+            had_hf_r_128_inner<true, false>(x + (size_t) row * hidden + w * 128, hu_e + w * 128, uu_e + (w * 128) % hidden, 0.088388347648f);
+        }
+        grid.sync();
+    }
+
+    // Phase 2: Batched Gate & Up GEMV across all slots
+    if (stop_after >= 2)
+    {
+        int total_work = 2 * slots * num_groups_gate;
+        for (int item = blockIdx.x; item < total_work; item += gridDim.x) {
+            int is_up = item & 1;
+            int rem = item >> 1;
+            int s = rem / num_groups_gate;
+            int group = rem % num_groups_gate;
+            if (__half2float(rw[s]) == 0.0f) continue;
+            int src = ids[s];
+
+            const uint32_t* B32 = reinterpret_cast<const uint32_t*>(is_up ? ut_ptrs[src] : gt_ptrs[src]);
+            const half2* A2 = reinterpret_cast<const half2*>((is_up ? had_up : had_gate) + (size_t) s * hidden);
+            half* C = (is_up ? up : gate) + (size_t) s * inter;
+
+            run_gemv_tile<BITS, CB, 0>(B32, A2, C, kslices_gate, hidden, group, ntiles_gate, warp, lane, sh_red);
+        }
+        grid.sync();
+    }
+
+    // Epilogue Hadamard on Gate and Up
+    if (stop_after >= 2)
+    {
+        int warps_per_exp = inter / 128;
+        int total_warps = slots * warps_per_exp;
+        int this_warp = warp + (blockDim.x / 32) * blockIdx.x;
+        int grid_warps = gridDim.x * (blockDim.x / 32);
+
+        for (; this_warp < total_warps; this_warp += grid_warps) {
+            int s = this_warp / warps_per_exp;
+            int w = this_warp % warps_per_exp;
+            if (__half2float(rw[s]) == 0.0f) continue;
+            int src = ids[s];
+            const half* gv_e = reinterpret_cast<const half*>(gv_ptrs[src]);
+            const half* uv_e = reinterpret_cast<const half*>(uv_ptrs[src]);
+            half* gp_e = gate + (size_t) s * inter;
+            half* up_e = up + (size_t) s * inter;
+
+            had_hf_r_128_inner<false, true>(gp_e + w * 128, gp_e + w * 128, gv_e + (w * 128) % inter, 0.088388347648f);
+            had_hf_r_128_inner<false, true>(up_e + w * 128, up_e + w * 128, uv_e + (w * 128) % inter, 0.088388347648f);
+        }
+        grid.sync();
+    }
+
+    // Phase 3: SwiGLU activation + Down input Hadamard across all slots
+    {
+        int total_elements = slots * inter;
+        for (int j = tid; j < total_elements; j += total_threads) {
+            if (__half2float(rw[j / inter]) == 0.0f) continue;
+            float g = __half2float(gate[j]);
+            float u = __half2float(up[j]);
+            float s = g / (1.0f + expf(-g));
+            had_down[j] = __float2half(s * u);
+        }
+        grid.sync();
+
+        int warps_per_exp = inter / 128;
+        int total_warps = slots * warps_per_exp;
+        int this_warp = warp + (blockDim.x / 32) * blockIdx.x;
+        int grid_warps = gridDim.x * (blockDim.x / 32);
+
+        for (; this_warp < total_warps; this_warp += grid_warps) {
+            int s = this_warp / warps_per_exp;
+            int w = this_warp % warps_per_exp;
+            if (__half2float(rw[s]) == 0.0f) continue;
+            int src = ids[s];
+            const half* du_e = reinterpret_cast<const half*>(du_ptrs[src]);
+            half* hd_e = had_down + (size_t) s * inter;
+
+            had_hf_r_128_inner<true, false>(hd_e + w * 128, hd_e + w * 128, du_e + (w * 128) % inter, 0.088388347648f);
+        }
+        grid.sync();
+    }
+
+    // Phase 4: Batched Down GEMV across all slots
+    if (stop_after >= 4)
+    {
+        int total_work = slots * num_groups_down;
+        for (int item = blockIdx.x; item < total_work; item += gridDim.x) {
+            int s = item / num_groups_down;
+            int group = item % num_groups_down;
+            if (__half2float(rw[s]) == 0.0f) continue;
+            int src = ids[s];
+
+            const uint32_t* B32 = reinterpret_cast<const uint32_t*>(dt_ptrs[src]);
+            const half2* A2 = reinterpret_cast<const half2*>(had_down + (size_t) s * inter);
+            half* C = down + (size_t) s * hidden;
+
+            run_gemv_tile<BITS, CB, 0>(B32, A2, C, kslices_down, inter, group, ntiles_down, warp, lane, sh_red);
+        }
+        grid.sync();
+    }
+
+    // Down output Hadamard and atomic accumulation into accum
+    if (stop_after >= 4)
+    {
+        int warps_per_exp = hidden / 128;
+        int total_warps = slots * warps_per_exp;
+        int this_warp = warp + (blockDim.x / 32) * blockIdx.x;
+        int grid_warps = gridDim.x * (blockDim.x / 32);
+
+        for (; this_warp < total_warps; this_warp += grid_warps) {
+            int s = this_warp / warps_per_exp;
+            int w = this_warp % warps_per_exp;
+            if (__half2float(rw[s]) == 0.0f) continue;
+            int src = ids[s];
+            const half* dv_e = reinterpret_cast<const half*>(dv_ptrs[src]);
+            half* dp_e = down + (size_t) s * hidden;
+
+            had_hf_r_128_inner<false, true>(dp_e + w * 128, dp_e + w * 128, dv_e + (w * 128) % hidden, 0.088388347648f);
+        }
+        grid.sync();
+
+        // Weighted reduction into accum
+        int total_elements = slots * hidden;
+        for (int j = tid; j < total_elements; j += total_threads) {
+            int s = j / hidden;
+            int col = j % hidden;
+            float w = __half2float(rw[s]);
+            if (w != 0.0f)
+                atomicAdd(accum + (size_t) rows[s] * hidden + col, w * __half2float(down[j]));
+        }
+        grid.sync();
+    }
+
+    // Write back to out (fp32; the accumulator is returned directly)
+    if (stop_after >= 4)
+    for (int j = tid; j < m * hidden; j += total_threads) {
+        out[j] = accum[j];
+    }
+}
+
+template <int BITS, int CB>
+static void launch_moe_batched(
+    const at::Tensor& x, const at::Tensor& gt, const at::Tensor& gu,
+    const at::Tensor& gv, const at::Tensor& ut, const at::Tensor& uu,
+    const at::Tensor& uv, const at::Tensor& dt, const at::Tensor& du,
+    const at::Tensor& dv, const at::Tensor& ids, const at::Tensor& rows,
+    const at::Tensor& rw, at::Tensor& out, at::Tensor& gate, at::Tensor& up,
+    at::Tensor& down, at::Tensor& had_gate, at::Tensor& had_up,
+    at::Tensor& had_down, at::Tensor& accum,
+    int slots, int m, int hidden, int inter, int stop_after = 4)
+{
+    int dev = 0, sms = 0, resident = 0;
+    cudaGetDevice(&dev);
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
+    void* kernel = (void*) p2b_moe_batched_kernel<BITS, CB>;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&resident, kernel, 512, 0);
+    const int grid = std::max(1, resident * sms);
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    const half* xp = reinterpret_cast<const half*>(x.data_ptr<c10::Half>());
+    const int64_t* gtp = gt.data_ptr<int64_t>();
+    const int64_t* gup = gu.data_ptr<int64_t>();
+    const int64_t* gvp = gv.data_ptr<int64_t>();
+    const int64_t* utp = ut.data_ptr<int64_t>();
+    const int64_t* uup = uu.data_ptr<int64_t>();
+    const int64_t* uvp = uv.data_ptr<int64_t>();
+    const int64_t* dtp = dt.data_ptr<int64_t>();
+    const int64_t* dup = du.data_ptr<int64_t>();
+    const int64_t* dvp = dv.data_ptr<int64_t>();
+    const int32_t* idp = ids.data_ptr<int32_t>();
+    const int32_t* rowp = rows.data_ptr<int32_t>();
+    const half* rwp = reinterpret_cast<const half*>(rw.data_ptr<c10::Half>());
+
+    half* gp = reinterpret_cast<half*>(gate.data_ptr<c10::Half>());
+    half* up_p = reinterpret_cast<half*>(up.data_ptr<c10::Half>());
+    half* dp = reinterpret_cast<half*>(down.data_ptr<c10::Half>());
+    float* op = out.data_ptr<float>();  // fp32 accumulator returned directly
+    half* hg_p = reinterpret_cast<half*>(had_gate.data_ptr<c10::Half>());
+    half* hu_p = reinterpret_cast<half*>(had_up.data_ptr<c10::Half>());
+    half* hd_p = reinterpret_cast<half*>(had_down.data_ptr<c10::Half>());
+    float* accp = accum.data_ptr<float>();
+
+    int e = slots;
+    void* args[] = {
+        (void*)&xp, (void*)&gtp, (void*)&gup, (void*)&gvp,
+        (void*)&utp, (void*)&uup, (void*)&uvp,
+        (void*)&dtp, (void*)&dup, (void*)&dvp,
+        (void*)&idp, (void*)&rowp, (void*)&rwp,
+        (void*)&gp, (void*)&up_p, (void*)&dp, (void*)&op,
+        (void*)&hg_p, (void*)&hu_p, (void*)&hd_p, (void*)&accp,
+        (void*)&e, (void*)&m, (void*)&hidden, (void*)&inter, (void*)&stop_after
+    };
+
+    cuda_check(cudaLaunchCooperativeKernel(kernel, dim3(grid), dim3(512), args, 0, stream));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+at::Tensor p2b_fused_moe_cuda(const at::Tensor& x, at::Tensor& out,
+    const at::Tensor& gt, const at::Tensor& gu, const at::Tensor& gv,
+    const at::Tensor& ut, const at::Tensor& uu, const at::Tensor& uv,
+    const at::Tensor& dt, const at::Tensor& du, const at::Tensor& dv,
+    const at::Tensor& ids, const at::Tensor& rows, const at::Tensor& rw,
+    int64_t kg, int64_t ku, int64_t kd, bool mcg, bool mul1,
+    int64_t hidden, int64_t inter,
+    at::Tensor& gate, at::Tensor& up, at::Tensor& down,
+    at::Tensor& had_gate, at::Tensor& had_up, at::Tensor& had_down,
+    at::Tensor& accum)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == at::kHalf, "p2b fused MoE requires CUDA fp16 input");
+    TORCH_CHECK(out.is_cuda(), "p2b fused MoE output must be CUDA");  // dtype checked fp32 below
+    TORCH_CHECK(kg == ku && ku == kd && (kg == 2 || kg == 3 || kg == 4), "unsupported fused MoE K");
+    TORCH_CHECK(!(mcg && mul1), "specified both mcg and mul1");
+    // Codebook select, mirroring exl3_gemv.cu: 0 = default (neither flag), 1 = MCG, 2 = mul1
+    const int cb = mcg ? 1 : (mul1 ? 2 : 0);
+    TORCH_CHECK(hidden % 128 == 0 && inter % 128 == 0, "p2b fused MoE requires hidden/inter divisible by 128");
+    const int slots = static_cast<int>(ids.numel());
+    const int m = static_cast<int>(x.numel() / x.size(-1));
+
+    TORCH_CHECK(out.scalar_type() == at::kFloat, "p2b out must be fp32");
+    TORCH_CHECK(gate.size(0) >= slots && up.size(0) >= slots && down.size(0) >= slots &&
+                had_gate.size(0) >= slots && had_up.size(0) >= slots && had_down.size(0) >= slots,
+                "p2b scratch too small for slot count");
+    TORCH_CHECK(accum.size(0) >= m && accum.size(1) >= hidden, "p2b accum too small");
+
+    #define P2B_DISPATCH(BITS, CB) launch_moe_batched<BITS, CB>(x, gt, gu, gv, ut, uu, uv, dt, du, dv, ids, rows, rw, out, gate, up, down, had_gate, had_up, had_down, accum, slots, m, hidden, inter)
+    #define P2B_SWITCH_CB(BITS) \
+        switch (cb) { case 0: P2B_DISPATCH(BITS, 0); break; \
+                      case 1: P2B_DISPATCH(BITS, 1); break; \
+                      case 2: P2B_DISPATCH(BITS, 2); break; }
+    if (kg == 4) P2B_SWITCH_CB(4)
+    else if (kg == 3) P2B_SWITCH_CB(3)
+    else if (kg == 2) P2B_SWITCH_CB(2)
+    #undef P2B_SWITCH_CB
+    #undef P2B_DISPATCH
+
+    return out;
+}
+
+std::vector<at::Tensor> p2b_stage_debug_cuda(const at::Tensor& x,
+    const at::Tensor& gt, const at::Tensor& gu, const at::Tensor& gv,
+    const at::Tensor& ut, const at::Tensor& uu, const at::Tensor& uv,
+    const at::Tensor& dt, const at::Tensor& du, const at::Tensor& dv,
+    const at::Tensor& ids, const at::Tensor& rows, const at::Tensor& rw,
+    int64_t kg, int64_t ku, int64_t kd, bool mcg, bool mul1,
+    int64_t hidden, int64_t inter, int64_t stop_after)
+{
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == at::kHalf, "p2b debug requires CUDA fp16 input");
+    TORCH_CHECK(kg == ku && ku == kd && (kg == 2 || kg == 3 || kg == 4), "unsupported fused MoE K");
+    TORCH_CHECK(hidden % 128 == 0 && inter % 128 == 0, "p2b requires hidden/inter divisible by 128");
+    const int slots = static_cast<int>(ids.numel());
+    const int m = static_cast<int>(x.numel() / x.size(-1));
+
+    auto gate = at::empty({slots, inter}, x.options());
+    auto up = at::empty({slots, inter}, x.options());
+    auto down = at::empty({slots, hidden}, x.options());
+    auto had_gate = at::empty({slots, hidden}, x.options());
+    auto had_up = at::empty({slots, hidden}, x.options());
+    auto had_down = at::empty({slots, inter}, x.options());
+    auto accum = at::zeros({m, hidden}, x.options().dtype(at::kFloat));
+    auto out = at::empty({m, hidden}, x.options());
+
+    TORCH_CHECK(!(mcg && mul1), "specified both mcg and mul1");
+    const int cb = mcg ? 1 : (mul1 ? 2 : 0);
+    #define P2B_DBG(BITS, CB) launch_moe_batched<BITS, CB>(x, gt, gu, gv, ut, uu, uv, dt, du, dv, ids, rows, rw, out, gate, up, down, had_gate, had_up, had_down, accum, slots, m, hidden, inter, (int)stop_after)
+    #define P2B_DBG_CB(BITS) \
+        switch (cb) { case 0: P2B_DBG(BITS, 0); break; \
+                      case 1: P2B_DBG(BITS, 1); break; \
+                      case 2: P2B_DBG(BITS, 2); break; }
+    if (kg == 4) P2B_DBG_CB(4)
+    else if (kg == 3) P2B_DBG_CB(3)
+    else P2B_DBG_CB(2)
+    #undef P2B_DBG_CB
+    #undef P2B_DBG
+    return {had_gate, had_up, gate, up, had_down, down, out};
+}
+
+
+// Map global expert picks to local ids in one launch: out-of-range slots clamp to expert 0
+// with zero weight, in-range slots keep their weight. Replaces ~9 elementwise launches + 2
+// copies per layer in the Python caller.
+__global__ void p2b_map_slots_kernel(
+    const int64_t* __restrict__ sel,
+    const __half* __restrict__ rw,
+    int32_t* __restrict__ ids_out,
+    __half* __restrict__ rw_out,
+    int n,
+    int64_t first,
+    int64_t E)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    int64_t l = sel[i] - first;
+    bool ok = (l >= 0) && (l < E);
+    ids_out[i] = ok ? (int32_t) l : 0;
+    rw_out[i] = ok ? rw[i] : __float2half(0.0f);
+}
+
+void p2b_map_slots(
+    const at::Tensor& sel,
+    const at::Tensor& rw,
+    at::Tensor& ids_out,
+    at::Tensor& rw_out,
+    int64_t first,
+    int64_t E)
+{
+    const int n = (int) sel.numel();
+    const at::cuda::OptionalCUDAGuard device_guard(sel.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    TORCH_CHECK(sel.scalar_type() == at::kLong && rw.scalar_type() == at::kHalf, "p2b_map_slots dtype");
+    p2b_map_slots_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        sel.data_ptr<int64_t>(),
+        (const __half*) rw.data_ptr<c10::Half>(),
+        ids_out.data_ptr<int32_t>(),
+        (__half*) rw_out.data_ptr<c10::Half>(),
+        n, first, E);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}

--- a/exllamav3/exllamav3_ext/quant/p2b_moe.cuh
+++ b/exllamav3/exllamav3_ext/quant/p2b_moe.cuh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <torch/extension.h>
+
+at::Tensor p2b_fused_moe_cuda(const at::Tensor& x, at::Tensor& out,
+    const at::Tensor& gt, const at::Tensor& gu, const at::Tensor& gv,
+    const at::Tensor& ut, const at::Tensor& uu, const at::Tensor& uv,
+    const at::Tensor& dt, const at::Tensor& du, const at::Tensor& dv,
+    const at::Tensor& ids, const at::Tensor& rows, const at::Tensor& rw,
+    int64_t kg, int64_t ku, int64_t kd, bool mcg, bool mul1,
+    int64_t hidden, int64_t inter,
+    at::Tensor& gate, at::Tensor& up, at::Tensor& down,
+    at::Tensor& had_gate, at::Tensor& had_up, at::Tensor& had_down,
+    at::Tensor& accum);
+void p2b_map_slots(
+    const at::Tensor& sel,
+    const at::Tensor& rw,
+    at::Tensor& ids_out,
+    at::Tensor& rw_out,
+    int64_t first,
+    int64_t E);
+
+#include <vector>
+// Diagnostic entry point: the same kernel stopped after `stop_after` of its four phases,
+// with the staged intermediates returned for comparison against a reference. Not used at
+// inference; every production call site runs all four phases.
+std::vector<at::Tensor> p2b_stage_debug_cuda(const at::Tensor& x,
+    const at::Tensor& gt, const at::Tensor& gu, const at::Tensor& gv,
+    const at::Tensor& ut, const at::Tensor& uu, const at::Tensor& uv,
+    const at::Tensor& dt, const at::Tensor& du, const at::Tensor& dv,
+    const at::Tensor& ids, const at::Tensor& rows, const at::Tensor& rw,
+    int64_t kg, int64_t ku, int64_t kd, bool mcg, bool mul1,
+    int64_t hidden, int64_t inter, int64_t stop_after);

--- a/exllamav3/modules/block_sparse_mlp.py
+++ b/exllamav3/modules/block_sparse_mlp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing_extensions import override
+import os
 import torch
 import torch.nn.functional as F
 from ..model.config import Config
@@ -7,6 +8,14 @@ from ..util.tensor import to2
 from . import Module, Linear
 from .multilinear import MultiLinear
 from ..ext import exllamav3_ext as ext
+
+# Cooperative fused-MoE path (p2b port): decode-shaped passes route through ext.p2b_fused_moe
+# with slot tables instead of the dense bc graph. Under TP the caller zero-weights out-of-range
+# slots and the kernel skips them, so a rank pays only its ~active slots instead of traversing
+# all bsz*topk (bc dense: ~129 us fixed + 6.4 us/slot; p2b: ~21 us + 5.2 us/slot, skipped slots
+# a predicate).
+_p2b_moe_env = os.environ.get("EXL3_P2B_MOE", "0").lower() in ("1", "true", "yes")
+_p2b_announced = False
 from dataclasses import dataclass
 from .mlp import MLP, GatedMLP
 from .rmsnorm import RMSNorm
@@ -354,6 +363,8 @@ class BlockSparseMLP(BlockSparseMLP_CPU, Module):
 
         self.bc = None
         self.bc_sh_exp = False
+        self.p2b_ok = None
+        self._p2b_reset()
         self.fused_mode_buffers = None
         self._cpu_init_state()
 
@@ -706,6 +717,8 @@ class BlockSparseMLP(BlockSparseMLP_CPU, Module):
         self.cpu_unload()
         self.bc = None
         self.fused_mode_buffers = None
+        self.p2b_ok = None
+        self._p2b_reset()
         if self.multi_gate is not None:
             self.multi_gate.unload()
             self.multi_gate = None
@@ -724,6 +737,120 @@ class BlockSparseMLP(BlockSparseMLP_CPU, Module):
         self.bcast_weights_bsz1 = None
         super().unload()
 
+
+    def _p2b_reset(self):
+        # Every tensor the p2b path holds, in one place. These are per-module statics sized for
+        # the slot cap, so they pin device memory for the life of the module and they are bound
+        # to the device the module was loaded on. unload() has to drop them: a module reloaded
+        # onto a different device would otherwise keep launching against the old one.
+        self.p2b_ids = None
+        self.p2b_rw = None
+        self.p2b_rows = None
+        self.p2b_out = None
+        self.p2b_acc = None
+        self.p2b_gate = None
+        self.p2b_up = None
+        self.p2b_down = None
+        self.p2b_hg = None
+        self.p2b_hu = None
+        self.p2b_hd = None
+        self.p2b_sh = None
+
+
+    def _p2b_ok(self):
+        if self.p2b_ok is None:
+            mg, mu, md = self.multi_gate, self.multi_up, self.multi_down
+            ok = (
+                self.is_quantized and
+                self.gated and
+                self.activation_fn == "silu" and
+                self.act_limit in (None, 0.0) and   # 0.0 is the constructor default = no limit
+                mg is not None and mu is not None and md is not None and
+                mg.K == mu.K == md.K and mg.K in (2, 3, 4) and
+                self.hidden_size % 128 == 0 and
+                self.intermediate_size_padded % 128 == 0 and
+                not self.cpu_offload and
+                not self.config.infer_params.no_reconstruct
+            )
+            self.p2b_ok = bool(ok)
+        return self.p2b_ok
+
+    def _p2b_forward_bszn(self, y, x, bsz, selected_experts, routing_weights):
+        # Launch on the layer's own device. The layer-split forward does not set the current
+        # CUDA device around eager ext calls, so it stays cuda:0 for the whole process. A
+        # cuda:0 launch can still reach cuda:1 tensors through peer access, but the first
+        # non-peer pair (cuda:0 -> cuda:2) faults with an illegal access inside the
+        # cooperative kernel, surfacing asynchronously at whatever kernel checks next.
+        with torch.cuda.device(self.device):
+            return self._p2b_forward_bszn_dev(y, x, bsz, selected_experts, routing_weights)
+
+    def _p2b_forward_bszn_dev(self, y, x, bsz, selected_experts, routing_weights):
+        mg, mu, md = self.multi_gate, self.multi_up, self.multi_down
+        E = self.num_local_experts
+        topk = self.num_experts_per_tok
+        n = bsz * topk
+        H, I = self.hidden_size, self.intermediate_size_padded
+
+        if self.p2b_ids is None:
+            # Sized to the bound that actually gates this path: bszn_eligible requires
+            # bsz <= MAX_BSZN, so anything above it is scratch nothing can reach.
+            cap = MAX_BSZN * topk
+            dev = self.device
+            self.p2b_ids = torch.empty(cap, dtype = torch.int32, device = dev)
+            self.p2b_rw = torch.empty(cap, dtype = torch.half, device = dev)
+            self.p2b_rows = {}
+            self.p2b_out = torch.empty((MAX_BSZN, H), dtype = torch.float, device = dev)
+            self.p2b_acc = torch.empty((MAX_BSZN, H), dtype = torch.float, device = dev)
+            self.p2b_gate = torch.empty((cap, I), dtype = torch.half, device = dev)
+            self.p2b_up = torch.empty((cap, I), dtype = torch.half, device = dev)
+            self.p2b_down = torch.empty((cap, H), dtype = torch.half, device = dev)
+            self.p2b_hg = torch.empty((cap, H), dtype = torch.half, device = dev)
+            self.p2b_hu = torch.empty((cap, H), dtype = torch.half, device = dev)
+            self.p2b_hd = torch.empty((cap, I), dtype = torch.half, device = dev)
+            self.p2b_sh = None
+            # One-line engagement proof. A path that silently never engaged has fooled this
+            # project's benches before, so say so once, and only once: a per-module print is
+            # one line per layer, which is noise rather than evidence.
+            global _p2b_announced
+            if not _p2b_announced:
+                _p2b_announced = True
+                print(f" -- p2b MoE path engaged: {self.key}", flush = True)
+        if bsz not in self.p2b_rows:
+            self.p2b_rows[bsz] = torch.arange(bsz, device = self.device) \
+                .repeat_interleave(topk).to(torch.int32)
+
+        first = self.routing_first if self.routing_first is not None else 0
+        ext.p2b_map_slots(
+            selected_experts.reshape(-1), routing_weights.reshape(-1),
+            self.p2b_ids[:n], self.p2b_rw[:n], first, E,
+        )
+
+        out = self.p2b_out[:bsz]
+        ext.p2b_fused_moe(
+            y, out,
+            mg.ptrs_trellis, mg.ptrs_suh, mg.ptrs_svh,
+            mu.ptrs_trellis, mu.ptrs_suh, mu.ptrs_svh,
+            md.ptrs_trellis, md.ptrs_suh, md.ptrs_svh,
+            self.p2b_ids[:n], self.p2b_rows[bsz], self.p2b_rw[:n],
+            mg.K, mg.K, mg.K, bool(mg.mcg), bool(mg.mul1),
+            H, I,
+            self.p2b_gate[:n], self.p2b_up[:n], self.p2b_down[:n],
+            self.p2b_hg[:n], self.p2b_hu[:n], self.p2b_hd[:n],
+            self.p2b_acc[:bsz],
+        )
+
+        # Shared expert through its own multi-row graph + the sigmoid-gate combine, replacing
+        # the eager tail (~100-150 us/layer) with ~25 us + one combine kernel. Falls back to
+        # the common tail when the shared BC was not bound.
+        if self.bc_sh_exp:
+            if self.p2b_sh is None:
+                self.p2b_sh = torch.empty((1, MAX_BSZN, H), dtype = torch.float, device = self.device)
+            self.shared_experts.bc.run_bszN(y.view(1, bsz, H), self.p2b_sh[:, :bsz])
+            ext.add_sigmoid_gate_proj(
+                self.p2b_sh[0, :bsz], x.view(-1, H), out, self.shared_gate.inner.weight,
+            )
+
+        return out
 
     @override
     def forward(
@@ -976,6 +1103,15 @@ class BlockSparseMLP(BlockSparseMLP_CPU, Module):
         # multi-row BC_GatedMLP graph, fused into the same capture. Expert-range shards (CPU
         # split, TP) produce a partial sum here: out-of-range picks are masked inactive inside
         # the mgemm kernel and contribute exact zeros
+        elif bszn_eligible and _p2b_moe_env and self._p2b_ok():
+            # p2b slot-table path. Shared experts run through their own multi-row graph inside
+            # the helper when bound (bc_sh_exp set True below mirrors the dense-graph path and
+            # suppresses the eager tail); the block-level reduction handles the per-rank
+            # partial sums under TP either way
+            final_hidden_states = self._p2b_forward_bszn(y, x, bsz, selected_experts, routing_weights).view(x.shape)
+            if self.bc_sh_exp:
+                bc_sh_exp = True
+
         elif bszn_eligible:
             self.bc.run_bszN(y, selected_experts, routing_weights)
             if self.experts_cfg.out_trim is not None:


### PR DESCRIPTION
Brings the p2b cooperative fused-MoE kernel from the [vllm-exl3](https://github.com/vcruz305/vllm-exl3) plugin (MIT) into exllamav3, behind `EXL3_P2B_MOE`. Default off, so nothing changes unless it is set.

### Credit

The port is @creslinux's work. He opened it as #354, and closed it so it could go up from here; the kernel is mine but the exllamav3 port, the integration follow-ons and the `p2b_stage_debug` tool are his, and both commits carry him as co-author. He also raised the caveat on the numbers below, which is his own, not something I found.

### What it does

Decode-shaped passes (`bsz <= MAX_BSZN`) route through `ext.p2b_fused_moe` instead of the dense BC graph. Four grid-synchronised phases over the active slots: input Hadamard, batched gate/up GEMV through the existing exl3 GEMV path, SwiGLU plus down-input Hadamard, batched down GEMV, then output Hadamard and weighted atomic accumulation.

Grid size is occupancy-derived and every phase grid-strides over its work items, so there is no architecture-specific code: plain warp shuffles and cooperative groups, no tensor-core intrinsics, no compute-capability branches.

The kernel takes an explicit row-expert slot table rather than the dense `(row x top_k)` form, so the caller maps global expert picks to local ids and clamps out-of-range slots to expert 0 with zero weight. Under an expert-range shard a rank then pays only its active slots. No argsort, no host sync, shapes stay fixed.

### Changes against the vllm-exl3 original

- One input row per launch becomes a full row-expert slot table, so a whole verify window runs as one cooperative launch instead of one launch per row.
- Dimensions are runtime parameters. The original hardcoded hidden 4096 and intermediate 1024/2048; both now need only be multiples of 128 for the Hadamard warp tiling.
- Codebook selection is generalised. The original is MCG-only by construction, fixing the codebook template argument at 1 and rejecting anything else. It is now a template parameter chosen the way `exl3_gemv.cu` chooses it (0 default, 1 MCG, 2 mul1), with both flags at once rejected. Nine instantiations, 3 K by 3 codebook.
- The fp32 accumulator is returned directly rather than rounded to half and converted back in Python.
- `p2b_stage_debug` runs the kernel to phase N and returns the intermediates, so a parity failure bisects to a phase rather than a tile.

Constraints: K in {2, 3, 4}, uniform across gate/up/down, matching the MultiLinear pointer tables.

### Measurements

These are @creslinux's, on 4x3090 layer split, Qwen3.8-Flash-Next 4.05bpw with MTP: **+18-23% decode** against his own tree, **+25% prose** against plain `dev`.

He asked that the +76% figure from #354's description be disregarded: its control arm was noisier than it should have been. I have not reproduced either number on my own hardware, so please read them as his measurements rather than as a verified claim of this PR.

### What I verified

- Compiles clean for `sm_121a` under CUDA 13.0, all nine template instantiations, no warnings referencing `p2b_moe.cu`.
- Rebased onto current `dev` (`8473340`). Upstream has only touched `coop_autotune.cu` since the port was written, which this does not.

### What I changed on top of the port

- Scratch is sized from `MAX_BSZN` rather than a separate hardcoded 16. `bszn_eligible` already gates the path at `bsz <= MAX_BSZN` (8), so the buffers were double what anything could reach, and they can no longer silently diverge from the bound.
- `unload()` releases the p2b buffers through a `_p2b_reset()` helper. They are per-module statics pinning device memory for the life of the module and bound to the device it loaded on, so a module reloaded onto another device would otherwise keep launching against the old one.
- The output parameter is typed `float*` to match what the launcher passes. It was declared `half*` and cast at its single use, which compiled only because `cudaLaunchCooperativeKernel` passes arguments through an untyped `void*` array.
- Normalised a `__restrict__` qualifier that was attached to the pointee rather than the pointer, unlike its nine sibling parameters.
- The engagement notice prints once per process instead of once per layer.

### Not covered

Correctness parity against the dense path on this hardware, and any measurement of my own. Happy to add either if you want them before this is considered. @creslinux offered to test on the 4x3090 rig once it is up.
