### PR TITLE
Write the fused RoPE normalization partials from lane zero

### DIFF
--- a/exllamav3/exllamav3_ext/rope.cu
+++ b/exllamav3/exllamav3_ext/rope.cu
@@ -188,7 +188,7 @@ void rope_kernel
         auto apply_norm = [&] ()
         {
             half2 *tptr = (half2*)(sh_head + t * 2);
-            // int lane_id = threadIdx.x % 32;
+            int lane_id = threadIdx.x % 32;
             int warp_id = threadIdx.x / 32;
             int warps = blockDim.x / 32;
 
@@ -197,7 +197,8 @@ void rope_kernel
             float v1 = __low2float(v);
             float v2 = __high2float(v);
             float sum = v1 * v1 + v2 * v2;
-            sums[warps * t_head + warp_id] = warp_reduce_sum_f(sum);
+            sum = warp_reduce_sum_f(sum);
+            if (lane_id == 0) sums[warps * t_head + warp_id] = sum;
             __syncthreads();
 
             sum = sums[warps * t_head];


### PR DESCRIPTION
This came up because I have weird hardware. 2x AMD GPU with a built-in AMD CPU-driven "GPU".

Write the fused RoPE normalization partials from lane zero.

The fused RoPE kernel's RMS-norm reduction has a shared-memory race. `warp_reduce_sum_f`
reduces with `__shfl_down_sync`, so only lane zero holds the complete warp sum, but every
lane then stores its value to the same slot:

    sums[warps * t_head + warp_id] = warp_reduce_sum_f(sum);

The slot ends up holding whichever lane wrote last. The cross-warp reduction then sums one
full partial and `warps - 1` stale or partial values, so the normalized output can be wrong.
The outcome depends on warp write ordering, so failures are nondeterministic.

Change: compute the warp reduction once and gate the store on `lane_id == 0`.

Validation:

- `tests/test_rope.py`: 64/64 pass on RTX 3090 (CUDA 13.3.33, torch 2.11.0+cu130)
- `tests/test_rope.py` and `tests/test_cache_rotate.py`: 96/96 pass on AMD Radeon AI PRO
  R9700 (gfx1201, ROCm 7.2.4, torch 2.12.0+git6bbd260), together with the full test suite
  (916 passed, 27 skipped)