### PR TITLE
MoE: M=16/32/64 prefill row-tile dispatch

### DIFF
--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
@@ -736,3 +736,978 @@ void exl3_gemm_kernel_inner
         }
     }
 }
+
+
+// Multi-row-M prefill variant used only by the fused MoE kernel. Kept separate from the
+// function above so the dense/decode instantiations (TILESIZE_M == 16) are untouched and
+// remain byte-identical. TILEBLOCKS_M row fragments share each dequantized B fragment.
+template<EXL3_GEMM_T_ARGS, bool shmem_out_had>
+inline __device__
+void exl3_gemm_kernel_inner_mt
+(
+    const half* __restrict__  A,
+    const uint16_t* __restrict__ B,
+    void* __restrict__ C,
+    const int size_m,
+    const int size_k,
+    const int size_n,
+    int* __restrict__ locks,
+    const half* post_scale,
+    int size_n_stride = 0     // full width of B and C when computing a column slice (0: = size_n)
+)
+{
+    // Row fragments: one m16 fragment per 16 rows. TILEBLOCKS_M == 1 is the original dense/decode
+    // shape (byte-identical codegen); > 1 is the prefill MoE shape, where several row fragments
+    // share each dequantized B fragment instead of re-running the whole B pipeline per 16 rows.
+    const int TILEBLOCKS_M = TILESIZE_M / 16;
+    if (size_n_stride == 0) size_n_stride = size_n;
+    // Column blocks of the full-width B row: slices index B relative to their own column offset,
+    // but a k-tile row still spans the whole matrix
+    const int blocks_n_full = size_n_stride / 16;
+    const int TILEBLOCKS_K = TILESIZE_K / 16;
+    const int TILEBLOCKS_N = TILESIZE_N / 16;
+    // const int FRAGS_M = TILEBLOCKS_M;
+    const int FRAGS_N_PER_WARP = 2 * TILEBLOCKS_N / (EXL3_GEMM_BASE_THREADS / 32);
+
+    const int sh_a_stage_size = TILESIZE_M * TILESIZE_K;                         // in halfs
+    const int sh_b_stage_size = TILEBLOCKS_K * TILEBLOCKS_N * 256 / 16 * bits;   // in uint16s
+    const int sh_c_size = MAX  // in floats
+    (
+        4 * EXL3_GEMM_BASE_THREADS * FRAGS_N_PER_WARP * TILEBLOCKS_M,
+        shmem_out_had ? TILESIZE_N * TILESIZE_M : 0
+    );
+
+    // XOR-swizzle constants for bank-conflict-free A fragment loads
+    // col_swizzled = col ^ ((row >> SHIFT) & MASK)
+    const int A_COLS = TILESIZE_K / 8;                                            // int4 columns per row
+    const int A_SWIZZLE_MASK = A_COLS - 1;
+    const int A_SWIZZLE_SHIFT = (A_COLS <= 2) ? 2 : 1;
+
+    // Sanity checks
+    static_assert(EXL3_GEMM_BASE_THREADS == 256);
+    static_assert(TILESIZE_M >= 16 && TILESIZE_M % 16 == 0, "Invalid kernel params");
+    static_assert(TILESIZE_K % 16 == 0, "Invalid kernel params");
+    static_assert(TILESIZE_N % 128 == 0, "Invalid kernel params");
+    static_assert
+    (
+        SMEM_MAX >= SH_STAGES * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size,
+        "Invalid kernel params (insufficient shared memory for shape)"
+    );
+
+    // Shared memory
+    extern __shared__ half shared[];
+    half* sh_a = shared;
+    uint16_t* sh_b = (uint16_t*) (sh_a + SH_STAGES * sh_a_stage_size);
+    float* sh_c = (float*) (sh_b + sh_b_stage_size * SH_STAGES);
+
+    // Thread index
+    int t = threadIdx.x % EXL3_GEMM_BASE_THREADS;
+    int sub_k = threadIdx.x / EXL3_GEMM_BASE_THREADS;
+    int warp_id = t / 32;
+    int lane_id = t % 32;
+
+    // Dimensions
+    //int tiles_m = CEIL_DIVIDE(size_m, TILESIZE_M);
+    int tiles_k = size_k / TILESIZE_K;
+    int tiles_n = size_n / TILESIZE_N;
+    //int blocks_m = 1;
+    //int blocks_k = tiles_k * TILEBLOCKS_K;
+    int blocks_n = tiles_n * TILEBLOCKS_N;
+
+    // Start and end index of current slice, must span at least one tile
+    int num_slices = gridDim.x;
+    int slice_beg = tiles_k * tiles_n * blockIdx.x / num_slices;
+    int slice_end = tiles_k * tiles_n * (blockIdx.x + 1) / num_slices;
+    int slice_len = slice_end - slice_beg;
+    if (slice_len < 1) return;
+
+    auto index_m = [&] (int slice_i) { return 0; }; //blockIdx.y; };
+    auto index_k = [&] (int slice_i) { return (slice_i % tiles_k); };
+    auto index_n = [&] (int slice_i) { return (slice_i / tiles_k); };
+
+    // Batch dimension
+    // int slice_m = index_m(slice_beg);
+    // int max_m = MIN(size_m - slice_m * TILESIZE_M, TILESIZE_M);
+    const int slice_m = 0;
+
+    // Pipe 0, global A, B tile and shared A, B tile
+    int slice0_k = index_k(slice_beg);
+    int slice0_n = index_n(slice_beg);
+    int slice0_iters = slice_len;
+
+    int gl_a_stride_m = TILESIZE_M * size_k;
+    const int gl_a_stride_k = TILESIZE_K;
+    const int sh0_a_stride_m = TILESIZE_M * TILESIZE_K;
+    const half* gl_a_ptr = A + slice_m * gl_a_stride_m + slice0_k * gl_a_stride_k;
+    half* sh0_a_ptr = sh_a + (slice0_iters % SH_STAGES) * sh_a_stage_size;
+
+    const int load_a_iters = CEIL_DIVIDE(sh0_a_stride_m / 8, EXL3_GEMM_BASE_THREADS);
+    bool pred_a_gl[load_a_iters];
+    int load_a_gl[load_a_iters];
+    int load_a_sh[load_a_iters];
+    for (int i = 0; i < load_a_iters; ++i)
+    {
+        int k = (i * EXL3_GEMM_BASE_THREADS + t) % (gl_a_stride_k / 8);
+        int m = (i * EXL3_GEMM_BASE_THREADS + t) / (gl_a_stride_k / 8);
+        load_a_gl[i] = m * size_k / 8 + k;
+        load_a_sh[i] = m * A_COLS + (k ^ ((m >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK));
+        pred_a_gl[i] = m < size_m;
+    }
+
+    int gl_b_stride_k = blocks_n_full * TILEBLOCKS_K * 256 / 16 * bits;
+    const int gl_b_stride_n = TILEBLOCKS_N * 256 / 16 * bits;
+    const int sh0_b_stride_k = TILEBLOCKS_K * TILEBLOCKS_N * 256 / 16 * bits;
+    const uint16_t* gl_b_ptr = B + slice0_k * gl_b_stride_k + slice0_n * gl_b_stride_n;
+    uint16_t* sh0_b_ptr = sh_b + (slice0_iters % SH_STAGES) * sh_b_stage_size;
+
+    const int load_b_iters = CEIL_DIVIDE(sh0_b_stride_k / 8, EXL3_GEMM_BASE_THREADS);
+    bool pred_b_gl[load_b_iters];
+    int load_b_gl[load_b_iters];
+    for (int i = 0; i < load_b_iters; ++i)
+    {
+        int n = (i * EXL3_GEMM_BASE_THREADS + t) % (gl_b_stride_n / 8);
+        int k = (i * EXL3_GEMM_BASE_THREADS + t) / (gl_b_stride_n / 8);
+        load_b_gl[i] = k * (blocks_n_full * 256 / 16 * bits / 8) + n;
+        pred_b_gl[i] = i * EXL3_GEMM_BASE_THREADS + t < sh0_b_stride_k / 8;
+    }
+
+    auto advance0 = [&] ()
+    {
+        slice0_k++;
+        slice0_iters--;
+
+        int stage = slice0_iters % SH_STAGES;
+        sh0_a_ptr = sh_a + stage * sh_a_stage_size;
+        sh0_b_ptr = sh_b + stage * sh_b_stage_size;
+
+        if (slice0_k >= tiles_k)
+        {
+            slice0_k = 0;
+            slice0_n++;
+            gl_a_ptr = A + slice_m * gl_a_stride_m + slice0_k * gl_a_stride_k;
+            gl_b_ptr = B + slice0_k * gl_b_stride_k + slice0_n * gl_b_stride_n;
+        }
+        else
+        {
+            gl_a_ptr += gl_a_stride_k;
+            gl_b_ptr += gl_b_stride_k;
+        }
+    };
+
+    // Pipe 1, shared A, B tile and registers
+    int slice1_k = slice0_k;
+    int slice1_n = slice0_n;
+    int slice1_iters = slice0_iters;
+
+    half* sh1_a_ptr = sh_a + (slice1_iters % SH_STAGES) * sh_a_stage_size;
+    uint16_t* sh1_b_ptr = sh_b + (slice1_iters % SH_STAGES) * sh_b_stage_size;
+
+    auto advance1 = [&] ()
+    {
+        slice1_k++;
+        slice1_iters--;
+
+        int stage = slice1_iters % SH_STAGES;
+        sh1_a_ptr = sh_a + stage * sh_a_stage_size;
+        sh1_b_ptr = sh_b + stage * sh_b_stage_size;
+
+        if (slice1_k >= tiles_k)
+        {
+            slice1_k = 0;
+            slice1_n++;
+        }
+    };
+
+    // Pipe 2
+    int slice2_k = slice0_k;
+    int slice2_k0 = slice0_k;
+    int slice2_n = slice0_n;
+    int slice2_iters = slice0_iters;
+
+    int gl_c_stride_n = TILESIZE_N;
+    int gl_c_stride_m = TILESIZE_M * size_n_stride;
+
+    half* gl_c_ptr_16 = ((half*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
+    float* gl_c_ptr_32 = ((float*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
+
+    register FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
+    register FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
+    register FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+    #if EXL3_GEMM_H_ACC
+        register FragC_h frag_c_h[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+    #endif
+
+    auto advance2 = [&] ()
+    {
+        slice2_k++;
+        slice2_iters--;
+
+        if (slice2_k >= tiles_k)
+        {
+            slice2_k = 0;
+            slice2_k0 = 0;
+            slice2_n++;
+            if constexpr (c_fp32)
+                gl_c_ptr_32 += gl_c_stride_n;
+            else
+                gl_c_ptr_16 += gl_c_stride_n;
+        }
+    };
+
+    // Schedule load of the next A, B tiles to shared memory and advance the pipeline
+    auto async_load_gl = [&] ()
+    {
+        if (sub_k)
+        {
+            cp_async_fence();
+            return;
+        }
+
+        if (slice0_iters)
+        {
+            // Copy tile from row-major A matrix (XOR-swizzled for bank-conflict-free ldmatrix)
+            {
+                const int4* gl = (const int4*) gl_a_ptr;
+                int4* sh = (int4*) sh0_a_ptr;
+                #pragma unroll
+                for (int i = 0; i < load_a_iters; ++i)
+                {
+                    if (pred_a_gl[i]) cp_async(sh + load_a_sh[i], gl + load_a_gl[i]);
+                }
+            }
+
+            // Copy tile of 256-element blocks from quantized B matrix
+            {
+                const int4* gl = (const int4*) gl_b_ptr;
+                int4* sh = (int4*) sh0_b_ptr;
+                #pragma unroll
+                for (int i = 0; i < load_b_iters; ++i)
+                {
+                    // cp_async_pred(sh + EXL3_GEMM_BASE_THREADS * i + t, gl + load_b_gl[i], pred_b_gl[i]);
+                    if (pred_b_gl[i]) cp_async(sh + EXL3_GEMM_BASE_THREADS * i + t, gl + load_b_gl[i]);
+                }
+            }
+            advance0();
+        }
+
+        // Sync and advance
+        cp_async_fence();
+    };
+
+    // Load fragments
+    // Ref. for fragment layout:
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+    auto load_frags = [&] (int buf)
+    {
+        if (!slice1_iters) return;
+
+        // A fragments (XOR-swizzled shared memory layout)
+        {
+            int r = (lane_id % 8) + 8 * ((lane_id / 8) % 2);
+            int base_c = lane_id / 16 + sub_k * 2;
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                int R = r + m * 16;
+                int c_swizzled = base_c ^ ((R >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK);
+                ldsm4(frag_a[buf][m], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
+            }
+        }
+
+        // B fragments
+        #pragma unroll
+        for (int n2 = 0; n2 < FRAGS_N_PER_WARP; n2 += 2)
+        {
+            int sub_n2 = warp_id * FRAGS_N_PER_WARP / 2 + n2 / 2;
+            const uint32_t* shb = (const uint32_t*) (sh1_b_ptr + (sub_k * TILEBLOCKS_N + sub_n2) * 256 / 16 * bits);
+
+            dq_dispatch<bits, cb>(shb, lane_id << 3, frag_b[buf][n2], frag_b[buf][n2 + 1]);
+        }
+
+        __syncthreads();
+        advance1();
+    };
+
+    // Clear C fragments
+    auto clear_frag_c = [&] ()
+    {
+        if constexpr (TILEBLOCKS_M == 1)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                frag_c[0][n] = {};
+            #if EXL3_GEMM_H_ACC
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    frag_c_h[0][n] = {};
+            #endif
+        }
+        else
+        {
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    frag_c[m][n] = {};
+            #if EXL3_GEMM_H_ACC
+                #pragma unroll
+                for (int m = 0; m < TILEBLOCKS_M; ++m)
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                        frag_c_h[m][n] = {};
+            #endif
+        }
+    };
+
+    // Threadblock reduction
+    auto threadblock_reduce = [&] ()
+    {
+        auto store = [&] (int i)
+        {
+            if (sub_k == i)
+            {
+                if constexpr (TILEBLOCKS_M == 1)
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    {
+                        #pragma unroll
+                        for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[0][n][j];
+                    }
+                }
+                else
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4 * TILEBLOCKS_M) * t;
+                    #pragma unroll
+                    for (int m = 0; m < TILEBLOCKS_M; ++m)
+                        #pragma unroll
+                        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                        {
+                            #pragma unroll
+                            for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[m][n][j];
+                        }
+                }
+            }
+            __syncthreads();
+        };
+
+        auto add = [&] (int i)
+        {
+            if (sub_k == i)
+            {
+                if constexpr (TILEBLOCKS_M == 1)
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    {
+                        #pragma unroll
+                        for (int j = 0; j < 4; ++j) frag_c[0][n][j] += *sh_red++;
+                    }
+                }
+                else
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4 * TILEBLOCKS_M) * t;
+                    #pragma unroll
+                    for (int m = 0; m < TILEBLOCKS_M; ++m)
+                        #pragma unroll
+                        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                        {
+                            #pragma unroll
+                            for (int j = 0; j < 4; ++j) frag_c[m][n][j] += *sh_red++;
+                        }
+                }
+            }
+        };
+
+        auto store_small = [&] (int i)
+        {
+            if constexpr (TILEBLOCKS_M == 1)
+            {
+                if (sub_k == i && lane_id / 4 < size_m)
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    {
+                        *sh_red++ = frag_c[0][n][0];
+                        *sh_red++ = frag_c[0][n][1];
+                    }
+                }
+                __syncthreads();
+            }
+            else
+            {
+                if (sub_k == i)
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4 * TILEBLOCKS_M) * t;
+                    #pragma unroll
+                    for (int m = 0; m < TILEBLOCKS_M; ++m)
+                    {
+                        bool row_ok = (m * 16 + lane_id / 4) < size_m;
+                        #pragma unroll
+                        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                        {
+                            if (row_ok) { *sh_red = frag_c[m][n][0]; *(sh_red + 1) = frag_c[m][n][1]; }
+                            sh_red += 2;
+                        }
+                    }
+                }
+                __syncthreads();
+            }
+        };
+
+        auto add_small = [&] (int i)
+        {
+            if constexpr (TILEBLOCKS_M == 1)
+            {
+                if (sub_k == i && lane_id / 4 < size_m)
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    {
+                        frag_c[0][n][0] += *sh_red++;
+                        frag_c[0][n][1] += *sh_red++;
+                    }
+                }
+            }
+            else
+            {
+                if (sub_k == i)
+                {
+                    float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4 * TILEBLOCKS_M) * t;
+                    #pragma unroll
+                    for (int m = 0; m < TILEBLOCKS_M; ++m)
+                    {
+                        bool row_ok = (m * 16 + lane_id / 4) < size_m;
+                        #pragma unroll
+                        for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                        {
+                            if (row_ok) { frag_c[m][n][0] += *sh_red; frag_c[m][n][1] += *(sh_red + 1); }
+                            sh_red += 2;
+                        }
+                    }
+                }
+            }
+        };
+
+        if (size_m <= 8)
+        {
+            if constexpr (TILEBLOCKS_K == 2)
+            {
+                store_small(1);
+                add_small(0);
+            }
+            if constexpr (TILEBLOCKS_K == 3)
+            {
+                store_small(1);
+                add_small(0);
+                store_small(2);
+                add_small(0);
+            }
+            if constexpr (TILEBLOCKS_K == 4)
+            {
+                store_small(3);
+                add_small(2);
+                store_small(1);
+                add_small(0);
+                store_small(2);
+                add_small(0);
+            }
+        }
+        else
+        {
+            if constexpr (TILEBLOCKS_K == 2)
+            {
+                store(1);
+                add(0);
+            }
+            if constexpr (TILEBLOCKS_K == 3)
+            {
+                store(1);
+                add(0);
+                store(2);
+                add(0);
+            }
+            if constexpr (TILEBLOCKS_K == 4)
+            {
+                store(3);
+                add(2);
+                store(1);
+                add(0);
+                store(2);
+                add(0);
+            }
+        }
+    };
+
+    // Pre-hadamard: Write final output tile to shmem
+    auto write_sum_tile_sh = [&]()
+    {
+        const int n0 = warp_id * FRAGS_N_PER_WARP;
+        if constexpr (TILEBLOCKS_M == 1)
+        {
+            const int r0 = lane_id / 4;
+            const int r1 = r0 + 8;
+            if (r0 < size_m)
+            {
+                const int c = (lane_id % 4) * 2;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float* c_ptr = ((float*) sh_c) + r0 * TILESIZE_N + (n0 + n) * 8 + c;
+                    *c_ptr++ = frag_c[0][n][0];
+                    *c_ptr++ = frag_c[0][n][1];
+                }
+            }
+            if (r1 < size_m)
+            {
+                const int c = (lane_id % 4) * 2;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float* c_ptr = ((float*) sh_c) + r1 * TILESIZE_N + (n0 + n) * 8 + c;
+                    *c_ptr++ = frag_c[0][n][2];
+                    *c_ptr++ = frag_c[0][n][3];
+                }
+            }
+        }
+        else
+        {
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                const int r0 = m * 16 + lane_id / 4;
+                const int r1 = r0 + 8;
+                if (r0 < size_m)
+                {
+                    const int c = (lane_id % 4) * 2;
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    {
+                        float* c_ptr = ((float*) sh_c) + r0 * TILESIZE_N + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[m][n][0];
+                        *c_ptr++ = frag_c[m][n][1];
+                    }
+                }
+                if (r1 < size_m)
+                {
+                    const int c = (lane_id % 4) * 2;
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    {
+                        float* c_ptr = ((float*) sh_c) + r1 * TILESIZE_N + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[m][n][2];
+                        *c_ptr++ = frag_c[m][n][3];
+                    }
+                }
+            }
+        }
+    };
+
+    // Copy output tile to global with hadamard transform and out scale
+    auto output_had_sh_gl = [&]()
+    {
+        int sh_warp = warp_id;
+        constexpr int active_warps = EXL3_GEMM_BASE_THREADS / 32;
+        for (;; sh_warp += active_warps)
+        {
+            int col = sh_warp % (TILESIZE_N / 128);
+            int row = sh_warp / (TILESIZE_N / 128);
+            if (row >= size_m) break;
+
+            const float* had_in = sh_c + row * TILESIZE_N + col * 128;
+            const half* post_scale_c = post_scale + slice2_n * gl_c_stride_n + col * 128;
+
+            if constexpr (c_fp32)
+            {
+                float* had_out = gl_c_ptr_32 + row * size_n_stride + col * 128;
+                had_ff_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
+            }
+            else
+            {
+                half* had_out = gl_c_ptr_16 + row * size_n_stride + col * 128;
+                had_fh_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
+            }
+        }
+    };
+
+    auto read_sum_gl = [&]()
+    {
+        int n0 = warp_id * FRAGS_N_PER_WARP;
+        if constexpr (TILEBLOCKS_M == 1)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            {
+                int r0 = lane_id / 4;
+                int r1 = r0 + 8;
+                int c = (lane_id % 4) * 2;
+                if (r0 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r0 * size_n_stride + (n0 + n) * 8 + c;
+                        frag_c[0][n][0] += *c_ptr++;
+                        frag_c[0][n][1] += *c_ptr++;
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n_stride + (n0 + n) * 8 + c);
+                        float2 interm = __half22float2(*c_ptr);
+                        frag_c[0][n][0] += interm.x;
+                        frag_c[0][n][1] += interm.y;
+                    }
+                }
+                if (r1 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r1 * size_n_stride + (n0 + n) * 8 + c;
+                        frag_c[0][n][2] += *c_ptr++;
+                        frag_c[0][n][3] += *c_ptr++;
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n_stride + (n0 + n) * 8 + c);
+                        float2 interm = __half22float2(*c_ptr);
+                        frag_c[0][n][2] += interm.x;
+                        frag_c[0][n][3] += interm.y;
+                    }
+                }
+            }
+        }
+        else
+        {
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    int r0 = m * 16 + lane_id / 4;
+                    int r1 = r0 + 8;
+                    int c = (lane_id % 4) * 2;
+                    if (r0 < size_m)
+                    {
+                        if constexpr (c_fp32)
+                        {
+                            float* c_ptr = gl_c_ptr_32 + r0 * size_n_stride + (n0 + n) * 8 + c;
+                            frag_c[m][n][0] += *c_ptr++;
+                            frag_c[m][n][1] += *c_ptr++;
+                        }
+                        else
+                        {
+                            half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n_stride + (n0 + n) * 8 + c);
+                            float2 interm = __half22float2(*c_ptr);
+                            frag_c[m][n][0] += interm.x;
+                            frag_c[m][n][1] += interm.y;
+                        }
+                    }
+                    if (r1 < size_m)
+                    {
+                        if constexpr (c_fp32)
+                        {
+                            float* c_ptr = gl_c_ptr_32 + r1 * size_n_stride + (n0 + n) * 8 + c;
+                            frag_c[m][n][2] += *c_ptr++;
+                            frag_c[m][n][3] += *c_ptr++;
+                        }
+                        else
+                        {
+                            half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n_stride + (n0 + n) * 8 + c);
+                            float2 interm = __half22float2(*c_ptr);
+                            frag_c[m][n][2] += interm.x;
+                            frag_c[m][n][3] += interm.y;
+                        }
+                    }
+                }
+        }
+    };
+
+    auto write_sum_gl = [&]()
+    {
+        int n0 = warp_id * FRAGS_N_PER_WARP;
+        if constexpr (TILEBLOCKS_M == 1)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            {
+                int r0 = lane_id / 4;
+                int r1 = r0 + 8;
+                int c = (lane_id % 4) * 2;
+                if (r0 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r0 * size_n_stride + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[0][n][0];
+                        *c_ptr++ = frag_c[0][n][1];
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n_stride + (n0 + n) * 8 + c);
+                        half2 sum = __floats2half2_rn(frag_c[0][n][0], frag_c[0][n][1]);
+                        *c_ptr = sum;
+                    }
+                }
+                if (r1 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r1 * size_n_stride + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[0][n][2];
+                        *c_ptr++ = frag_c[0][n][3];
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n_stride + (n0 + n) * 8 + c);
+                        half2 sum = __floats2half2_rn(frag_c[0][n][2], frag_c[0][n][3]);
+                        *c_ptr = sum;
+                    }
+                }
+            }
+        }
+        else
+        {
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    int r0 = m * 16 + lane_id / 4;
+                    int r1 = r0 + 8;
+                    int c = (lane_id % 4) * 2;
+                    if (r0 < size_m)
+                    {
+                        if constexpr (c_fp32)
+                        {
+                            float* c_ptr = gl_c_ptr_32 + r0 * size_n_stride + (n0 + n) * 8 + c;
+                            *c_ptr++ = frag_c[m][n][0];
+                            *c_ptr++ = frag_c[m][n][1];
+                        }
+                        else
+                        {
+                            half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n_stride + (n0 + n) * 8 + c);
+                            half2 sum = __floats2half2_rn(frag_c[m][n][0], frag_c[m][n][1]);
+                            *c_ptr = sum;
+                        }
+                    }
+                    if (r1 < size_m)
+                    {
+                        if constexpr (c_fp32)
+                        {
+                            float* c_ptr = gl_c_ptr_32 + r1 * size_n_stride + (n0 + n) * 8 + c;
+                            *c_ptr++ = frag_c[m][n][2];
+                            *c_ptr++ = frag_c[m][n][3];
+                        }
+                        else
+                        {
+                            half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n_stride + (n0 + n) * 8 + c);
+                            half2 sum = __floats2half2_rn(frag_c[m][n][2], frag_c[m][n][3]);
+                            *c_ptr = sum;
+                        }
+                    }
+                }
+        }
+    };
+
+    // Output reduction
+    auto reduce = [&] ()
+    {
+        #if EXL3_GEMM_H_ACC
+            // Fold the fp16 MMA accumulators into the fp32 accumulators once per k-slice
+            if constexpr (TILEBLOCKS_M == 1)
+            {
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float2 f0 = __half22float2(frag_c_h[0][n][0]);
+                    float2 f1 = __half22float2(frag_c_h[0][n][1]);
+                    frag_c[0][n][0] += f0.x; frag_c[0][n][1] += f0.y;
+                    frag_c[0][n][2] += f1.x; frag_c[0][n][3] += f1.y;
+                }
+            }
+            else
+            {
+                #pragma unroll
+                for (int m = 0; m < TILEBLOCKS_M; ++m)
+                    #pragma unroll
+                    for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    {
+                        float2 f0 = __half22float2(frag_c_h[m][n][0]);
+                        float2 f1 = __half22float2(frag_c_h[m][n][1]);
+                        frag_c[m][n][0] += f0.x; frag_c[m][n][1] += f0.y;
+                        frag_c[m][n][2] += f1.x; frag_c[m][n][3] += f1.y;
+                    }
+            }
+        #endif
+
+        // First reduce all partial sums along k for the current slice
+        threadblock_reduce();
+
+        // Process (partial) slices within column in reverse order so the threadblock doing the bottom slice is
+        // free to proceed to the next column right away
+        int lock_i = tiles_k - slice2_k - 1;
+        int lock_d = slice2_k - slice2_k0 + 1;
+        int* lock = &locks[slice_m * blocks_n + slice2_n];
+
+        barrier_acquire(lock, lock_i);
+
+        bool first = lock_i == 0;
+        bool last = lock_i + lock_d == tiles_k;
+
+        // Second and subsequent threadblocks in column read back the intermediate sum from global memory
+        if (!sub_k && !first)
+        {
+            read_sum_gl();
+        }
+
+        // All but last threadblock in column write the intermediate result to global memory
+        if (!sub_k && !last)
+        {
+            write_sum_gl();
+        }
+
+        // Last block writes in row-major format
+        if (!sub_k && last)
+        {
+            if constexpr (shmem_out_had)
+                write_sum_tile_sh();
+            else
+                write_sum_gl();
+        }
+
+        if constexpr (shmem_out_had)
+        {
+            if (last) __syncthreads();
+            if (!sub_k && last)
+                output_had_sh_gl();
+        }
+
+        barrier_release(lock, lock_d, last);
+
+        clear_frag_c();
+    };
+
+    // Wait until there are at most SH_STAGES - 2 async copies pending, i.e. at least one stage has finished loading
+    auto wait_stage = [&] ()
+    {
+        cp_async_wait<SH_STAGES - 2>();
+        __syncthreads();
+    };
+
+    // Perform tensor core matmul on current tile
+    auto matmul = [&] (int buf)
+    {
+        if constexpr (TILEBLOCKS_M == 1)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            {
+                #if EXL3_GEMM_H_ACC
+                    ptx_mma_m16n8k16(frag_a[buf][0], frag_b[buf][n], frag_c_h[0][n]);
+                #else
+                    ptx_mma_m16n8k16(frag_a[buf][0], frag_b[buf][n], frag_c[0][n]);
+                #endif
+            }
+        }
+        else
+        {
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    #if EXL3_GEMM_H_ACC
+                        ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c_h[m][n]);
+                    #else
+                        ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c[m][n]);
+                    #endif
+                }
+        }
+    };
+
+    // Start global to shared pipeline
+    #pragma unroll
+    for (int i = 0; i < SH_STAGES - 1; ++i)
+        async_load_gl();
+    wait_stage();
+
+    // Start shared to register pipeline.
+    clear_frag_c();
+    if constexpr (FRAG_STAGES > 1)
+        load_frags(0);
+
+    // Main loop. Fragments are double buffered to allow more interleaving. This is especially important to hide the
+    // dequantization overhead, but we need two different iterations of the main loop to avoid confusing the compiler
+    // and making it (sometimes) place the fragment arrays in local memory
+
+    #define FSTAGE_OLD(_load, _mul) \
+        async_load_gl(); \
+        wait_stage(); \
+        load_frags(_load); \
+        matmul(_mul); \
+        if (slice2_k == tiles_k - 1 || slice2_iters == 1) { reduce(); slice2_k0 = slice2_k + 1; } \
+        advance2(); \
+        if (!slice2_iters) break; \
+
+    #define FSTAGE(_load, _mul) \
+        async_load_gl(); \
+        wait_stage(); \
+        matmul(_mul); \
+        if (slice2_k == tiles_k - 1 || slice2_iters == 1) { reduce(); slice2_k0 = slice2_k + 1; } \
+        advance2(); \
+        if (!slice2_iters) break; \
+        load_frags(_load); \
+
+    if constexpr (FRAG_STAGES == 1)
+    {
+        while (true)
+        {
+            FSTAGE_OLD(0, 0);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 2)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(0, 1);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 3)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(2, 1);
+            FSTAGE(0, 2);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 4)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(2, 1);
+            FSTAGE(3, 2);
+            FSTAGE(0, 3);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 5)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(2, 1);
+            FSTAGE(3, 2);
+            FSTAGE(4, 3);
+            FSTAGE(0, 4);
+        }
+    }
+}

