### PR TITLE
sc_measure: add layer streaming

### DIFF
--- a/sc_measure.py
+++ b/sc_measure.py
@@ -5,11 +5,13 @@ import json
 import math
 import zlib
 from collections import defaultdict
+from contextlib import contextmanager
 import torch
 
 from exllamav3 import Config, Model, Tokenizer
 from exllamav3.util.file import disk_lru_cache
 from exllamav3.util.measures import compute_kl_div
+from exllamav3.util.tensor import g_tensor_cache
 from exllamav3.modules.linear import Linear
 from exllamav3.modules.quant.fp16 import LinearFP16
 from exllamav3.modules.quant.exl3_lib.quantize import finalize_capture_H, get_hadamard_dt, had_k
@@ -47,12 +49,129 @@ the quadratic law.
 Output JSON feeds sc_optimize.py, which turns the sensitivities into a per-tensor bitrate
 recipe. Results are written incrementally and the script resumes from a partial output file.
 
-NOTE: Currently the script requires the ability to load the full model under measurement on a 
-      single GPU. Not validate don MoE models.
+With --streaming, load one top-level module at a time and keep cached states in system RAM.
+Perturbed states fan out at each noise site and share module loads. --max-sys budgets pending
+states by splitting the work into passes, with results saved after each pass.
+The largest module plus Hessian/noise workspace must still fit on the device.
+Not validated on MoE models.
 """
 
-# TODO: Add layer-streaming option
 # TODO: Validate on MoE models
+
+
+class ModuleRunner:
+    """Run rows through one module at a time. Clone states because modules may mutate inputs,
+    including modules that run on CPU."""
+
+    def __init__(self, config, modules, device, streaming):
+        self.config = config
+        self.modules = modules
+        self.device = device
+        self.streaming = streaming
+
+    @contextmanager
+    def loaded(self, idx):
+        mod = self.modules[idx]
+        try:
+            if self.streaming:
+                defer = mod.can_defer_load()
+                if defer:
+                    self.config.stc.begin_deferred_load()
+                try:
+                    mod.load("cpu" if mod.caps.get("prefer_cpu") else self.device)
+                    if defer:
+                        self.config.stc.end_deferred_load()
+                except BaseException:
+                    if defer:
+                        self.config.stc.abort_deferred_load()
+                    raise
+            yield mod
+        finally:
+            if self.streaming:
+                mod.unload()
+                g_tensor_cache.drop_all()
+
+    def rows(self, mod, states, capture=None, consume=None):
+        outputs = []
+        for r, state in enumerate(states):
+            params = {} if capture is None else {"capture": capture}
+            x = mod.prepare_for_device(state.clone(), params)
+            x = mod.forward(x, params)
+            if consume is None:
+                outputs.append(x.to("cpu", copy=True))
+            else:
+                consume(r, x)
+            del x, params
+        return outputs
+
+
+def estimate_resident_bytes(modules, rows, length, vocab_size, shaped, h_rows, stc):
+    """Estimate resident VRAM for weights, cached states, logits and noise/Hessian workspace.
+    Use checkpoint headers since unloaded modules may return None from weights_numel()."""
+    def walk(mod):
+        yield mod
+        for child in getattr(mod, "modules", []):
+            yield from walk(child)
+
+    weights = 0
+    for key, filename in stc.tensor_file_map.items():
+        tensor = stc.file_headers[filename][key]
+        start, end = tensor["data_offsets"]
+        # FP8 weights expand to FP16; retain the larger size for FP32 tensors
+        weights += max(2 * math.prod(tensor["shape"]), end - start)
+    linear_weights = 0
+    width = 0
+    largest_weight = 0
+    hessian_peak = 0
+    for mod in modules:
+        qmaps = {}
+        for lin in walk(mod):
+            if isinstance(lin, Linear):
+                weight_bytes = 2 * lin.in_features * lin.out_features
+                linear_weights += weight_bytes
+                width = max(width, lin.in_features)
+                largest_weight = max(largest_weight, weight_bytes)
+                if lin.qmap is not None:
+                    qmaps[lin.qmap] = max(qmaps.get(lin.qmap, 0), lin.in_features)
+        if qmaps:
+            hessian_peak = max(hessian_peak,
+                               4 * sum(k * k for k in qmaps.values())
+                               + 16 * max(qmaps.values()) ** 2)
+    weights = max(weights, linear_weights)  # account for padded/repeated linear modules
+    states = 2 * length * width * (rows * (len(modules) + 2) + (h_rows if shaped else 0))
+    logits = 2 * length * vocab_size + 16 * min(length, 256) * vocab_size
+    workspace = largest_weight + (hessian_peak if shaped else 0) + 3 * 1024 ** 3
+    return math.ceil(1.15 * (weights + states + logits + workspace))
+
+
+def sysmem_budget(max_sys_gb):
+    """Pending-state budget in bytes; default to half the RAM available after the reference pass"""
+    if max_sys_gb is not None:
+        return int(max_sys_gb * 1024 ** 3)
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024 // 2
+    except OSError:
+        pass
+    return 8 * 1024 ** 3
+
+
+def plan_fanout_passes(measurements_by_idx, state_bytes, budget):
+    """Group modules by pending-state budget, counting control measurements too.
+    Keep each module's measurements together, even if that module exceeds the budget."""
+    passes, current, pending = [], [], 0
+    for idx in sorted(measurements_by_idx):
+        count = measurements_by_idx[idx]
+        if current and (pending + count) * state_bytes > budget:
+            passes.append(current)
+            current, pending = [], 0
+        current.append(idx)
+        pending += count
+    if current:
+        passes.append(current)
+    return passes
 
 @disk_lru_cache("get_dataset_text")
 def get_dataset_text(spec: dict):
