### PR TITLE
Build the CUDA extension as C++20

### DIFF
--- a/exllamav3/ext.py
+++ b/exllamav3/ext.py
@@ -90,6 +90,7 @@ else:
     extra_cflags = []
     extra_cuda_cflags = [
         "-lineinfo", "-O3", "--use_fast_math",
+        "-std=c++20",
         "-Xcudafe", "--diag_suppress=177",
         "-Xcudafe", "--diag_suppress=20012",
     ]

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ windows = os.name == "nt"
 extra_cflags = []
 extra_cuda_cflags = [
     "-lineinfo", "-O3", "--use_fast_math",
+    "-std=c++20",
     "-Xcudafe", "--diag_suppress=177",
     "-Xcudafe", "--diag_suppress=20012",
 ]


### PR DESCRIPTION
I hit this testing something on my 3090 box:

Build the CUDA extension as C++20.

nvcc from CUDA 13.x misparses torch's ATen list headers when it compiles a CUDA extension in
C++17 mode. Any extension that includes ATen tensor headers fails with:

    ATen/core/List_inl.h:202:52: error: need 'typename' before 'decltype
    (((c10::List<T>*)this)->c10::List<T>::impl_->list)::difference_type' because 'decltype
    (((c10::List<T>*)this)->c10::List<T>::impl_->list)' is a dependent scope

C++20 mode compiles the same headers without change. CUDA 11.8 and every CUDA 12.x release
accept `-std=c++20` for nvcc, so the flag does not restrict supported toolchains.

Changes:

- `setup.py`: add `-std=c++20` to the CUDA extension's nvcc flags
- `exllamav3/ext.py`: add the same flag to the JIT build path

Validation: on CUDA 13.3.33, gcc 13.3, torch 2.11.0+cu130, RTX 3090, both commands now
complete where the C++17 build failed with the error above:

- `pip install --no-build-isolation --no-deps -e .` builds the extension end to end
- `import exllamav3` loads it; an EXL3 3.5bpw model loads and generates under tabbyAPI