--- a/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_gemm_inner.cuh
@@ -930,7 +930,7 @@ void exl3_gemm_kernel_inner_mt
     half* gl_c_ptr_16 = ((half*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
     float* gl_c_ptr_32 = ((float*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
 
-    register FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
+    register FragA frag_a[TILEBLOCKS_M];   // single-buffered: A is cheap from shared, B is prefetched
     register FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
     register FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
     #if EXL3_GEMM_H_ACC
@@ -1010,7 +1010,7 @@ void exl3_gemm_kernel_inner_mt
             {
                 int R = r + m * 16;
                 int c_swizzled = base_c ^ ((R >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK);
-                ldsm4(frag_a[buf][m], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
+                ldsm4(frag_a[m], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
             }
         }
 
@@ -1606,9 +1606,9 @@ void exl3_gemm_kernel_inner_mt
             for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
             {
                 #if EXL3_GEMM_H_ACC
-                    ptx_mma_m16n8k16(frag_a[buf][0], frag_b[buf][n], frag_c_h[0][n]);
+                    ptx_mma_m16n8k16(frag_a[0], frag_b[buf][n], frag_c_h[0][n]);
                 #else
-                    ptx_mma_m16n8k16(frag_a[buf][0], frag_b[buf][n], frag_c[0][n]);
+                    ptx_mma_m16n8k16(frag_a[0], frag_b[buf][n], frag_c[0][n]);
                 #endif
             }
         }
@@ -1620,9 +1620,9 @@ void exl3_gemm_kernel_inner_mt
                 for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
                 {
                     #if EXL3_GEMM_H_ACC
-                        ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c_h[m][n]);
+                        ptx_mma_m16n8k16(frag_a[m], frag_b[buf][n], frag_c_h[m][n]);
                     #else
-                        ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c[m][n]);
+                        ptx_mma_m16n8k16(frag_a[m], frag_b[buf][n], frag_c[m][n]);
                     #endif
                 }
         }

--- a/exllamav3/exllamav3_ext/quant/exl3_moe_common.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe_common.cuh
@@ -10,7 +10,7 @@
 #define MOE_SMS_PER_EXPERT 8       // default/minimum group width, also sets max concurrency (buffer count)
 #define MOE_MAX_SMS_PER_EXPERT 32  // widest expert group when few experts are active
 #define MOE_TILESIZE_K 32
-#define MOE_TILESIZE_M 32          // prefill row tile: 2 m16 fragments share each dequantized B tile
+#define MOE_TILESIZE_M 32          // N=256 row tile; N=128 uses 64 (see MOE_M_TILE)
 #define MOE_SH_STAGES 3
 #define MOE_FRAG_STAGES 3
 

--- a/exllamav3/exllamav3_ext/quant/exl3_moe_common.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe_common.cuh
@@ -10,7 +10,7 @@
 #define MOE_SMS_PER_EXPERT 8       // default/minimum group width, also sets max concurrency (buffer count)
 #define MOE_MAX_SMS_PER_EXPERT 32  // widest expert group when few experts are active
 #define MOE_TILESIZE_K 32
-#define MOE_TILESIZE_M 16
+#define MOE_TILESIZE_M 32          // prefill row tile: 2 m16 fragments share each dequantized B tile
 #define MOE_SH_STAGES 3
 #define MOE_FRAG_STAGES 3
 

--- a/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
@@ -29,6 +29,11 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
     const int warps_per_block = block_threads / 32;
     const int warp_idx0 = block_idx * warps_per_block + warp_id;
 
+    // Prefill row tile for this N shape. M=64 (4 m16 fragments) was measured slower: the extra
+    // fragment registers spill and small experts waste whole fragments. M=32 is the measured
+    // sweet spot (2 fragments per dequantized B tile) and fits the smem budget at every N/K.
+    constexpr int MOE_M_TILE = MOE_TILESIZE_M;
+
     // Buffers for group
     temp_state_g += group_idx * max_tokens_per_expert * hidden_dim;
     temp_state_u += group_idx * max_tokens_per_expert * hidden_dim;
@@ -123,36 +128,36 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     in_addr,            \
                     trellis,            \
                     out_addr,           \
-                    MIN(size_m, 16),    \
+                    MIN(size_m, MOE_M_TILE), \
                     hidden_dim,         \
                     intermediate_dim,   \
                     locks,              \
                     nullptr
                 #define SHAPE_ARGS      \
-                    MOE_TILESIZE_M,     \
+                    MOE_M_TILE,         \
                     MOE_TILESIZE_K,     \
                     MOE_TILESIZE_N,     \
                     MOE_SH_STAGES,      \
                     MOE_FRAG_STAGES
                 if constexpr (t_bits)
-                    exl3_gemm_kernel_inner<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
+                    exl3_gemm_kernel_inner_mt<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
                 else switch(K)
                 {
-                    case 1: exl3_gemm_kernel_inner<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 2: exl3_gemm_kernel_inner<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 3: exl3_gemm_kernel_inner<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 4: exl3_gemm_kernel_inner<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 5: exl3_gemm_kernel_inner<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 6: exl3_gemm_kernel_inner<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 7: exl3_gemm_kernel_inner<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 8: exl3_gemm_kernel_inner<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 1: exl3_gemm_kernel_inner_mt<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner_mt<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner_mt<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner_mt<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner_mt<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner_mt<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner_mt<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner_mt<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
                 };
                 #undef ARGS
                 #undef SHAPE_ARGS
 
-                in_addr += 16 * hidden_dim;
-                out_addr += 16 * intermediate_dim;
-                size_m -= 16;
+                in_addr += MOE_M_TILE * hidden_dim;
+                out_addr += MOE_M_TILE * intermediate_dim;
+                size_m -= MOE_M_TILE;
             }
         };
 