@@ -87,8 +206,31 @@ def main(args):
     vocab_size = tokenizer.actual_vocab_size
 
     model = Model.from_config(config)
-    print(f" -- Loading model: {args.model}")
-    model.load(device = device)
+    mode = args.load_mode
+    streaming = mode == "streaming"
+    if mode == "auto":
+        required = estimate_resident_bytes(model.modules, args.rows, args.length,
+                                           vocab_size, args.shaped, args.h_rows, config.stc)
+        free, _ = torch.cuda.mem_get_info(device)
+        streaming = required > free
+        print(f" -- VRAM preflight: {free / 1024 ** 3:.1f} GiB free, "
+              f"{required / 1024 ** 3:.1f} GiB estimated for resident measurement")
+    print(f" -- {'Streaming' if streaming else 'Loading'} model: {args.model}")
+    if not streaming:
+        try:
+            model.load(device = device)
+        except torch.cuda.OutOfMemoryError:
+            if mode != "auto":
+                raise
+            config.stc.abort_deferred_load()
+            model.unload()
+            g_tensor_cache.drop_all()
+            # Release the OOM traceback before retrying so it cannot retain weight buffers
+            streaming = True
+        if streaming:
+            torch.cuda.empty_cache()
+            print(" -- Full-model load exceeded VRAM; switching to layer streaming")
+    runner = ModuleRunner(config, model.modules, device, streaming)
 
     total_rows = args.rows + (args.h_rows if args.shaped else 0)
     if args.trace:
@@ -109,11 +251,23 @@ def main(args):
     mods = model.modules
     num_mods = len(mods)
 
+    def row_kld(r, x):
+        ref = ref_logits[r]
+        kl_vocab = min(vocab_size, x.shape[-1], ref.shape[-1])
+        x2 = x.reshape(-1, x.shape[-1])
+        ref2 = ref.reshape(-1, ref.shape[-1])
+        kl_row = 0.0
+        for a in range(0, x2.shape[0], 256):
+            b = min(a + 256, x2.shape[0])
+            kl_row += compute_kl_div(x2[a:b].float(), ref2[a:b].to(x.device), kl_vocab).sum().item()
+        return kl_row / x2.shape[0]
+
     @torch.inference_mode()
     def forward_rows(start_idx, states, collect_states = False):
         """
         Forward every row from module start_idx to the end, streaming the KL vs the reference
         per row. Returns (mean kld, per-row hidden state after module start_idx if requested).
+        Resident mode only.
         """
         kld_sum = 0.0
         out_states = []
