### PR TITLE
Fix/dsa optional triton import 309

### DIFF
--- a/exllamav3/modules/attention_fn/bc_dsa.py
+++ b/exllamav3/modules/attention_fn/bc_dsa.py
@@ -305,8 +305,8 @@ class BCDsa:
 
     def run(self, x, rs, rsl, bt_row = None):
         """x (1, seq, hidden) fp16 contiguous, bt_row (1, npr) i32 device block-table row of
-        this job (paged pools). Returns y (1, seq, hidden) fp32 (a static: consume before the
-        next BC call), or None to decline (host-side ring maintenance needed this
+        this job (paged pools). Returns y (1, seq, hidden) fp32 (a static: consume before
+        the next BC call), or None to decline (host-side ring maintenance needed this
         step)."""
         seq = x.shape[1]
         pos = rs.position
@@ -414,7 +414,7 @@ class BCDsaBatch:
                 m.indexer._build_fused()
             fan_lins += [m.indexer.wkv, m.indexer.wgate]
         fan_inner = [l.inner for l in fan_lins]
-        self.fan_ns = [l.out_features for l in fan_inner] if False else [l.out_features for l in fan_lins]
+        self.fan_ns = [l.out_features for l in fan_lins]
         q_lora = m.q_a.out_features
         self.q_lora = q_lora
         if not (

--- a/exllamav3/modules/attention_fn/bc_dsa.py
+++ b/exllamav3/modules/attention_fn/bc_dsa.py
@@ -6,7 +6,11 @@ from ...ext import exllamav3_ext as ext
 from ...constants import PAGE_SIZE
 from ...util.tensor import g_tensor_cache
 from .bc_attn import _compile_kernel
-from .dsa_triton import _dsa_attn_split_kernel, _dsa_attn_combine_kernel, _dsa_indexer_fewq_kernel
+from .dsa_triton import has_triton
+
+# These kernel names are only defined when Triton is available.
+if has_triton:
+    from .dsa_triton import _dsa_attn_split_kernel, _dsa_attn_combine_kernel, _dsa_indexer_fewq_kernel
 
 """
 Whole-attention-step graphs for DeepSeek-V4 DSA decode (BC_DSV4Attention): projections,
@@ -22,7 +26,7 @@ On by default; EXL3_BC_DSA=0 falls back to the eager path. Ineligible configurat
 decline per-layer; build failures raise with EXL3_BC_DSA_DEBUG=1, else decline.
 """
 
-bc_dsa_enable = os.environ.get("EXL3_BC_DSA", "1") != "0"
+bc_dsa_enable = has_triton and os.environ.get("EXL3_BC_DSA", "1") != "0"
 _bc_debug = os.environ.get("EXL3_BC_DSA_DEBUG", "0") != "0"
 
 MAX_QLEN = 16
@@ -301,8 +305,8 @@ class BCDsa:
 
     def run(self, x, rs, rsl, bt_row = None):
         """x (1, seq, hidden) fp16 contiguous, bt_row (1, npr) i32 device block-table row of
-        this job (paged pools). Returns y (1, seq, hidden) fp32 (a static: consume before
-        the next BC call), or None to decline (host-side ring maintenance needed this
+        this job (paged pools). Returns y (1, seq, hidden) fp32 (a static: consume before the
+        next BC call), or None to decline (host-side ring maintenance needed this
         step)."""
         seq = x.shape[1]
         pos = rs.position
@@ -345,6 +349,8 @@ class BCDsa:
 
 
 def build_bc_dsa(module, rs, rsl, kl):
+    if not has_triton:
+        return None
     try:
         return BCDsa(module, rs, rsl, kl)
     except Exception:
@@ -408,7 +414,7 @@ class BCDsaBatch:
                 m.indexer._build_fused()
             fan_lins += [m.indexer.wkv, m.indexer.wgate]
         fan_inner = [l.inner for l in fan_lins]
-        self.fan_ns = [l.out_features for l in fan_lins]
+        self.fan_ns = [l.out_features for l in fan_inner] if False else [l.out_features for l in fan_lins]
         q_lora = m.q_a.out_features
         self.q_lora = q_lora
         if not (
@@ -633,6 +639,8 @@ class BCDsaBatch:
 
 
 def build_bc_dsa_batch(module, rsl, kl):
+    if not has_triton:
+        return None
     try:
         return BCDsaBatch(module, rsl, kl)
     except Exception:

--- a/tests/test_bc_dsa_import.py
+++ b/tests/test_bc_dsa_import.py
@@ -1,0 +1,120 @@
+"""CPU-only import/availability regressions for the optional DSA BC path.
+
+Load the real module with isolated dependency stubs so these tests do not need
+Torch, Triton, the native extension, or model weights.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from types import ModuleType
+import unittest
+from unittest.mock import Mock, patch
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "exllamav3/modules/attention_fn/bc_dsa.py"
+PACKAGE = "_bc_dsa_import_test"
+KERNEL_NAMES = (
+    "_dsa_attn_split_kernel",
+    "_dsa_attn_combine_kernel",
+    "_dsa_indexer_fewq_kernel",
+)
+
+
+def load_bc_dsa(has_triton, enabled = None, debug = "0", missing_kernel = None):
+    modules = {}
+    for name in (PACKAGE, f"{PACKAGE}.modules", f"{PACKAGE}.modules.attention_fn"):
+        module = ModuleType(name)
+        module.__path__ = []
+        modules[name] = module
+
+    def dependency(name, **attributes):
+        module = ModuleType(name)
+        module.__dict__.update(attributes)
+        modules[name] = module
+        return module
+
+    dependency("torch")
+    dependency(f"{PACKAGE}.ext", exllamav3_ext = object())
+    dependency(f"{PACKAGE}.constants", PAGE_SIZE = 256)
+    dependency(f"{PACKAGE}.util.tensor", g_tensor_cache = object())
+    dependency(f"{PACKAGE}.modules.attention_fn.bc_attn", _compile_kernel = Mock())
+    kernels = {name: object() for name in KERNEL_NAMES if name != missing_kernel} if has_triton else {}
+    dependency(f"{PACKAGE}.modules.attention_fn.dsa_triton", has_triton = has_triton, **kernels)
+
+    env = dict(os.environ)
+    env.pop("EXL3_BC_DSA", None)
+    if enabled is not None:
+        env["EXL3_BC_DSA"] = enabled
+    env["EXL3_BC_DSA_DEBUG"] = debug
+
+    name = f"{PACKAGE}.modules.attention_fn.bc_dsa"
+    spec = importlib.util.spec_from_file_location(name, SOURCE)
+    module = importlib.util.module_from_spec(spec)
+    modules[name] = module
+    with patch.dict(sys.modules, modules), patch.dict(os.environ, env, clear = True):
+        spec.loader.exec_module(module)
+    return module, kernels
+
+
+class TestBCDsaImport(unittest.TestCase):
+
+    def test_import_without_triton_disables_bc(self):
+        for enabled in (None, "0", "1"):
+            with self.subTest(enabled = enabled):
+                module, _ = load_bc_dsa(False, enabled = enabled)
+                self.assertFalse(module.bc_dsa_enable)
+                for name in KERNEL_NAMES:
+                    self.assertFalse(hasattr(module, name))
+
+    def test_builders_decline_without_triton_even_in_debug_mode(self):
+        for debug in ("0", "1"):
+            with self.subTest(debug = debug):
+                module, _ = load_bc_dsa(False, debug = debug)
+                for builder_name, class_name, count in (
+                    ("build_bc_dsa", "BCDsa", 4),
+                    ("build_bc_dsa_batch", "BCDsaBatch", 3),
+                ):
+                    with patch.object(module, class_name) as constructor:
+                        result = getattr(module, builder_name)(*([None] * count))
+                        self.assertIsNone(result)
+                        constructor.assert_not_called()
+
+    def test_available_triton_preserves_kernels_and_environment_switch(self):
+        for enabled, expected in ((None, True), ("0", False), ("1", True)):
+            with self.subTest(enabled = enabled):
+                module, kernels = load_bc_dsa(True, enabled = enabled)
+                self.assertEqual(module.bc_dsa_enable, expected)
+                for name, kernel in kernels.items():
+                    self.assertIs(getattr(module, name), kernel)
+
+    def test_available_triton_does_not_hide_missing_kernel_errors(self):
+        for name in KERNEL_NAMES:
+            with self.subTest(kernel = name), self.assertRaises(ImportError):
+                load_bc_dsa(True, missing_kernel = name)
+
+    def test_available_triton_preserves_builder_results_and_error_policy(self):
+        for debug in ("0", "1"):
+            module, _ = load_bc_dsa(True, debug = debug)
+            for builder_name, class_name, count in (
+                ("build_bc_dsa", "BCDsa", 4),
+                ("build_bc_dsa_batch", "BCDsaBatch", 3),
+            ):
+                with self.subTest(debug = debug, builder = builder_name):
+                    args = tuple(object() for _ in range(count))
+                    builder = getattr(module, builder_name)
+                    sentinel = object()
+                    with patch.object(module, class_name, return_value = sentinel) as constructor:
+                        self.assertIs(builder(*args), sentinel)
+                        constructor.assert_called_once_with(*args)
+                    with patch.object(module, class_name, side_effect = RuntimeError("build failed")):
+                        if debug == "1":
+                            with self.assertRaisesRegex(RuntimeError, "build failed"):
+                                builder(*args)
+                        else:
+                            self.assertIsNone(builder(*args))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #309.

`dsa_triton.py` defines its JIT kernel symbols only when `has_triton` is true, but `bc_dsa.py` imports three of them unconditionally. This raises `ImportError` while the architecture registry is being imported, including for architectures that do not use DeepSeek DSA.

This change:
- imports the three DSA kernels only when `dsa_triton.has_triton` is true;
- disables `bc_dsa_enable` when Triton is unavailable;
- makes both single-job and batched BC builders decline immediately without Triton, including with `EXL3_BC_DSA_DEBUG=1`;
- adds CPU-only import/availability regression tests covering the missing and available dependency cases, the environment switch, both builders, and propagation of genuinely missing kernel symbols when Triton is present.

The existing Windows dependency declaration and GPU kernel implementations are unchanged. The Python/FLA compatibility caveat mentioned in the issue is outside this patch's scope.

## Verification

Based on upstream `dev` at `f64d5b2a43e1a1094930a18c0de86b5476335562`.

The regression tests reproduce the original `ImportError` on the unmodified source. With this patch:

```text
python -m unittest discover -s tests -p test_bc_dsa_import.py -v
Ran 5 tests
OK

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_bc_dsa_import.py
5 passed, 15 subtests passed

python -m py_compile exllamav3/modules/attention_fn/bc_dsa.py tests/test_bc_dsa_import.py
git diff --check
```

Tests were executed on Linux with Python 3.13.5. They load the complete, real `bc_dsa.py` module using isolated dependency stubs; they exercise import and dispatch-availability behavior without compiling CUDA or running model inference. Full-package loading, Windows execution, and GPU inference have **not** been tested in this environment.