@@ -197,36 +202,36 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
                     in_addr,            \
                     trellis,            \
                     out_addr,           \
-                    MIN(size_m, 16),    \
+                    MIN(size_m, MOE_M_TILE), \
                     intermediate_dim,   \
                     hidden_dim,         \
                     locks,              \
                     nullptr
                 #define SHAPE_ARGS      \
-                    MOE_TILESIZE_M,     \
+                    MOE_M_TILE,         \
                     MOE_TILESIZE_K,     \
                     MOE_TILESIZE_N,     \
                     MOE_SH_STAGES,      \
                     MOE_FRAG_STAGES
                 if constexpr (t_bits)
-                    exl3_gemm_kernel_inner<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
+                    exl3_gemm_kernel_inner_mt<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
                 else switch(K)
                 {
-                    case 1: exl3_gemm_kernel_inner<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 2: exl3_gemm_kernel_inner<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 3: exl3_gemm_kernel_inner<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 4: exl3_gemm_kernel_inner<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 5: exl3_gemm_kernel_inner<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 6: exl3_gemm_kernel_inner<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 7: exl3_gemm_kernel_inner<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 8: exl3_gemm_kernel_inner<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 1: exl3_gemm_kernel_inner_mt<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner_mt<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner_mt<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner_mt<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner_mt<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner_mt<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner_mt<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner_mt<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
                 };
                 #undef ARGS
                 #undef SHAPE_ARGS
 