@@ -145,6 +299,17 @@ def main(args):
         """Full reference pass, caching the input state to every module and the final logits"""
         boundary = [[] for _ in range(num_mods)]
         logits = []
+        if streaming:
+            states = rows
+            for i in range(num_mods):
+                boundary[i] = states
+                with runner.loaded(i) as mod:
+                    states = runner.rows(
+                        mod, states,
+                        consume=(lambda r, x: logits.append(x.half().to("cpu", copy=True)))
+                        if i == num_mods - 1 else None,
+                    )
+            return boundary, logits
         for ids_row in rows:
             params = {}
             x = ids_row
@@ -157,9 +322,6 @@ def main(args):
                 x = mod.forward(x, params)
             logits.append(x.half().cpu())
         return boundary, logits
-
-    print(" -- Reference pass")
-    boundary, ref_logits = ref_pass()
 
     # Collect perturbation targets: every quantizable Linear, grouped by top-level module
     def walk(mod, out):
@@ -174,10 +336,13 @@ def main(args):
         walk(mods[i], tree)
         for t in tree:
             if isinstance(t, Linear) and t.qmap is not None:
-                assert isinstance(t.inner, LinearFP16), \
-                    f"{t.key}: expected unquantized (fp16) tensor, got {type(t.inner).__name__}"
+                if not streaming:
+                    assert isinstance(t.inner, LinearFP16), \
+                        f"{t.key}: expected unquantized (fp16) tensor, got {type(t.inner).__name__}"
                 targets_by_idx[i].append(t)
                 num_targets += 1
+
+    expected_keys = {lin.key for targets in targets_by_idx.values() for lin in targets}
 
     # Per-target noise levels
     if args.rfn_ref:
@@ -200,7 +365,7 @@ def main(args):
     if args.out and os.path.exists(args.out):
         with open(args.out, "r") as f:
             prev = json.load(f)
-        results = prev["results"]
+        results = [r for r in prev["results"] if r["key"] in expected_keys]
         done = {r["key"] for r in results}
         print(f" -- Resuming: {len(done)} tensors already measured")
 
@@ -209,7 +374,7 @@ def main(args):
             return
         tmp = args.out + ".tmp"
         with open(tmp, "w") as f:
-            json.dump(dict(
+            output = dict(
                 model = args.model,
                 rows = args.rows,
                 length = args.length,
@@ -221,8 +386,20 @@ def main(args):
                 rfn_scale = args.rfn_scale if args.rfn_ref else None,
                 rfn = None if args.rfn_ref else args.rfn,
                 results = results,
-            ), f, indent = 2)
+            )
+            json.dump(output, f, indent = 2)
         os.replace(tmp, args.out)
+
+    if expected_keys <= done:
+        save()
+        model.unload()
+        config.stc.close()
+        print(" -- All tensors already measured")
+        return
+
+    save()
+    print(" -- Reference pass")
+    boundary, ref_logits = ref_pass()
 
     @torch.inference_mode()
     def perturb_iid(lin, rfn, seed):