-                in_addr += 16 * intermediate_dim;
-                out_addr += 16 * hidden_dim;
-                size_m -= 16;
+                in_addr += MOE_M_TILE * intermediate_dim;
+                out_addr += MOE_M_TILE * hidden_dim;
+                size_m -= MOE_M_TILE;
             }
         };
 

--- a/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
@@ -14,6 +14,71 @@
 #include "exl3_devctx.cuh"
 #include "../ptx.cuh"
 
+// Prefill tile dispatch for one expert's rows. Small experts pay M=16's low fixed cost; large
+// ones amortise B decode over M=64. All tiers use the MoE-only _mt inner; the shared dense inner
+// is untouched. FS is the fragment pipeline depth per tier.
+template<int t_bits, int M_TILE, int N_TILE, int cb, int FS>
+__device__ __forceinline__
+void moe_gemm_tile
+(
+    const half* __restrict__ in_addr,
+    const uint16_t* __restrict__ trellis,
+    half* __restrict__ out_addr,
+    const int size_m,
+    const int size_k,
+    const int size_n,
+    int* __restrict__ locks,
+    const int K
+)
+{
+    #define MOE_TILE_ARGS \
+        in_addr, trellis, out_addr, MIN(size_m, M_TILE), size_k, size_n, locks, nullptr
+    #define MOE_TILE_SHAPE \
+        M_TILE, MOE_TILESIZE_K, N_TILE, MOE_SH_STAGES, FS
+    if constexpr (t_bits)
+        exl3_gemm_kernel_inner_mt<t_bits, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS);
+    else switch (K)
+    {
+        case 1: exl3_gemm_kernel_inner_mt<1, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+        case 2: exl3_gemm_kernel_inner_mt<2, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+        case 3: exl3_gemm_kernel_inner_mt<3, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+        case 4: exl3_gemm_kernel_inner_mt<4, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+        case 5: exl3_gemm_kernel_inner_mt<5, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+        case 6: exl3_gemm_kernel_inner_mt<6, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+        case 7: exl3_gemm_kernel_inner_mt<7, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+        case 8: exl3_gemm_kernel_inner_mt<8, false, cb, MOE_TILE_SHAPE, false>(MOE_TILE_ARGS); break;
+    }
+    #undef MOE_TILE_ARGS
+    #undef MOE_TILE_SHAPE
+}
+
+// Whole-expert loop for the M=32/64 tiers, outlined so their (larger) register frames do not
+// inflate the kernel's live set. The M=16 tier is left inline at the call site: it is small and
+// every small expert pays a call otherwise.
+template<int t_bits, int M_TILE, int N_TILE, int cb, int FS>
+__device__ __noinline__
+void moe_gemm_rows
+(
+    const half* __restrict__ in_addr,
+    const uint16_t* __restrict__ trellis,
+    half* __restrict__ out_addr,
+    int size_m,
+    const int size_k,
+    const int size_n,
+    int* __restrict__ locks,
+    const int K
+)
+{
+    while (size_m > 0)
+    {
+        moe_gemm_tile<t_bits, M_TILE, N_TILE, cb, FS>
+        (in_addr, trellis, out_addr, size_m, size_k, size_n, locks, K);
+        in_addr += M_TILE * size_k;
+        out_addr += M_TILE * size_n;
+        size_m -= M_TILE;
+    }
+}
+
 template<int t_bits, int MOE_TILESIZE_N, int cb>
 __global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16)
 void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
@@ -29,12 +94,11 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
     const int warps_per_block = block_threads / 32;
     const int warp_idx0 = block_idx * warps_per_block + warp_id;
 
-    // Prefill row tile for this N shape. M=64 (4 m16 fragments) was measured slower: the extra
-    // fragment registers spill and small experts waste whole fragments. M=32 is the measured
-    // sweet spot (2 fragments per dequantized B tile) and fits the smem budget at every N/K.
-    // N=128 fits an M=64 tile (4 m16 fragments sharing each dequantized B tile) with
-    // single-buffered A; N=256's reduction scratch does not, so it keeps M=32.
-    constexpr int MOE_M_TILE = (MOE_TILESIZE_N == 128) ? 64 : MOE_TILESIZE_M;
+    // Per-expert tile dispatch thresholds and the large tile for this N shape. N=128 fits M=64
+    // with single-buffered A (FS=2 to chase STACK 0); N=256's reduction scratch does not, so its
+    // large tier stays M=32.
+    constexpr int MOE_BIG_M = (MOE_TILESIZE_N == 128) ? 64 : MOE_TILESIZE_M;
+    constexpr int MOE_BIG_FS = (MOE_TILESIZE_N == 128) ? 2 : MOE_FRAG_STAGES;
 
     // Buffers for group
     temp_state_g += group_idx * max_tokens_per_expert * hidden_dim;