@@ -314,7 +491,7 @@ def main(args):
     @torch.inference_mode()
     def advance_capture(top_idx, capture):
         """Advance the capture rows through module top_idx, accumulating H per qmap if capture
-        is a dict (shared across rows)"""
+        is a dict (shared across rows). Resident mode only."""
         nonlocal cap_states
         new_states = []
         for st in cap_states:
@@ -334,88 +511,215 @@ def main(args):
     control_kld = {}
     quant_args = {"sigma_reg": 0.025}
 
-    for top_idx in range(num_mods):
-        tlist = targets_by_idx.get(top_idx, [])
-        todo = [lin for lin in tlist if lin.key not in done]
-
-        # Advance the capture rows through every module; accumulate H only where needed
+    def finalize_shaping(top_idx, capture):
+        """Finalize per-qmap shaping factors, falling back to iid noise for unusable captures"""
         shaping = {}
-        if args.shaped:
-            capture = {} if todo else None
-            advance_capture(top_idx, capture)
-            if todo:
-                torch.manual_seed(zlib.crc32(f"su|{top_idx}".encode()) & 0x7fffffff)
-                for qmap, h_data in capture.items():
-                    q_fallback, H, L, su, H_diag = finalize_capture_H(h_data, quant_args, False)
-                    if q_fallback or L is None:
-                        print(f" !! q_fallback for {qmap}, using iid noise")
-                        shaping[qmap] = None
-                    else:
-                        shaping[qmap] = (L, su)
-                    del H, H_diag
-                del capture
+        torch.manual_seed(zlib.crc32(f"su|{top_idx}".encode()) & 0x7fffffff)
+        for qmap in list(capture):
+            h_data = capture.pop(qmap)
+            q_fallback, H, L, su, H_diag = finalize_capture_H(h_data, quant_args, False)
+            if q_fallback or L is None:
+                print(f" !! q_fallback for {qmap}, using iid noise")
+                shaping[qmap] = None
+            else:
+                shaping[qmap] = (L.cpu(), su.cpu()) if streaming else (L, su)
+            del H, H_diag, L, su, h_data
+        return shaping
 
-        if not todo:
-            continue
+    def measurement_plan(lin):
+        """(level index, rfn, draw, seed) for every measurement on one tensor"""
+        return [(li, rfn, draw, zlib.crc32(f"{lin.key}|{li}|{draw}".encode()) & 0x7fffffff)
+                for li, rfn in enumerate(levels[lin.key]) for draw in range(args.draws)]
 
+    def new_result(top_idx, lin, shaped):
+        return dict(
+            idx = top_idx,
+            key = lin.key,
+            qbits_key = lin.qbits_key,
+            numel = lin.weights_numel(),
+            shaped = shaped,
+            levels = [],
+        )
+
+    def injected_rfn(states, top_idx):
+        """Injected error at the top-level module output, relative to the clean state"""
+        if states is None or top_idx + 1 >= num_mods:
+            return 0.0
+        inj_sq, ref_sq = 0.0, 0.0
+        for st, clean in zip(states, boundary[top_idx + 1]):
+            d = st.float() - clean.float().to(st.device)
+            inj_sq += d.square().sum().item()
+            ref_sq += clean.float().square().sum().item()
+            del d
+        return (inj_sq / ref_sq) ** 0.5 if ref_sq else 0.0
+
+    def record(res, rfn, rfn_actual, draw, kld, inj_rfn, w_norm):
+        res["levels"].append(dict(
+            rfn = rfn,
+            rfn_actual = rfn_actual,
+            draw = draw,
+            kld = kld,
+            inj_rfn = inj_rfn,
+        ))
+        res["w_norm"] = w_norm
+        print(f"    {res['key']:60} rfn {rfn_actual:.5f}   kld {kld:11.8f}   inj_rfn {inj_rfn:.6f}")
+
+    def check_control(top_idx, kld):
         # No-perturbation control: restarting from the cached boundary must reproduce the
         # reference exactly
-        if top_idx not in control_kld:
-            control_kld[top_idx], _ = forward_rows(top_idx, boundary[top_idx])
-            assert control_kld[top_idx] == 0.0, \
-                f"ctrl {control_kld[top_idx]} != 0 at module {top_idx}, restart machinery broken"
+        control_kld[top_idx] = kld
+        assert kld == 0.0, f"ctrl {kld} != 0 at module {top_idx}, restart machinery broken"
 
-        for lin in todo:
-            shape_lin = shaping.get(lin.qmap) if args.shaped else None
-            res = dict(
-                idx = top_idx,
-                key = lin.key,
-                qbits_key = lin.qbits_key,
-                numel = lin.weights_numel(),
-                shaped = shape_lin is not None,
-                levels = [],
-            )
-            for li, rfn in enumerate(levels[lin.key]):
-                for draw in range(args.draws):
-                    seed = zlib.crc32(f"{lin.key}|{li}|{draw}".encode()) & 0x7fffffff
+    if streaming:
+        # Load each module once per pass, advancing pending states and spawning new perturbed states
+        todo_by_idx = {idx: [lin for lin in targets_by_idx[idx] if lin.key not in done]
+                       for idx in sorted(targets_by_idx)}
+        todo_by_idx = {idx: lins for idx, lins in todo_by_idx.items() if lins}
+        measurements_by_idx = {idx: 1 + sum(len(measurement_plan(lin)) for lin in lins)
+                              for idx, lins in todo_by_idx.items()}
+        state_bytes = max((sum(t.numel() * t.element_size() for t in states)
+                           for states in boundary[1:]), default = 0)
+        budget = sysmem_budget(args.max_sys)
+        passes = plan_fanout_passes(measurements_by_idx, state_bytes, budget)
+        peak = max((sum(measurements_by_idx[i] for i in p) for p in passes), default = 0)
+        print(f" -- Fan-out: {sum(measurements_by_idx.values())} measurements over "
+              f"{len(todo_by_idx)} module(s) in {len(passes)} pass(es); peak pending states "
+              f"{peak * state_bytes / 1024 ** 3:.1f} GiB, budget {budget / 1024 ** 3:.1f} GiB")
+
+        cap_idx = 0  # next module for capture rows
+        for pass_no, members in enumerate(passes):
+            # Capture rows stop where the next pass starts, so each module is captured once
+            cap_stop = passes[pass_no + 1][0] - 1 if pass_no + 1 < len(passes) else members[-1]
+            pending = []
+            pass_results = []
+            start = min(cap_idx, members[0]) if args.shaped else members[0]
+            for idx in range(start, num_mods):
+                last_mod = idx == num_mods - 1
+                need_cap = args.shaped and cap_idx == idx and idx <= cap_stop
+                spawn = todo_by_idx[idx] if idx in members else []
+                assert not spawn or not args.shaped or need_cap
+                if not (need_cap or pending or spawn):
+                    continue
+                print(f" -- [pass {pass_no + 1}/{len(passes)}] module {idx + 1}/{num_mods}: "
+                      f"{len(pending)} pending, {len(spawn)} new tensor(s)")
+                with runner.loaded(idx) as mod:
+
+                    def run(states):
+                        """Forward rows through the loaded module: (states, None), or
+                        (None, mean KL) on the last module"""
+                        scores = []
+                        out = runner.rows(
+                            mod, states,
+                            consume = (lambda r, x: scores.append(row_kld(r, x))) if last_mod else None,
+                        )
+                        return (None, sum(scores) / len(scores)) if last_mod else (out, None)
+
+                    shaping = {}
+                    if need_cap:
+                        capture = {} if spawn else None
+                        cap_states = runner.rows(mod, cap_states, capture = capture,
+                                                 consume = (lambda r, x: None) if last_mod else None)
+                        cap_idx += 1
+                        if spawn:
+                            shaping = finalize_shaping(idx, capture)
+                        del capture
+
+                    # Advance pending states through the unperturbed module
+                    for exp in pending:
+                        exp["states"], exp["kld"] = run(exp["states"])
+
+                    if spawn:
+                        states, kld = run(boundary[idx])
+                        pending.append(dict(control = idx, states = states, kld = kld))
+
+                    for lin in spawn:
+                        assert isinstance(lin.inner, LinearFP16), \
+                            f"{lin.key}: expected unquantized (fp16) tensor, got {type(lin.inner).__name__}"
+                        shape_lin = shaping.get(lin.qmap) if args.shaped else None
+                        factors = None if shape_lin is None else \
+                            tuple(t.to(lin.inner.weight.device) for t in shape_lin)
+                        res = new_result(idx, lin, shape_lin is not None)
+                        for li, rfn, draw, seed in measurement_plan(lin):
+                            if factors is not None:
+                                saved, rfn_actual, w_norm = perturb_shaped(lin, rfn, seed, *factors)
+                            else:
+                                saved, rfn_actual, w_norm = perturb_iid(lin, rfn, seed)
+                            try:
+                                states, kld = run(boundary[idx])
+                            finally:
+                                # Restore before unloading, which discards lin.inner
+                                lin.inner.weight.copy_(saved)
+                                del saved
+                            pending.append(dict(
+                                res = res, rfn = rfn, rfn_actual = rfn_actual, draw = draw,
+                                w_norm = w_norm, inj_rfn = injected_rfn(states, idx),
+                                states = states, kld = kld,
+                            ))
+                        pass_results.append(res)
+                        del factors
+                    for v in shaping.values():
+                        del v
+                    shaping.clear()
+
+            # Check controls and save the completed pass
+            for exp in pending:
+                if "control" in exp:
+                    check_control(exp["control"], exp["kld"])
+                else:
+                    record(exp["res"], exp["rfn"], exp["rfn_actual"], exp["draw"], exp["kld"],
+                           exp["inj_rfn"], exp["w_norm"])
+            del pending
+            results.extend(pass_results)
+            save()
+            torch.cuda.empty_cache()
+
+    else:
+        for top_idx in range(num_mods):
+            if top_idx > max(targets_by_idx, default=-1):
+                break
+            todo = [lin for lin in targets_by_idx.get(top_idx, []) if lin.key not in done]
+
+            # Advance the capture rows through every module; accumulate H only where needed
+            shaping = {}
+            if args.shaped:
+                capture = {} if todo else None
+                advance_capture(top_idx, capture)
+                if todo:
+                    shaping = finalize_shaping(top_idx, capture)
+                del capture
+
+            if not todo:
+                continue
+
+            if top_idx not in control_kld:
+                kld, _ = forward_rows(top_idx, boundary[top_idx])
+                check_control(top_idx, kld)
+
+            for lin in todo:
+                shape_lin = shaping.get(lin.qmap) if args.shaped else None
+                res = new_result(top_idx, lin, shape_lin is not None)
+                for li, rfn, draw, seed in measurement_plan(lin):
                     if shape_lin is not None:
                         saved, rfn_actual, w_norm = perturb_shaped(lin, rfn, seed, *shape_lin)
                     else:
                         saved, rfn_actual, w_norm = perturb_iid(lin, rfn, seed)
                     try:
-                        collect = top_idx + 1 < num_mods
-                        kld, states = forward_rows(top_idx, boundary[top_idx], collect_states = collect)
+                        kld, states = forward_rows(top_idx, boundary[top_idx],
+                                                   collect_states = top_idx + 1 < num_mods)
                     finally:
                         lin.inner.weight.copy_(saved)
                         del saved
-
-                    # Injected error at the top-level module output, relative to the clean state
-                    inj_sq, ref_sq = 0.0, 0.0
-                    for st, clean in zip(states, boundary[top_idx + 1] if collect else []):
-                        d = st.float() - clean.float().to(st.device)
-                        inj_sq += d.square().sum().item()
-                        ref_sq += clean.float().square().sum().item()
-                        del d
+                    record(res, rfn, rfn_actual, draw, kld, injected_rfn(states, top_idx), w_norm)
                     del states
-                    inj_rfn = (inj_sq / ref_sq) ** 0.5 if ref_sq else 0.0
 
-                    res["levels"].append(dict(
-                        rfn = rfn,
-                        rfn_actual = rfn_actual,
-                        draw = draw,
-                        kld = kld,
-                        inj_rfn = inj_rfn,
-                    ))
-                    res["w_norm"] = w_norm
-                    print(f"    {lin.key:60} rfn {rfn_actual:.5f}   kld {kld:11.8f}   inj_rfn {inj_rfn:.6f}")
+                results.append(res)
+                save()
 
-            results.append(res)
-            save()
-
-        for v in shaping.values():
-            del v
-        shaping.clear()
-        torch.cuda.empty_cache()
+            for v in shaping.values():
+                del v
+            shaping.clear()
+            shape_lin = None
+            torch.cuda.empty_cache()
 
     # Summary
     total = sum(r["levels"][0]["kld"] for r in results)
@@ -456,6 +760,8 @@ def main(args):
     save()
     if args.out:
         print(f"\n -- Saved: {args.out}")
+    model.unload()
+    config.stc.close()
 
 
 if __name__ == "__main__":
@@ -464,6 +770,15 @@ if __name__ == "__main__":
     parser.add_argument("-r", "--rows", type = int, default = 10, help = "Number of eval rows, default: 10")
     parser.add_argument("-l", "--length", type = int, default = 1024, help = "Tokens per row, default: 1024")
     parser.add_argument("-d", "--device", type = int, default = 0, help = "CUDA device index")
+    loading = parser.add_mutually_exclusive_group()
+    loading.add_argument("--load-mode", choices = ("auto", "resident", "streaming"),
+                         default = "auto", help = "auto (default): check free VRAM before choosing full-model loading or streaming")
+    loading.add_argument("--streaming", dest = "load_mode", action = "store_const", const = "streaming",
+                         help = "Force one-module-at-a-time loading with states and shaping factors in system RAM")
+    loading.add_argument("--no-streaming", dest = "load_mode", action = "store_const", const = "resident",
+                         help = "Force full-model loading, bypassing the VRAM preflight")
+    parser.add_argument("-ms", "--max-sys", dest = "max_sys", type = float, default = None,
+                        help = "Streaming: system RAM for pending fan-out states, in GB (default: half of what is available)")
     parser.add_argument("-tr", "--trace", type = str, default = None, help = "Packed self-sampled trace (safetensors from sc_trace.py) to use as eval")
     parser.add_argument("-sh", "--shaped", action = "store_true", help = "LDLQ-shaped noise from captured Hessians (recommended; extra capture pass)")
     parser.add_argument("-hr", "--h_rows", type = int, default = 64, help = "Calibration rows for Hessian capture in shaped mode, default: 64")


### PR DESCRIPTION
`sc_measure.py` currently requires the full model to fit on one GPU. This adds layer streaming so larger models can be measured by loading one top-level module at a time and keeping cached states in system RAM.

Following the approach in `conversion/measure_model.py`, perturbed states advance through subsequent modules together, sharing each module load. Pending states are grouped into passes using a RAM budget. `--max-sys` overrides the default of half the available RAM after the reference pass.

The default loading mode is `auto`: estimate resident VRAM requirements and choose full-model loading when it fits, otherwise stream. An OOM during the initial full-model load also falls back to streaming. `--streaming` and `--no-streaming` force either mode. The noise generation logic and resident suffix-forward logic are preserved.

**Validation:**

- Full Qwen3.5-0.8B shaped-noise measurement against the original upstream script: all 302 KL scores across 151 tensors, realized noise values, and weight norms matched exactly. The maximum absolute difference in `inj_rfn` was approximately 1.87e-9. Upstream resident loading took 11:55 with 4.69 GiB peak VRAM; forced streaming took 15:21 with 3.01 GiB peak VRAM.

- A 49-tensor slice of Qwopus3.8-27B on one RTX 3090 compared fan-out against an earlier, unpublished simple streaming implementation, using the same calibration inputs and library build with a warm page cache. Time decreased from 46:01 to 26:21 (1.75x), with exact agreement in the recorded measurement values. Forcing eight passes with `--max-sys 3` took 27:20 and also matched exactly. These timings compare two streaming implementations, not streaming against upstream resident loading.