@@ -123,44 +187,15 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
         // g, u GEMM
         auto gemm_up = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
         {
-            int size_m = token_count;
-            while (size_m > 0)
-            {
-                #define ARGS            \
-                    in_addr,            \
-                    trellis,            \
-                    out_addr,           \
-                    MIN(size_m, MOE_M_TILE), \
-                    hidden_dim,         \
-                    intermediate_dim,   \
-                    locks,              \
-                    nullptr
-                #define SHAPE_ARGS      \
-                    MOE_M_TILE,         \
-                    MOE_TILESIZE_K,     \
-                    MOE_TILESIZE_N,     \
-                    MOE_SH_STAGES,      \
-                    MOE_FRAG_STAGES
-                if constexpr (t_bits)
-                    exl3_gemm_kernel_inner_mt<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
-                else switch(K)
-                {
-                    case 1: exl3_gemm_kernel_inner_mt<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 2: exl3_gemm_kernel_inner_mt<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 3: exl3_gemm_kernel_inner_mt<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 4: exl3_gemm_kernel_inner_mt<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 5: exl3_gemm_kernel_inner_mt<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 6: exl3_gemm_kernel_inner_mt<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 7: exl3_gemm_kernel_inner_mt<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 8: exl3_gemm_kernel_inner_mt<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                };
-                #undef ARGS
-                #undef SHAPE_ARGS
-
-                in_addr += MOE_M_TILE * hidden_dim;
-                out_addr += MOE_M_TILE * intermediate_dim;
-                size_m -= MOE_M_TILE;
-            }
+            if (token_count <= 16)
+                moe_gemm_tile<t_bits, 16, MOE_TILESIZE_N, cb, MOE_FRAG_STAGES>
+                (in_addr, trellis, out_addr, token_count, hidden_dim, intermediate_dim, locks, K);
+            else if (token_count <= 48)
+                moe_gemm_rows<t_bits, 32, MOE_TILESIZE_N, cb, MOE_FRAG_STAGES>
+                (in_addr, trellis, out_addr, token_count, hidden_dim, intermediate_dim, locks, K);
+            else
+                moe_gemm_rows<t_bits, MOE_BIG_M, MOE_TILESIZE_N, cb, MOE_BIG_FS>
+                (in_addr, trellis, out_addr, token_count, hidden_dim, intermediate_dim, locks, K);
         };
 
         if (gated)
@@ -197,44 +232,15 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
         // d GEMM
         auto gemm_down = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
         {
-            int size_m = token_count;
-            while (size_m > 0)
-            {
-                #define ARGS            \
-                    in_addr,            \
-                    trellis,            \
-                    out_addr,           \
-                    MIN(size_m, MOE_M_TILE), \
-                    intermediate_dim,   \
-                    hidden_dim,         \
-                    locks,              \
-                    nullptr
-                #define SHAPE_ARGS      \
-                    MOE_M_TILE,         \
-                    MOE_TILESIZE_K,     \
-                    MOE_TILESIZE_N,     \
-                    MOE_SH_STAGES,      \
-                    MOE_FRAG_STAGES
-                if constexpr (t_bits)
-                    exl3_gemm_kernel_inner_mt<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
-                else switch(K)
-                {
-                    case 1: exl3_gemm_kernel_inner_mt<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 2: exl3_gemm_kernel_inner_mt<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 3: exl3_gemm_kernel_inner_mt<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 4: exl3_gemm_kernel_inner_mt<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 5: exl3_gemm_kernel_inner_mt<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 6: exl3_gemm_kernel_inner_mt<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 7: exl3_gemm_kernel_inner_mt<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                    case 8: exl3_gemm_kernel_inner_mt<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
-                };
-                #undef ARGS
-                #undef SHAPE_ARGS
-
-                in_addr += MOE_M_TILE * intermediate_dim;
-                out_addr += MOE_M_TILE * hidden_dim;
-                size_m -= MOE_M_TILE;
-            }
+            if (token_count <= 16)
+                moe_gemm_tile<t_bits, 16, MOE_TILESIZE_N, cb, MOE_FRAG_STAGES>
+                (in_addr, trellis, out_addr, token_count, intermediate_dim, hidden_dim, locks, K);
+            else if (token_count <= 48)
+                moe_gemm_rows<t_bits, 32, MOE_TILESIZE_N, cb, MOE_FRAG_STAGES>
+                (in_addr, trellis, out_addr, token_count, intermediate_dim, hidden_dim, locks, K);
+            else
+                moe_gemm_rows<t_bits, MOE_BIG_M, MOE_TILESIZE_N, cb, MOE_BIG_FS>
+                (in_addr, trellis, out_addr, token_count, intermediate_dim, hidden_dim, locks, K);
         };
 
         gemm_down(temp_intermediate_g, temp_state_g, exp_down_trellis, K_down);

--- a/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
+++ b/exllamav3/exllamav3_ext/quant/exl3_moe_kernel.cuh
@@ -32,7 +32,9 @@ void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
     // Prefill row tile for this N shape. M=64 (4 m16 fragments) was measured slower: the extra
     // fragment registers spill and small experts waste whole fragments. M=32 is the measured
     // sweet spot (2 fragments per dequantized B tile) and fits the smem budget at every N/K.
-    constexpr int MOE_M_TILE = MOE_TILESIZE_M;
+    // N=128 fits an M=64 tile (4 m16 fragments sharing each dequantized B tile) with
+    // single-buffered A; N=256's reduction scratch does not, so it keeps M=32.
+    constexpr int MOE_M_TILE = (MOE_TILESIZE_N == 128) ? 64 : MOE_TILESIZE_M;
 
     // Buffers for group
     temp_state_g += group_idx * max_tokens_per_expert * hidden_dim;


### PR DESCRIPTION
# Fused MoE prefill: M=16/32/64 row-tile dispatch

## Problem
The fused MoE re-runs the whole packed-weight load+decode pipeline once per 16-row M tile.
Nsight Compute on one full-routing layer call: 33% occupancy (1 block/SM, register- and
smem-limited), 4 warps/scheduler, 57% of cycles with no eligible warp, 25% SM / 13% DRAM, and a
22:1 ALU+FMA:tensor instruction ratio. It is a decode instruction stream stalled on barriers
(23%) and fixed-latency dependencies (19%), not MMA or bandwidth.

## Mechanism
A separate `exl3_gemm_kernel_inner_mt` holds `TILEBLOCKS_M` m16 row fragments and decodes each B
fragment once for all of them; the shared dense inner is byte-identical. Isolated marginal cost
per 16 rows: M=16 64.4 us, M=32 48.3 us, M=64 35.0 us. Dispatch by `token_count` (<=16 -> M=16,
<=48 -> M=32, else M=64 for N=128 / M=32 for N=256); the M=16 tier is inlined, M=32/64 run an
outlined whole-expert loop.

**Why a copy, not a parameter.** The `_mt` inner is a separate 975-line function rather than a
parameter on the shared inner because parameterising it reordered eight instructions in the dense
SASS; the copy is what keeps every existing model byte-identical. If you would rather have a single
parameterised inner and accept a scheduling perturbation on the dense path, that version is one
commit away.

## Results (4x3090, layer-split qwen3.8-Flash-Next EXL3 4.05bpw; all figures throughput)

| gate | dev tip | PR | |
|---|--:|--:|--:|
| full routing | 12.16 ms / 16.6 TF | 9.69 ms / 20.8 TF | **1.25x** |
| prefill 16k | 1498 tok/s | 1702 tok/s | **1.14x** |
| prefill 64k | 1796 tok/s | 1919 tok/s | **1.07x** |
| decode bsz1 / bsz8 | ~58 / ~152 tok/s | unchanged | 1.00x |

Only `k4_n128_cb2` (N=128, K=4, mul1) is exercised by this checkpoint, all 48 layers, so that
tier is measured on real weights. The N=256 tier is measured on seeded synthetic trellis.

## Correctness
- per-expert parity: bit-identical vs the current kernel; full routing max abs 1.9e-9.
- dense path: all 36 dense objects (12 top-level + 24 comp-units) have identical SASS.
- N=256 synthetic tier: bit-identical base vs PR at every C.
- 16k logits: top-3 token ids identical across base and PR; values are within the model's own
  run-to-run nondeterminism (base-vs-base max abs 3.29 > base-vs-PR 2.72; n=10 per arm), so the
  id agreement is the end-to-end gate, not a bitwise logits comparison.

## Rejected
- Occupancy (2 blocks/SM, 64 regs): residency rose to 57% but full routing regressed to 47 ms.
- N-split (own N range, no K partial): 12.71 ms at `TILESIZE_N=128` (only 5 N tiles for the
  640-wide gate over 8 blocks).
- Uniform M=64: 12.87 ms (median expert holds 13 rows; 3 of 4 fragments wasted).

Build cost: +15 s wall, +14 MB `.so` (same `MAX_JOBS=16`).
